### PR TITLE
feat: Phase 1 MVP — domain, adapters, services, CLI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -136,6 +136,7 @@ repos:
         entry: uv run validate-commit-msg
         language: system
         stages: [commit-msg]
+        pass_filenames: false
         # Optional: customize commit types, scopes, or refs-optional types via CLI arguments.
         # By default, scopes are not enforced. Set --scopes to require specific scopes.
         # Examples (choose one args line):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "Programmable, reproducible scientific literature retrieval"
 requires-python = ">=3.12"
 dependencies = [
     "click>=8.1",
+    "defusedxml>=0.7",
     "httpx>=0.27",
     "bibtexparser>=1.4",
     "pyalex>=0.14",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,18 @@
 [project]
 name = "scitadel"
 version = "0.1.0"
-description = "scitadel project"
+description = "Programmable, reproducible scientific literature retrieval"
 requires-python = ">=3.12"
-dependencies = []
+dependencies = [
+    "click>=8.1",
+    "httpx>=0.27",
+    "bibtexparser>=1.4",
+    "pyalex>=0.14",
+    "pydantic>=2.0",
+]
+
+[project.scripts]
+scitadel = "scitadel.cli:cli"
 
 [project.optional-dependencies]
 dev = [
@@ -28,6 +37,12 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/scitadel"]
+
+[tool.ruff]
+src = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
 
 [dependency-groups]
 dev = [

--- a/src/scitadel/__init__.py
+++ b/src/scitadel/__init__.py
@@ -1,3 +1,3 @@
-"""scitadel - A new Python project."""
+"""Scitadel — Programmable, reproducible scientific literature retrieval."""
 
 __version__ = "0.1.0"

--- a/src/scitadel/adapters/__init__.py
+++ b/src/scitadel/adapters/__init__.py
@@ -1,0 +1,5 @@
+"""Source adapters for external academic APIs."""
+
+from scitadel.adapters.base import SourceAdapter
+
+__all__ = ["SourceAdapter"]

--- a/src/scitadel/adapters/arxiv/__init__.py
+++ b/src/scitadel/adapters/arxiv/__init__.py
@@ -1,0 +1,1 @@
+"""arXiv source adapter."""

--- a/src/scitadel/adapters/arxiv/adapter.py
+++ b/src/scitadel/adapters/arxiv/adapter.py
@@ -1,0 +1,112 @@
+"""arXiv source adapter using the arXiv API.
+
+Docs: https://info.arxiv.org/help/api/index.html
+Rate limit: be polite, ~1 req/3s recommended.
+"""
+
+from __future__ import annotations
+
+import re
+
+import defusedxml.ElementTree as ET
+import httpx
+
+from scitadel.domain.models import CandidatePaper
+
+ARXIV_API_URL = "https://export.arxiv.org/api/query"
+
+# Namespace used in arXiv Atom feed
+NS = {"atom": "http://www.w3.org/2005/Atom", "arxiv": "http://arxiv.org/schemas/atom"}
+
+
+class ArxivAdapter:
+    """arXiv API adapter."""
+
+    def __init__(self, timeout: float = 30.0) -> None:
+        self._timeout = timeout
+
+    @property
+    def name(self) -> str:
+        return "arxiv"
+
+    async def search(
+        self,
+        query: str,
+        max_results: int = 50,
+        **params: object,
+    ) -> list[CandidatePaper]:
+        """Search arXiv and return normalized candidate records."""
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            search_params = {
+                "search_query": f"all:{query}",
+                "start": 0,
+                "max_results": max_results,
+                "sortBy": "relevance",
+                "sortOrder": "descending",
+            }
+            resp = await client.get(ARXIV_API_URL, params=search_params)
+            resp.raise_for_status()
+            return _parse_arxiv_atom(resp.text)
+
+
+def _parse_arxiv_atom(xml_text: str) -> list[CandidatePaper]:
+    """Parse arXiv Atom XML response into CandidatePaper records."""
+    root = ET.fromstring(xml_text)
+    candidates = []
+
+    for rank, entry in enumerate(root.findall("atom:entry", NS), start=1):
+        entry_id = entry.findtext("atom:id", "", NS)
+        arxiv_id = _extract_arxiv_id(entry_id)
+
+        title = entry.findtext("atom:title", "", NS)
+        title = " ".join(title.split())  # collapse whitespace
+
+        summary = entry.findtext("atom:summary", "", NS)
+        abstract = " ".join(summary.split())
+
+        authors = []
+        for author in entry.findall("atom:author", NS):
+            name = author.findtext("atom:name", "", NS)
+            if name:
+                authors.append(name)
+
+        # DOI from arxiv:doi element
+        doi_el = entry.find("arxiv:doi", NS)
+        doi = doi_el.text if doi_el is not None else None
+
+        # Published date -> year
+        published = entry.findtext("atom:published", "", NS)
+        year = None
+        if published:
+            try:
+                year = int(published[:4])
+            except ValueError:
+                pass
+
+        # Journal ref
+        journal_el = entry.find("arxiv:journal_ref", NS)
+        journal = journal_el.text if journal_el is not None else None
+
+        candidates.append(
+            CandidatePaper(
+                source="arxiv",
+                source_id=arxiv_id,
+                title=title,
+                authors=authors,
+                abstract=abstract,
+                doi=doi,
+                arxiv_id=arxiv_id,
+                year=year,
+                journal=journal,
+                url=entry_id,
+                rank=rank,
+            )
+        )
+
+    return candidates
+
+
+def _extract_arxiv_id(url: str) -> str:
+    """Extract arXiv ID from URL like http://arxiv.org/abs/2301.12345v1."""
+    match = re.search(r"arxiv\.org/abs/(.+?)(?:v\d+)?$", url)
+    return match.group(1) if match else url

--- a/src/scitadel/adapters/base.py
+++ b/src/scitadel/adapters/base.py
@@ -1,0 +1,29 @@
+"""Base adapter contract for source integrations."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from scitadel.domain.models import CandidatePaper
+
+
+class SourceAdapter(Protocol):
+    """Port contract for source adapters.
+
+    Each adapter translates a canonical search request into
+    source-specific syntax and normalizes responses into CandidatePaper records.
+    """
+
+    @property
+    def name(self) -> str:
+        """Source identifier (e.g., 'pubmed', 'arxiv')."""
+        ...
+
+    async def search(
+        self,
+        query: str,
+        max_results: int = 50,
+        **params: object,
+    ) -> list[CandidatePaper]:
+        """Execute a search and return normalized candidate records."""
+        ...

--- a/src/scitadel/adapters/inspire/__init__.py
+++ b/src/scitadel/adapters/inspire/__init__.py
@@ -1,0 +1,1 @@
+"""INSPIRE-HEP source adapter."""

--- a/src/scitadel/adapters/inspire/adapter.py
+++ b/src/scitadel/adapters/inspire/adapter.py
@@ -1,0 +1,112 @@
+"""INSPIRE-HEP source adapter using the INSPIRE REST API.
+
+Docs: https://github.com/inspirehep/rest-api-doc
+Rate limit: generous, CERN-maintained.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+from scitadel.domain.models import CandidatePaper
+
+INSPIRE_API_URL = "https://inspirehep.net/api/literature"
+
+
+class InspireAdapter:
+    """INSPIRE-HEP REST API adapter."""
+
+    def __init__(self, timeout: float = 30.0) -> None:
+        self._timeout = timeout
+
+    @property
+    def name(self) -> str:
+        return "inspire"
+
+    async def search(
+        self,
+        query: str,
+        max_results: int = 50,
+        **params: object,
+    ) -> list[CandidatePaper]:
+        """Search INSPIRE-HEP and return normalized candidate records."""
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            search_params = {
+                "q": query,
+                "size": max_results,
+                "sort": "mostrecent",
+                "fields": "titles,authors,abstracts,dois,arxiv_eprints,"
+                "publication_info,external_system_identifiers,urls",
+            }
+            resp = await client.get(INSPIRE_API_URL, params=search_params)
+            resp.raise_for_status()
+            data = resp.json()
+            return _parse_inspire_results(data)
+
+
+def _parse_inspire_results(data: dict) -> list[CandidatePaper]:
+    """Parse INSPIRE API response into CandidatePaper records."""
+    candidates = []
+    hits = data.get("hits", {}).get("hits", [])
+
+    for rank, hit in enumerate(hits, start=1):
+        meta = hit.get("metadata", {})
+        inspire_id = str(hit.get("id", ""))
+
+        # Title
+        titles = meta.get("titles", [])
+        title = titles[0].get("title", "") if titles else ""
+
+        # Authors
+        authors = []
+        for auth in meta.get("authors", []):
+            name = auth.get("full_name", "")
+            if name:
+                authors.append(name)
+
+        # Abstract
+        abstracts = meta.get("abstracts", [])
+        abstract = abstracts[0].get("value", "") if abstracts else ""
+
+        # DOI
+        dois = meta.get("dois", [])
+        doi = dois[0].get("value") if dois else None
+
+        # arXiv ID
+        arxiv_eprints = meta.get("arxiv_eprints", [])
+        arxiv_id = arxiv_eprints[0].get("value") if arxiv_eprints else None
+
+        # Year from publication_info
+        year = None
+        pub_info = meta.get("publication_info", [])
+        if pub_info:
+            year_str = pub_info[0].get("year")
+            if year_str:
+                try:
+                    year = int(year_str)
+                except (ValueError, TypeError):
+                    pass
+
+        # Journal
+        journal = None
+        if pub_info:
+            journal = pub_info[0].get("journal_title")
+
+        candidates.append(
+            CandidatePaper(
+                source="inspire",
+                source_id=inspire_id,
+                title=title,
+                authors=authors,
+                abstract=abstract,
+                doi=doi,
+                arxiv_id=arxiv_id,
+                inspire_id=inspire_id,
+                year=year,
+                journal=journal,
+                url=f"https://inspirehep.net/literature/{inspire_id}",
+                rank=rank,
+            )
+        )
+
+    return candidates

--- a/src/scitadel/adapters/openalex/__init__.py
+++ b/src/scitadel/adapters/openalex/__init__.py
@@ -1,0 +1,1 @@
+"""OpenAlex source adapter via PyAlex."""

--- a/src/scitadel/adapters/openalex/adapter.py
+++ b/src/scitadel/adapters/openalex/adapter.py
@@ -1,0 +1,106 @@
+"""OpenAlex source adapter via PyAlex.
+
+Docs: https://docs.openalex.org/
+Rate limit: 100k req/day (polite pool with email).
+"""
+
+from __future__ import annotations
+
+import pyalex
+from pyalex import Works
+
+from scitadel.domain.models import CandidatePaper
+
+
+class OpenAlexAdapter:
+    """OpenAlex adapter using PyAlex."""
+
+    def __init__(self, email: str = "", timeout: float = 30.0) -> None:
+        if email:
+            pyalex.config.email = email
+        self._timeout = timeout
+
+    @property
+    def name(self) -> str:
+        return "openalex"
+
+    async def search(
+        self,
+        query: str,
+        max_results: int = 50,
+        **params: object,
+    ) -> list[CandidatePaper]:
+        """Search OpenAlex and return normalized candidate records.
+
+        PyAlex is synchronous; we wrap it for the async interface.
+        """
+        results = Works().search(query).get(per_page=max_results)
+        return [_work_to_candidate(work, rank) for rank, work in enumerate(results, 1)]
+
+
+def _work_to_candidate(work: dict, rank: int) -> CandidatePaper:
+    """Map an OpenAlex work dict to a CandidatePaper."""
+    openalex_id = work.get("id", "")
+    # Extract short ID from URL
+    short_id = openalex_id.rsplit("/", 1)[-1] if openalex_id else ""
+
+    title = work.get("title") or work.get("display_name") or ""
+
+    # Authors
+    authors = []
+    for authorship in work.get("authorships", []):
+        author = authorship.get("author", {})
+        name = author.get("display_name", "")
+        if name:
+            authors.append(name)
+
+    # Abstract (OpenAlex returns inverted index)
+    abstract = ""
+    abstract_index = work.get("abstract_inverted_index")
+    if abstract_index:
+        abstract = _reconstruct_abstract(abstract_index)
+
+    doi_url = work.get("doi") or ""
+    doi = doi_url.replace("https://doi.org/", "") if doi_url else None
+
+    year = work.get("publication_year")
+
+    # Journal
+    journal = None
+    primary_location = work.get("primary_location") or {}
+    source = primary_location.get("source") or {}
+    if source:
+        journal = source.get("display_name")
+
+    # IDs
+    ids = work.get("ids", {})
+    pmid_url = ids.get("pmid") or ""
+    pmid = pmid_url.rsplit("/", 1)[-1] if pmid_url else None
+
+    return CandidatePaper(
+        source="openalex",
+        source_id=short_id,
+        title=title,
+        authors=authors,
+        abstract=abstract,
+        doi=doi,
+        openalex_id=short_id,
+        pubmed_id=pmid,
+        year=year,
+        journal=journal,
+        url=openalex_id,
+        rank=rank,
+        raw_data=work,
+    )
+
+
+def _reconstruct_abstract(inverted_index: dict) -> str:
+    """Reconstruct abstract text from OpenAlex inverted index format."""
+    if not inverted_index:
+        return ""
+    word_positions: list[tuple[int, str]] = []
+    for word, positions in inverted_index.items():
+        for pos in positions:
+            word_positions.append((pos, word))
+    word_positions.sort()
+    return " ".join(w for _, w in word_positions)

--- a/src/scitadel/adapters/pubmed/__init__.py
+++ b/src/scitadel/adapters/pubmed/__init__.py
@@ -1,0 +1,1 @@
+"""PubMed source adapter."""

--- a/src/scitadel/adapters/pubmed/adapter.py
+++ b/src/scitadel/adapters/pubmed/adapter.py
@@ -1,0 +1,166 @@
+"""PubMed source adapter using E-utilities API.
+
+Docs: https://www.ncbi.nlm.nih.gov/books/NBK25497/
+Rate limit: 3 req/s without API key, 10 req/s with.
+"""
+
+from __future__ import annotations
+
+import defusedxml.ElementTree as ET
+import httpx
+
+from scitadel.domain.models import CandidatePaper
+
+ESEARCH_URL = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi"
+EFETCH_URL = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
+
+
+class PubMedAdapter:
+    """PubMed E-utilities adapter."""
+
+    def __init__(self, api_key: str = "", timeout: float = 30.0) -> None:
+        self._api_key = api_key
+        self._timeout = timeout
+
+    @property
+    def name(self) -> str:
+        return "pubmed"
+
+    async def search(
+        self,
+        query: str,
+        max_results: int = 50,
+        **params: object,
+    ) -> list[CandidatePaper]:
+        """Search PubMed and return normalized candidate records."""
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            pmids = await self._esearch(client, query, max_results)
+            if not pmids:
+                return []
+            return await self._efetch(client, pmids)
+
+    async def _esearch(
+        self, client: httpx.AsyncClient, query: str, max_results: int
+    ) -> list[str]:
+        """Search for PMIDs matching the query."""
+        search_params: dict[str, str | int] = {
+            "db": "pubmed",
+            "term": query,
+            "retmax": max_results,
+            "retmode": "json",
+            "sort": "relevance",
+        }
+        if self._api_key:
+            search_params["api_key"] = self._api_key
+
+        resp = await client.get(ESEARCH_URL, params=search_params)
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("esearchresult", {}).get("idlist", [])
+
+    async def _efetch(
+        self, client: httpx.AsyncClient, pmids: list[str]
+    ) -> list[CandidatePaper]:
+        """Fetch article details for a list of PMIDs."""
+        fetch_params: dict[str, str] = {
+            "db": "pubmed",
+            "id": ",".join(pmids),
+            "retmode": "xml",
+        }
+        if self._api_key:
+            fetch_params["api_key"] = self._api_key
+
+        resp = await client.get(EFETCH_URL, params=fetch_params)
+        resp.raise_for_status()
+        return _parse_pubmed_xml(resp.text)
+
+
+def _parse_pubmed_xml(xml_text: str) -> list[CandidatePaper]:
+    """Parse PubMed XML response into CandidatePaper records."""
+    root = ET.fromstring(xml_text)
+    candidates = []
+
+    for rank, article in enumerate(root.findall(".//PubmedArticle"), start=1):
+        medline = article.find("MedlineCitation")
+        if medline is None:
+            continue
+
+        pmid_el = medline.find("PMID")
+        pmid = pmid_el.text if pmid_el is not None else ""
+
+        art = medline.find("Article")
+        if art is None:
+            continue
+
+        title_el = art.find("ArticleTitle")
+        title = title_el.text or "" if title_el is not None else ""
+
+        # Authors
+        authors = []
+        author_list = art.find("AuthorList")
+        if author_list is not None:
+            for author in author_list.findall("Author"):
+                last = author.findtext("LastName", "")
+                first = author.findtext("ForeName", "")
+                if last:
+                    authors.append(f"{last}, {first}".strip(", "))
+
+        # Abstract
+        abstract_el = art.find("Abstract")
+        abstract = ""
+        if abstract_el is not None:
+            parts = []
+            for text_el in abstract_el.findall("AbstractText"):
+                label = text_el.get("Label", "")
+                text = text_el.text or ""
+                if label:
+                    parts.append(f"{label}: {text}")
+                else:
+                    parts.append(text)
+            abstract = " ".join(parts)
+
+        # DOI
+        doi = None
+        for eid in art.findall(".//ELocationID"):
+            if eid.get("EIdType") == "doi":
+                doi = eid.text
+
+        # Also check ArticleIdList in PubmedData
+        pubmed_data = article.find("PubmedData")
+        if pubmed_data is not None and doi is None:
+            for aid in pubmed_data.findall(".//ArticleId"):
+                if aid.get("IdType") == "doi":
+                    doi = aid.text
+
+        # Journal
+        journal_el = art.find("Journal/Title")
+        journal = journal_el.text if journal_el is not None else None
+
+        # Year
+        year = None
+        pub_date = art.find("Journal/JournalIssue/PubDate")
+        if pub_date is not None:
+            year_el = pub_date.find("Year")
+            if year_el is not None and year_el.text:
+                try:
+                    year = int(year_el.text)
+                except ValueError:
+                    pass
+
+        candidates.append(
+            CandidatePaper(
+                source="pubmed",
+                source_id=pmid,
+                title=title,
+                authors=authors,
+                abstract=abstract,
+                doi=doi,
+                pubmed_id=pmid,
+                year=year,
+                journal=journal,
+                url=f"https://pubmed.ncbi.nlm.nih.gov/{pmid}/",
+                rank=rank,
+            )
+        )
+
+    return candidates

--- a/src/scitadel/cli.py
+++ b/src/scitadel/cli.py
@@ -5,9 +5,14 @@ Thin wrapper over application services — business logic lives in services/.
 
 from __future__ import annotations
 
+import asyncio
+import sys
+from pathlib import Path
+
 import click
 
 from scitadel import __version__
+from scitadel.config import load_config
 
 
 @click.group()
@@ -33,16 +38,100 @@ def cli() -> None:
 )
 def search(query: str, sources: str, max_results: int) -> None:
     """Run a federated literature search."""
+    from scitadel.adapters.arxiv.adapter import ArxivAdapter
+    from scitadel.adapters.inspire.adapter import InspireAdapter
+    from scitadel.adapters.openalex.adapter import OpenAlexAdapter
+    from scitadel.adapters.pubmed.adapter import PubMedAdapter
+    from scitadel.repositories.sqlite import (
+        Database,
+        SQLitePaperRepository,
+        SQLiteSearchRepository,
+    )
+    from scitadel.services.dedup import deduplicate
+    from scitadel.services.orchestrator import run_search
+
+    config = load_config()
     source_list = [s.strip() for s in sources.split(",")]
+
+    adapter_map = {
+        "pubmed": lambda: PubMedAdapter(api_key=config.pubmed.api_key),
+        "arxiv": lambda: ArxivAdapter(),
+        "openalex": lambda: OpenAlexAdapter(email=config.openalex.api_key),
+        "inspire": lambda: InspireAdapter(),
+    }
+
+    adapters = []
+    for name in source_list:
+        if name in adapter_map:
+            adapters.append(adapter_map[name]())
+        else:
+            click.echo(f"Unknown source: {name}", err=True)
+            sys.exit(1)
+
     click.echo(f"Searching {', '.join(source_list)} for: {query}")
-    click.echo("(not yet implemented — see issue #10)")
+
+    search_record, candidates = asyncio.run(
+        run_search(query, adapters, max_results=max_results)
+    )
+
+    click.echo(f"  Sources queried: {len(search_record.source_outcomes)}")
+    for outcome in search_record.source_outcomes:
+        status_icon = "+" if outcome.status.value == "success" else "!"
+        click.echo(
+            f"  [{status_icon}] {outcome.source}: "
+            f"{outcome.result_count} results ({outcome.latency_ms:.0f}ms)"
+            + (f" - {outcome.error}" if outcome.error else "")
+        )
+    click.echo(f"  Total candidates: {search_record.total_candidates}")
+
+    papers, search_results = deduplicate(candidates)
+    search_record = search_record.model_copy(update={"total_papers": len(papers)})
+    click.echo(f"  Unique papers after dedup: {len(papers)}")
+
+    # Persist
+    db = Database(config.db_path)
+    db.migrate()
+    paper_repo = SQLitePaperRepository(db)
+    search_repo = SQLiteSearchRepository(db)
+
+    paper_repo.save_many(papers)
+    search_repo.save(search_record)
+
+    for sr in search_results:
+        sr.search_id = search_record.id
+    search_repo.save_results(search_results)
+
+    click.echo(f"\n  Search ID: {search_record.id}")
+    click.echo(f"  Results saved to: {config.db_path}")
+    db.close()
 
 
 @cli.command()
 @click.option("--limit", "-n", default=20, type=int, help="Number of recent searches.")
 def history(limit: int) -> None:
     """Show past search runs and parameters."""
-    click.echo("(not yet implemented — see issue #13)")
+    from scitadel.repositories.sqlite import Database, SQLiteSearchRepository
+
+    config = load_config()
+    db = Database(config.db_path)
+    db.migrate()
+    search_repo = SQLiteSearchRepository(db)
+
+    searches = search_repo.list_searches(limit=limit)
+    if not searches:
+        click.echo("No search history found.")
+        db.close()
+        return
+
+    for s in searches:
+        success_count = sum(1 for o in s.source_outcomes if o.status.value == "success")
+        click.echo(
+            f"  {s.id[:8]}  {s.created_at:%Y-%m-%d %H:%M}  "
+            f'"{s.query}"  '
+            f"{s.total_papers} papers  "
+            f"{success_count}/{len(s.source_outcomes)} sources ok"
+        )
+    db.close()
 
 
 @cli.command()
@@ -58,5 +147,68 @@ def history(limit: int) -> None:
 @click.option("--output", "-o", type=click.Path(), help="Output file path.")
 def export(search_id: str, fmt: str, output: str | None) -> None:
     """Export search results in structured formats."""
-    click.echo(f"Exporting search {search_id} as {fmt}")
-    click.echo("(not yet implemented — see issue #12)")
+    from scitadel.repositories.sqlite import (
+        Database,
+        SQLitePaperRepository,
+        SQLiteSearchRepository,
+    )
+    from scitadel.services.export import export_bibtex, export_csv, export_json
+
+    config = load_config()
+    db = Database(config.db_path)
+    db.migrate()
+    search_repo = SQLiteSearchRepository(db)
+    paper_repo = SQLitePaperRepository(db)
+
+    # Support prefix matching on search IDs
+    s = search_repo.get(search_id)
+    if not s:
+        searches = search_repo.list_searches(limit=100)
+        matches = [sr for sr in searches if sr.id.startswith(search_id)]
+        if len(matches) == 1:
+            s = matches[0]
+        elif len(matches) > 1:
+            click.echo(f"Ambiguous search ID prefix '{search_id}'. Matches:")
+            for m in matches:
+                click.echo(f"  {m.id}")
+            db.close()
+            sys.exit(1)
+        else:
+            click.echo(f"Search '{search_id}' not found.")
+            db.close()
+            sys.exit(1)
+
+    results = search_repo.get_results(s.id)
+    paper_ids = {r.paper_id for r in results}
+    papers = [p for pid in paper_ids if (p := paper_repo.get(pid)) is not None]
+
+    formatters = {
+        "json": export_json,
+        "csv": export_csv,
+        "bibtex": export_bibtex,
+    }
+    content = formatters[fmt](papers)
+
+    if output:
+        Path(output).write_text(content)
+        click.echo(f"Exported {len(papers)} papers to {output}")
+    else:
+        click.echo(content)
+
+    db.close()
+
+
+@cli.command()
+@click.option(
+    "--db", type=click.Path(), help="Database path (default: ~/.scitadel/scitadel.db)"
+)
+def init(db: str | None) -> None:
+    """Initialize the scitadel database."""
+    from scitadel.repositories.sqlite import Database
+
+    config = load_config()
+    db_path = Path(db) if db else config.db_path
+    database = Database(db_path)
+    database.migrate()
+    click.echo(f"Database initialized at: {db_path}")
+    database.close()

--- a/src/scitadel/cli.py
+++ b/src/scitadel/cli.py
@@ -1,0 +1,62 @@
+"""CLI entry point for scitadel.
+
+Thin wrapper over application services — business logic lives in services/.
+"""
+
+from __future__ import annotations
+
+import click
+
+from scitadel import __version__
+
+
+@click.group()
+@click.version_option(version=__version__, prog_name="scitadel")
+def cli() -> None:
+    """Scitadel — Programmable, reproducible scientific literature retrieval."""
+
+
+@cli.command()
+@click.argument("query")
+@click.option(
+    "--sources",
+    "-s",
+    default="pubmed,arxiv,openalex,inspire",
+    help="Comma-separated list of sources to search.",
+)
+@click.option(
+    "--max-results",
+    "-n",
+    default=50,
+    type=int,
+    help="Maximum results per source.",
+)
+def search(query: str, sources: str, max_results: int) -> None:
+    """Run a federated literature search."""
+    source_list = [s.strip() for s in sources.split(",")]
+    click.echo(f"Searching {', '.join(source_list)} for: {query}")
+    click.echo("(not yet implemented — see issue #10)")
+
+
+@cli.command()
+@click.option("--limit", "-n", default=20, type=int, help="Number of recent searches.")
+def history(limit: int) -> None:
+    """Show past search runs and parameters."""
+    click.echo("(not yet implemented — see issue #13)")
+
+
+@cli.command()
+@click.argument("search_id")
+@click.option(
+    "--format",
+    "-f",
+    "fmt",
+    type=click.Choice(["bibtex", "json", "csv"]),
+    default="json",
+    help="Export format.",
+)
+@click.option("--output", "-o", type=click.Path(), help="Output file path.")
+def export(search_id: str, fmt: str, output: str | None) -> None:
+    """Export search results in structured formats."""
+    click.echo(f"Exporting search {search_id} as {fmt}")
+    click.echo("(not yet implemented — see issue #12)")

--- a/src/scitadel/cli.py
+++ b/src/scitadel/cli.py
@@ -94,11 +94,22 @@ def search(query: str, sources: str, max_results: int) -> None:
     paper_repo = SQLitePaperRepository(db)
     search_repo = SQLiteSearchRepository(db)
 
+    # Resolve new papers against existing DB records (match by DOI)
+    # so we reuse existing IDs instead of creating duplicates.
+    id_map: dict[str, str] = {}
+    for paper in papers:
+        if paper.doi:
+            existing = paper_repo.find_by_doi(paper.doi)
+            if existing and existing.id != paper.id:
+                id_map[paper.id] = existing.id
+                paper.id = existing.id
+
     paper_repo.save_many(papers)
     search_repo.save(search_record)
 
     for sr in search_results:
         sr.search_id = search_record.id
+        sr.paper_id = id_map.get(sr.paper_id, sr.paper_id)
     search_repo.save_results(search_results)
 
     click.echo(f"\n  Search ID: {search_record.id}")

--- a/src/scitadel/config.py
+++ b/src/scitadel/config.py
@@ -1,0 +1,51 @@
+"""Application configuration with env + file defaults."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+def _default_db_path() -> Path:
+    return Path(os.environ.get("SCITADEL_DB", "~/.scitadel/scitadel.db")).expanduser()
+
+
+@dataclass(frozen=True)
+class SourceConfig:
+    """Per-source adapter configuration."""
+
+    enabled: bool = True
+    timeout: float = 30.0
+    max_retries: int = 3
+    api_key: str = ""
+
+
+@dataclass(frozen=True)
+class Config:
+    """Top-level application configuration."""
+
+    db_path: Path = field(default_factory=_default_db_path)
+    default_sources: tuple[str, ...] = ("pubmed", "arxiv", "openalex", "inspire")
+    pubmed: SourceConfig = field(default_factory=SourceConfig)
+    arxiv: SourceConfig = field(default_factory=SourceConfig)
+    openalex: SourceConfig = field(default_factory=SourceConfig)
+    inspire: SourceConfig = field(default_factory=SourceConfig)
+
+
+def load_config() -> Config:
+    """Load configuration from environment variables with sensible defaults."""
+    db_path = _default_db_path()
+
+    pubmed = SourceConfig(
+        api_key=os.environ.get("SCITADEL_PUBMED_API_KEY", ""),
+    )
+    openalex = SourceConfig(
+        api_key=os.environ.get("SCITADEL_OPENALEX_EMAIL", ""),
+    )
+
+    return Config(
+        db_path=db_path,
+        pubmed=pubmed,
+        openalex=openalex,
+    )

--- a/src/scitadel/domain/__init__.py
+++ b/src/scitadel/domain/__init__.py
@@ -1,0 +1,35 @@
+"""Domain models and repository port interfaces."""
+
+from scitadel.domain.models import (
+    Assessment,
+    CandidatePaper,
+    Paper,
+    ResearchQuestion,
+    Search,
+    SearchResult,
+    SearchTerm,
+    SourceOutcome,
+    SourceStatus,
+)
+from scitadel.domain.ports import (
+    AssessmentRepository,
+    PaperRepository,
+    ResearchQuestionRepository,
+    SearchRepository,
+)
+
+__all__ = [
+    "Assessment",
+    "AssessmentRepository",
+    "CandidatePaper",
+    "Paper",
+    "PaperRepository",
+    "ResearchQuestion",
+    "ResearchQuestionRepository",
+    "Search",
+    "SearchRepository",
+    "SearchResult",
+    "SearchTerm",
+    "SourceOutcome",
+    "SourceStatus",
+]

--- a/src/scitadel/domain/models.py
+++ b/src/scitadel/domain/models.py
@@ -1,0 +1,150 @@
+"""Core domain models.
+
+These models represent the canonical entities in the Scitadel system.
+A paper's relevance is not a property of the paper — it's a property of the
+paper in the context of a specific research question.
+"""
+
+from __future__ import annotations
+
+import enum
+import uuid
+from datetime import datetime, timezone
+
+from pydantic import BaseModel, Field
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _new_id() -> str:
+    return uuid.uuid4().hex
+
+
+class Paper(BaseModel):
+    """Canonical, deduplicated paper record.
+
+    A paper exists once regardless of how many searches found it.
+    """
+
+    id: str = Field(default_factory=_new_id)
+    title: str
+    authors: list[str] = Field(default_factory=list)
+    abstract: str = ""
+    doi: str | None = None
+    arxiv_id: str | None = None
+    pubmed_id: str | None = None
+    inspire_id: str | None = None
+    openalex_id: str | None = None
+    year: int | None = None
+    journal: str | None = None
+    url: str | None = None
+    source_urls: dict[str, str] = Field(default_factory=dict)
+    created_at: datetime = Field(default_factory=_utcnow)
+    updated_at: datetime = Field(default_factory=_utcnow)
+
+
+class CandidatePaper(BaseModel):
+    """Un-deduplicated paper record from a single source adapter.
+
+    Adapters produce candidates; the dedup engine merges them into Papers.
+    """
+
+    source: str
+    source_id: str
+    title: str
+    authors: list[str] = Field(default_factory=list)
+    abstract: str = ""
+    doi: str | None = None
+    arxiv_id: str | None = None
+    pubmed_id: str | None = None
+    inspire_id: str | None = None
+    openalex_id: str | None = None
+    year: int | None = None
+    journal: str | None = None
+    url: str | None = None
+    rank: int | None = None
+    score: float | None = None
+    raw_data: dict = Field(default_factory=dict)
+
+
+class SourceStatus(str, enum.Enum):
+    """Outcome status for a single source in a search run."""
+
+    SUCCESS = "success"
+    PARTIAL = "partial"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+
+
+class SourceOutcome(BaseModel):
+    """Per-source result metadata for a search run."""
+
+    source: str
+    status: SourceStatus
+    result_count: int = 0
+    latency_ms: float = 0.0
+    error: str | None = None
+
+
+class Search(BaseModel):
+    """Immutable search run record."""
+
+    id: str = Field(default_factory=_new_id)
+    query: str
+    sources: list[str] = Field(default_factory=list)
+    parameters: dict = Field(default_factory=dict)
+    source_outcomes: list[SourceOutcome] = Field(default_factory=list)
+    total_candidates: int = 0
+    total_papers: int = 0
+    created_at: datetime = Field(default_factory=_utcnow)
+
+
+class SearchResult(BaseModel):
+    """Join record: search -> paper, with per-source rank/score."""
+
+    search_id: str
+    paper_id: str
+    source: str
+    rank: int | None = None
+    score: float | None = None
+    raw_metadata: dict = Field(default_factory=dict)
+
+
+class ResearchQuestion(BaseModel):
+    """First-class research question entity."""
+
+    id: str = Field(default_factory=_new_id)
+    text: str
+    description: str = ""
+    created_at: datetime = Field(default_factory=_utcnow)
+    updated_at: datetime = Field(default_factory=_utcnow)
+
+
+class SearchTerm(BaseModel):
+    """Keyword combination linked to a research question."""
+
+    id: str = Field(default_factory=_new_id)
+    question_id: str
+    terms: list[str] = Field(default_factory=list)
+    query_string: str = ""
+    created_at: datetime = Field(default_factory=_utcnow)
+
+
+class Assessment(BaseModel):
+    """Paper x research question -> relevance score + provenance.
+
+    Multiple assessments per paper (different questions, models, human override).
+    """
+
+    id: str = Field(default_factory=_new_id)
+    paper_id: str
+    question_id: str
+    score: float
+    reasoning: str = ""
+    model: str | None = None
+    prompt: str | None = None
+    temperature: float | None = None
+    assessor: str = ""  # "human", model name, etc.
+    created_at: datetime = Field(default_factory=_utcnow)

--- a/src/scitadel/domain/ports.py
+++ b/src/scitadel/domain/ports.py
@@ -1,0 +1,80 @@
+"""Repository port interfaces (abstract contracts).
+
+All DB access goes through these protocols. No raw SQL in application services.
+Concrete implementations (SQLite, future Dolt) implement these contracts.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from scitadel.domain.models import (
+    Assessment,
+    Paper,
+    ResearchQuestion,
+    Search,
+    SearchResult,
+    SearchTerm,
+)
+
+
+class PaperRepository(Protocol):
+    """Port for paper persistence."""
+
+    def save(self, paper: Paper) -> None: ...
+
+    def save_many(self, papers: list[Paper]) -> None: ...
+
+    def get(self, paper_id: str) -> Paper | None: ...
+
+    def find_by_doi(self, doi: str) -> Paper | None: ...
+
+    def find_by_title(self, title: str, threshold: float = 0.85) -> Paper | None: ...
+
+    def list_all(self, limit: int = 100, offset: int = 0) -> list[Paper]: ...
+
+
+class SearchRepository(Protocol):
+    """Port for search run persistence."""
+
+    def save(self, search: Search) -> None: ...
+
+    def get(self, search_id: str) -> Search | None: ...
+
+    def save_results(self, results: list[SearchResult]) -> None: ...
+
+    def get_results(self, search_id: str) -> list[SearchResult]: ...
+
+    def list_searches(self, limit: int = 20) -> list[Search]: ...
+
+    def diff_searches(
+        self, search_id_a: str, search_id_b: str
+    ) -> tuple[list[str], list[str]]:
+        """Return (added_paper_ids, removed_paper_ids) between two runs."""
+        ...
+
+
+class ResearchQuestionRepository(Protocol):
+    """Port for research question and search term persistence."""
+
+    def save_question(self, question: ResearchQuestion) -> None: ...
+
+    def get_question(self, question_id: str) -> ResearchQuestion | None: ...
+
+    def list_questions(self) -> list[ResearchQuestion]: ...
+
+    def save_term(self, term: SearchTerm) -> None: ...
+
+    def get_terms(self, question_id: str) -> list[SearchTerm]: ...
+
+
+class AssessmentRepository(Protocol):
+    """Port for relevance assessment persistence."""
+
+    def save(self, assessment: Assessment) -> None: ...
+
+    def get_for_paper(
+        self, paper_id: str, question_id: str | None = None
+    ) -> list[Assessment]: ...
+
+    def get_for_question(self, question_id: str) -> list[Assessment]: ...

--- a/src/scitadel/repositories/__init__.py
+++ b/src/scitadel/repositories/__init__.py
@@ -1,0 +1,1 @@
+"""Repository implementations (persistence layer)."""

--- a/src/scitadel/repositories/migrations/001_initial.sql
+++ b/src/scitadel/repositories/migrations/001_initial.sql
@@ -1,0 +1,87 @@
+-- Migration 001: Initial schema for Phase 1
+-- Covers: papers, searches, search_results, research_questions, search_terms, assessments
+
+CREATE TABLE IF NOT EXISTS papers (
+    id TEXT PRIMARY KEY,
+    title TEXT NOT NULL,
+    authors TEXT NOT NULL DEFAULT '[]',  -- JSON array
+    abstract TEXT NOT NULL DEFAULT '',
+    doi TEXT,
+    arxiv_id TEXT,
+    pubmed_id TEXT,
+    inspire_id TEXT,
+    openalex_id TEXT,
+    year INTEGER,
+    journal TEXT,
+    url TEXT,
+    source_urls TEXT NOT NULL DEFAULT '{}',  -- JSON object
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_papers_doi ON papers(doi) WHERE doi IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_papers_title ON papers(title);
+
+CREATE TABLE IF NOT EXISTS searches (
+    id TEXT PRIMARY KEY,
+    query TEXT NOT NULL,
+    sources TEXT NOT NULL DEFAULT '[]',  -- JSON array
+    parameters TEXT NOT NULL DEFAULT '{}',  -- JSON object
+    source_outcomes TEXT NOT NULL DEFAULT '[]',  -- JSON array of SourceOutcome
+    total_candidates INTEGER NOT NULL DEFAULT 0,
+    total_papers INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS search_results (
+    search_id TEXT NOT NULL REFERENCES searches(id),
+    paper_id TEXT NOT NULL REFERENCES papers(id),
+    source TEXT NOT NULL,
+    rank INTEGER,
+    score REAL,
+    raw_metadata TEXT NOT NULL DEFAULT '{}',  -- JSON object
+    PRIMARY KEY (search_id, paper_id, source)
+);
+
+CREATE TABLE IF NOT EXISTS research_questions (
+    id TEXT PRIMARY KEY,
+    text TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS search_terms (
+    id TEXT PRIMARY KEY,
+    question_id TEXT NOT NULL REFERENCES research_questions(id),
+    terms TEXT NOT NULL DEFAULT '[]',  -- JSON array
+    query_string TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_search_terms_question ON search_terms(question_id);
+
+CREATE TABLE IF NOT EXISTS assessments (
+    id TEXT PRIMARY KEY,
+    paper_id TEXT NOT NULL REFERENCES papers(id),
+    question_id TEXT NOT NULL REFERENCES research_questions(id),
+    score REAL NOT NULL,
+    reasoning TEXT NOT NULL DEFAULT '',
+    model TEXT,
+    prompt TEXT,
+    temperature REAL,
+    assessor TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_assessments_paper ON assessments(paper_id);
+CREATE INDEX IF NOT EXISTS idx_assessments_question ON assessments(question_id);
+CREATE INDEX IF NOT EXISTS idx_assessments_paper_question ON assessments(paper_id, question_id);
+
+-- Schema version tracking
+CREATE TABLE IF NOT EXISTS schema_version (
+    version INTEGER PRIMARY KEY,
+    applied_at TEXT NOT NULL
+);
+
+INSERT OR IGNORE INTO schema_version (version, applied_at) VALUES (1, datetime('now'));

--- a/src/scitadel/repositories/sqlite.py
+++ b/src/scitadel/repositories/sqlite.py
@@ -1,0 +1,437 @@
+"""SQLite repository implementations.
+
+Concrete implementations of the repository port interfaces.
+All SQL is contained within this module — no raw SQL leaks into services.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timezone
+from importlib import resources
+from pathlib import Path
+
+from scitadel.domain.models import (
+    Assessment,
+    Paper,
+    ResearchQuestion,
+    Search,
+    SearchResult,
+    SearchTerm,
+    SourceOutcome,
+    SourceStatus,
+)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class Database:
+    """SQLite connection manager with migration support."""
+
+    def __init__(self, db_path: str | Path = ":memory:") -> None:
+        self.db_path = str(db_path)
+        self._conn: sqlite3.Connection | None = None
+
+    @property
+    def conn(self) -> sqlite3.Connection:
+        if self._conn is None:
+            if self.db_path != ":memory:":
+                Path(self.db_path).parent.mkdir(parents=True, exist_ok=True)
+            self._conn = sqlite3.connect(self.db_path)
+            self._conn.row_factory = sqlite3.Row
+            self._conn.execute("PRAGMA journal_mode=WAL")
+            self._conn.execute("PRAGMA foreign_keys=ON")
+        return self._conn
+
+    def migrate(self) -> None:
+        """Apply all pending migrations."""
+        migration_dir = resources.files("scitadel.repositories") / "migrations"
+        migration_files = sorted(
+            f for f in migration_dir.iterdir() if f.name.endswith(".sql")
+        )
+
+        for migration_file in migration_files:
+            sql = migration_file.read_text()
+            self.conn.executescript(sql)
+        self.conn.commit()
+
+    def close(self) -> None:
+        if self._conn is not None:
+            self._conn.close()
+            self._conn = None
+
+
+class SQLitePaperRepository:
+    """SQLite implementation of PaperRepository."""
+
+    def __init__(self, db: Database) -> None:
+        self._db = db
+
+    def save(self, paper: Paper) -> None:
+        self._db.conn.execute(
+            """INSERT OR REPLACE INTO papers
+               (id, title, authors, abstract, doi, arxiv_id, pubmed_id,
+                inspire_id, openalex_id, year, journal, url, source_urls,
+                created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                paper.id,
+                paper.title,
+                json.dumps(paper.authors),
+                paper.abstract,
+                paper.doi,
+                paper.arxiv_id,
+                paper.pubmed_id,
+                paper.inspire_id,
+                paper.openalex_id,
+                paper.year,
+                paper.journal,
+                paper.url,
+                json.dumps(paper.source_urls),
+                paper.created_at.isoformat(),
+                paper.updated_at.isoformat(),
+            ),
+        )
+        self._db.conn.commit()
+
+    def save_many(self, papers: list[Paper]) -> None:
+        for paper in papers:
+            self._db.conn.execute(
+                """INSERT OR REPLACE INTO papers
+                   (id, title, authors, abstract, doi, arxiv_id, pubmed_id,
+                    inspire_id, openalex_id, year, journal, url, source_urls,
+                    created_at, updated_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    paper.id,
+                    paper.title,
+                    json.dumps(paper.authors),
+                    paper.abstract,
+                    paper.doi,
+                    paper.arxiv_id,
+                    paper.pubmed_id,
+                    paper.inspire_id,
+                    paper.openalex_id,
+                    paper.year,
+                    paper.journal,
+                    paper.url,
+                    json.dumps(paper.source_urls),
+                    paper.created_at.isoformat(),
+                    paper.updated_at.isoformat(),
+                ),
+            )
+        self._db.conn.commit()
+
+    def get(self, paper_id: str) -> Paper | None:
+        row = self._db.conn.execute(
+            "SELECT * FROM papers WHERE id = ?", (paper_id,)
+        ).fetchone()
+        return _row_to_paper(row) if row else None
+
+    def find_by_doi(self, doi: str) -> Paper | None:
+        row = self._db.conn.execute(
+            "SELECT * FROM papers WHERE doi = ?", (doi,)
+        ).fetchone()
+        return _row_to_paper(row) if row else None
+
+    def find_by_title(self, title: str, threshold: float = 0.85) -> Paper | None:
+        # Simple exact match for now; fuzzy matching added in #11
+        row = self._db.conn.execute(
+            "SELECT * FROM papers WHERE LOWER(title) = LOWER(?)", (title,)
+        ).fetchone()
+        return _row_to_paper(row) if row else None
+
+    def list_all(self, limit: int = 100, offset: int = 0) -> list[Paper]:
+        rows = self._db.conn.execute(
+            "SELECT * FROM papers ORDER BY created_at DESC LIMIT ? OFFSET ?",
+            (limit, offset),
+        ).fetchall()
+        return [_row_to_paper(r) for r in rows]
+
+
+class SQLiteSearchRepository:
+    """SQLite implementation of SearchRepository."""
+
+    def __init__(self, db: Database) -> None:
+        self._db = db
+
+    def save(self, search: Search) -> None:
+        outcomes_json = json.dumps([o.model_dump() for o in search.source_outcomes])
+        self._db.conn.execute(
+            """INSERT OR REPLACE INTO searches
+               (id, query, sources, parameters, source_outcomes,
+                total_candidates, total_papers, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                search.id,
+                search.query,
+                json.dumps(search.sources),
+                json.dumps(search.parameters),
+                outcomes_json,
+                search.total_candidates,
+                search.total_papers,
+                search.created_at.isoformat(),
+            ),
+        )
+        self._db.conn.commit()
+
+    def get(self, search_id: str) -> Search | None:
+        row = self._db.conn.execute(
+            "SELECT * FROM searches WHERE id = ?", (search_id,)
+        ).fetchone()
+        return _row_to_search(row) if row else None
+
+    def save_results(self, results: list[SearchResult]) -> None:
+        for r in results:
+            self._db.conn.execute(
+                """INSERT OR REPLACE INTO search_results
+                   (search_id, paper_id, source, rank, score, raw_metadata)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                (
+                    r.search_id,
+                    r.paper_id,
+                    r.source,
+                    r.rank,
+                    r.score,
+                    json.dumps(r.raw_metadata),
+                ),
+            )
+        self._db.conn.commit()
+
+    def get_results(self, search_id: str) -> list[SearchResult]:
+        rows = self._db.conn.execute(
+            "SELECT * FROM search_results WHERE search_id = ?", (search_id,)
+        ).fetchall()
+        return [
+            SearchResult(
+                search_id=r["search_id"],
+                paper_id=r["paper_id"],
+                source=r["source"],
+                rank=r["rank"],
+                score=r["score"],
+                raw_metadata=json.loads(r["raw_metadata"]),
+            )
+            for r in rows
+        ]
+
+    def list_searches(self, limit: int = 20) -> list[Search]:
+        rows = self._db.conn.execute(
+            "SELECT * FROM searches ORDER BY created_at DESC LIMIT ?", (limit,)
+        ).fetchall()
+        return [_row_to_search(r) for r in rows]
+
+    def diff_searches(
+        self, search_id_a: str, search_id_b: str
+    ) -> tuple[list[str], list[str]]:
+        """Return (added_paper_ids, removed_paper_ids) between two runs."""
+        papers_a = {
+            r["paper_id"]
+            for r in self._db.conn.execute(
+                "SELECT DISTINCT paper_id FROM search_results WHERE search_id = ?",
+                (search_id_a,),
+            ).fetchall()
+        }
+        papers_b = {
+            r["paper_id"]
+            for r in self._db.conn.execute(
+                "SELECT DISTINCT paper_id FROM search_results WHERE search_id = ?",
+                (search_id_b,),
+            ).fetchall()
+        }
+        added = sorted(papers_b - papers_a)
+        removed = sorted(papers_a - papers_b)
+        return added, removed
+
+
+class SQLiteResearchQuestionRepository:
+    """SQLite implementation of ResearchQuestionRepository."""
+
+    def __init__(self, db: Database) -> None:
+        self._db = db
+
+    def save_question(self, question: ResearchQuestion) -> None:
+        self._db.conn.execute(
+            """INSERT OR REPLACE INTO research_questions
+               (id, text, description, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?)""",
+            (
+                question.id,
+                question.text,
+                question.description,
+                question.created_at.isoformat(),
+                question.updated_at.isoformat(),
+            ),
+        )
+        self._db.conn.commit()
+
+    def get_question(self, question_id: str) -> ResearchQuestion | None:
+        row = self._db.conn.execute(
+            "SELECT * FROM research_questions WHERE id = ?", (question_id,)
+        ).fetchone()
+        if not row:
+            return None
+        return ResearchQuestion(
+            id=row["id"],
+            text=row["text"],
+            description=row["description"],
+            created_at=datetime.fromisoformat(row["created_at"]),
+            updated_at=datetime.fromisoformat(row["updated_at"]),
+        )
+
+    def list_questions(self) -> list[ResearchQuestion]:
+        rows = self._db.conn.execute(
+            "SELECT * FROM research_questions ORDER BY created_at DESC"
+        ).fetchall()
+        return [
+            ResearchQuestion(
+                id=r["id"],
+                text=r["text"],
+                description=r["description"],
+                created_at=datetime.fromisoformat(r["created_at"]),
+                updated_at=datetime.fromisoformat(r["updated_at"]),
+            )
+            for r in rows
+        ]
+
+    def save_term(self, term: SearchTerm) -> None:
+        self._db.conn.execute(
+            """INSERT OR REPLACE INTO search_terms
+               (id, question_id, terms, query_string, created_at)
+               VALUES (?, ?, ?, ?, ?)""",
+            (
+                term.id,
+                term.question_id,
+                json.dumps(term.terms),
+                term.query_string,
+                term.created_at.isoformat(),
+            ),
+        )
+        self._db.conn.commit()
+
+    def get_terms(self, question_id: str) -> list[SearchTerm]:
+        rows = self._db.conn.execute(
+            "SELECT * FROM search_terms WHERE question_id = ?", (question_id,)
+        ).fetchall()
+        return [
+            SearchTerm(
+                id=r["id"],
+                question_id=r["question_id"],
+                terms=json.loads(r["terms"]),
+                query_string=r["query_string"],
+                created_at=datetime.fromisoformat(r["created_at"]),
+            )
+            for r in rows
+        ]
+
+
+class SQLiteAssessmentRepository:
+    """SQLite implementation of AssessmentRepository."""
+
+    def __init__(self, db: Database) -> None:
+        self._db = db
+
+    def save(self, assessment: Assessment) -> None:
+        self._db.conn.execute(
+            """INSERT OR REPLACE INTO assessments
+               (id, paper_id, question_id, score, reasoning, model,
+                prompt, temperature, assessor, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                assessment.id,
+                assessment.paper_id,
+                assessment.question_id,
+                assessment.score,
+                assessment.reasoning,
+                assessment.model,
+                assessment.prompt,
+                assessment.temperature,
+                assessment.assessor,
+                assessment.created_at.isoformat(),
+            ),
+        )
+        self._db.conn.commit()
+
+    def get_for_paper(
+        self, paper_id: str, question_id: str | None = None
+    ) -> list[Assessment]:
+        if question_id:
+            rows = self._db.conn.execute(
+                "SELECT * FROM assessments WHERE paper_id = ? AND question_id = ?",
+                (paper_id, question_id),
+            ).fetchall()
+        else:
+            rows = self._db.conn.execute(
+                "SELECT * FROM assessments WHERE paper_id = ?", (paper_id,)
+            ).fetchall()
+        return [_row_to_assessment(r) for r in rows]
+
+    def get_for_question(self, question_id: str) -> list[Assessment]:
+        rows = self._db.conn.execute(
+            "SELECT * FROM assessments WHERE question_id = ?", (question_id,)
+        ).fetchall()
+        return [_row_to_assessment(r) for r in rows]
+
+
+# -- Row mapping helpers --
+
+
+def _row_to_paper(row: sqlite3.Row) -> Paper:
+    return Paper(
+        id=row["id"],
+        title=row["title"],
+        authors=json.loads(row["authors"]),
+        abstract=row["abstract"],
+        doi=row["doi"],
+        arxiv_id=row["arxiv_id"],
+        pubmed_id=row["pubmed_id"],
+        inspire_id=row["inspire_id"],
+        openalex_id=row["openalex_id"],
+        year=row["year"],
+        journal=row["journal"],
+        url=row["url"],
+        source_urls=json.loads(row["source_urls"]),
+        created_at=datetime.fromisoformat(row["created_at"]),
+        updated_at=datetime.fromisoformat(row["updated_at"]),
+    )
+
+
+def _row_to_search(row: sqlite3.Row) -> Search:
+    raw_outcomes = json.loads(row["source_outcomes"])
+    outcomes = [
+        SourceOutcome(
+            source=o["source"],
+            status=SourceStatus(o["status"]),
+            result_count=o.get("result_count", 0),
+            latency_ms=o.get("latency_ms", 0.0),
+            error=o.get("error"),
+        )
+        for o in raw_outcomes
+    ]
+    return Search(
+        id=row["id"],
+        query=row["query"],
+        sources=json.loads(row["sources"]),
+        parameters=json.loads(row["parameters"]),
+        source_outcomes=outcomes,
+        total_candidates=row["total_candidates"],
+        total_papers=row["total_papers"],
+        created_at=datetime.fromisoformat(row["created_at"]),
+    )
+
+
+def _row_to_assessment(row: sqlite3.Row) -> Assessment:
+    return Assessment(
+        id=row["id"],
+        paper_id=row["paper_id"],
+        question_id=row["question_id"],
+        score=row["score"],
+        reasoning=row["reasoning"],
+        model=row["model"],
+        prompt=row["prompt"],
+        temperature=row["temperature"],
+        assessor=row["assessor"],
+        created_at=datetime.fromisoformat(row["created_at"]),
+    )

--- a/src/scitadel/repositories/sqlite.py
+++ b/src/scitadel/repositories/sqlite.py
@@ -70,59 +70,54 @@ class SQLitePaperRepository:
     def __init__(self, db: Database) -> None:
         self._db = db
 
-    def save(self, paper: Paper) -> None:
-        self._db.conn.execute(
-            """INSERT OR REPLACE INTO papers
-               (id, title, authors, abstract, doi, arxiv_id, pubmed_id,
-                inspire_id, openalex_id, year, journal, url, source_urls,
-                created_at, updated_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-            (
-                paper.id,
-                paper.title,
-                json.dumps(paper.authors),
-                paper.abstract,
-                paper.doi,
-                paper.arxiv_id,
-                paper.pubmed_id,
-                paper.inspire_id,
-                paper.openalex_id,
-                paper.year,
-                paper.journal,
-                paper.url,
-                json.dumps(paper.source_urls),
-                paper.created_at.isoformat(),
-                paper.updated_at.isoformat(),
-            ),
+    _UPSERT_SQL = """\
+        INSERT INTO papers
+            (id, title, authors, abstract, doi, arxiv_id, pubmed_id,
+             inspire_id, openalex_id, year, journal, url, source_urls,
+             created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(id) DO UPDATE SET
+            title      = excluded.title,
+            authors    = excluded.authors,
+            abstract   = CASE WHEN excluded.abstract != '' THEN excluded.abstract
+                              ELSE papers.abstract END,
+            doi        = COALESCE(excluded.doi, papers.doi),
+            arxiv_id   = COALESCE(excluded.arxiv_id, papers.arxiv_id),
+            pubmed_id  = COALESCE(excluded.pubmed_id, papers.pubmed_id),
+            inspire_id = COALESCE(excluded.inspire_id, papers.inspire_id),
+            openalex_id= COALESCE(excluded.openalex_id, papers.openalex_id),
+            year       = COALESCE(excluded.year, papers.year),
+            journal    = COALESCE(excluded.journal, papers.journal),
+            url        = COALESCE(excluded.url, papers.url),
+            source_urls= excluded.source_urls,
+            updated_at = excluded.updated_at"""
+
+    def _paper_row(self, paper: Paper) -> tuple:
+        return (
+            paper.id,
+            paper.title,
+            json.dumps(paper.authors),
+            paper.abstract,
+            paper.doi,
+            paper.arxiv_id,
+            paper.pubmed_id,
+            paper.inspire_id,
+            paper.openalex_id,
+            paper.year,
+            paper.journal,
+            paper.url,
+            json.dumps(paper.source_urls),
+            paper.created_at.isoformat(),
+            paper.updated_at.isoformat(),
         )
+
+    def save(self, paper: Paper) -> None:
+        self._db.conn.execute(self._UPSERT_SQL, self._paper_row(paper))
         self._db.conn.commit()
 
     def save_many(self, papers: list[Paper]) -> None:
         for paper in papers:
-            self._db.conn.execute(
-                """INSERT OR REPLACE INTO papers
-                   (id, title, authors, abstract, doi, arxiv_id, pubmed_id,
-                    inspire_id, openalex_id, year, journal, url, source_urls,
-                    created_at, updated_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                (
-                    paper.id,
-                    paper.title,
-                    json.dumps(paper.authors),
-                    paper.abstract,
-                    paper.doi,
-                    paper.arxiv_id,
-                    paper.pubmed_id,
-                    paper.inspire_id,
-                    paper.openalex_id,
-                    paper.year,
-                    paper.journal,
-                    paper.url,
-                    json.dumps(paper.source_urls),
-                    paper.created_at.isoformat(),
-                    paper.updated_at.isoformat(),
-                ),
-            )
+            self._db.conn.execute(self._UPSERT_SQL, self._paper_row(paper))
         self._db.conn.commit()
 
     def get(self, paper_id: str) -> Paper | None:
@@ -161,10 +156,17 @@ class SQLiteSearchRepository:
     def save(self, search: Search) -> None:
         outcomes_json = json.dumps([o.model_dump() for o in search.source_outcomes])
         self._db.conn.execute(
-            """INSERT OR REPLACE INTO searches
+            """INSERT INTO searches
                (id, query, sources, parameters, source_outcomes,
                 total_candidates, total_papers, created_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(id) DO UPDATE SET
+                query = excluded.query,
+                sources = excluded.sources,
+                parameters = excluded.parameters,
+                source_outcomes = excluded.source_outcomes,
+                total_candidates = excluded.total_candidates,
+                total_papers = excluded.total_papers""",
             (
                 search.id,
                 search.query,
@@ -187,9 +189,13 @@ class SQLiteSearchRepository:
     def save_results(self, results: list[SearchResult]) -> None:
         for r in results:
             self._db.conn.execute(
-                """INSERT OR REPLACE INTO search_results
+                """INSERT INTO search_results
                    (search_id, paper_id, source, rank, score, raw_metadata)
-                   VALUES (?, ?, ?, ?, ?, ?)""",
+                   VALUES (?, ?, ?, ?, ?, ?)
+                   ON CONFLICT(search_id, paper_id, source) DO UPDATE SET
+                    rank = excluded.rank,
+                    score = excluded.score,
+                    raw_metadata = excluded.raw_metadata""",
                 (
                     r.search_id,
                     r.paper_id,

--- a/src/scitadel/services/__init__.py
+++ b/src/scitadel/services/__init__.py
@@ -1,0 +1,1 @@
+"""Application services (orchestration, dedup, export)."""

--- a/src/scitadel/services/dedup.py
+++ b/src/scitadel/services/dedup.py
@@ -1,0 +1,148 @@
+"""Deterministic deduplication and canonicalization engine.
+
+DOI-first exact match with fuzzy-title fallback.
+Provenance retained for merged records.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+
+from scitadel.domain.models import CandidatePaper, Paper, SearchResult
+
+
+def _normalize_title(title: str) -> str:
+    """Normalize title for fuzzy matching: lowercase, strip punctuation/whitespace."""
+    title = unicodedata.normalize("NFKD", title)
+    title = title.lower()
+    title = re.sub(r"[^\w\s]", "", title)
+    title = re.sub(r"\s+", " ", title).strip()
+    return title
+
+
+def _title_similarity(a: str, b: str) -> float:
+    """Simple word-overlap similarity (Jaccard) for title matching."""
+    words_a = set(_normalize_title(a).split())
+    words_b = set(_normalize_title(b).split())
+    if not words_a or not words_b:
+        return 0.0
+    intersection = words_a & words_b
+    union = words_a | words_b
+    return len(intersection) / len(union)
+
+
+def _merge_candidate_into_paper(paper: Paper, candidate: CandidatePaper) -> Paper:
+    """Merge a candidate's metadata into an existing paper (fill gaps)."""
+    updates = {}
+
+    if not paper.doi and candidate.doi:
+        updates["doi"] = candidate.doi
+    if not paper.arxiv_id and candidate.arxiv_id:
+        updates["arxiv_id"] = candidate.arxiv_id
+    if not paper.pubmed_id and candidate.pubmed_id:
+        updates["pubmed_id"] = candidate.pubmed_id
+    if not paper.inspire_id and candidate.inspire_id:
+        updates["inspire_id"] = candidate.inspire_id
+    if not paper.openalex_id and candidate.openalex_id:
+        updates["openalex_id"] = candidate.openalex_id
+    if not paper.abstract and candidate.abstract:
+        updates["abstract"] = candidate.abstract
+    if not paper.year and candidate.year:
+        updates["year"] = candidate.year
+    if not paper.journal and candidate.journal:
+        updates["journal"] = candidate.journal
+    if not paper.authors and candidate.authors:
+        updates["authors"] = candidate.authors
+
+    source_urls = dict(paper.source_urls)
+    if candidate.url:
+        source_urls[candidate.source] = candidate.url
+    updates["source_urls"] = source_urls
+
+    if updates:
+        return paper.model_copy(update=updates)
+    return paper
+
+
+def deduplicate(
+    candidates: list[CandidatePaper],
+    title_threshold: float = 0.85,
+) -> tuple[list[Paper], list[SearchResult]]:
+    """Deduplicate candidates into canonical Papers.
+
+    Returns:
+        (papers, search_results) — deduplicated papers and per-source
+        search result records with provenance.
+    """
+    doi_index: dict[str, int] = {}  # doi -> index in papers
+    title_index: dict[str, int] = {}  # normalized title -> index in papers
+    papers: list[Paper] = []
+    search_results: list[SearchResult] = []
+
+    for candidate in candidates:
+        matched_idx = None
+
+        # 1. DOI exact match
+        if candidate.doi:
+            doi_lower = candidate.doi.lower()
+            if doi_lower in doi_index:
+                matched_idx = doi_index[doi_lower]
+
+        # 2. Fuzzy title match (only if no DOI match)
+        if matched_idx is None and candidate.title:
+            norm_title = _normalize_title(candidate.title)
+            if norm_title in title_index:
+                matched_idx = title_index[norm_title]
+            else:
+                # Check similarity against all existing titles
+                for existing_title, idx in title_index.items():
+                    if (
+                        _title_similarity(candidate.title, papers[idx].title)
+                        >= title_threshold
+                    ):
+                        matched_idx = idx
+                        break
+
+        if matched_idx is not None:
+            # Merge into existing paper
+            papers[matched_idx] = _merge_candidate_into_paper(
+                papers[matched_idx], candidate
+            )
+        else:
+            # Create new paper
+            paper = Paper(
+                title=candidate.title,
+                authors=candidate.authors,
+                abstract=candidate.abstract,
+                doi=candidate.doi,
+                arxiv_id=candidate.arxiv_id,
+                pubmed_id=candidate.pubmed_id,
+                inspire_id=candidate.inspire_id,
+                openalex_id=candidate.openalex_id,
+                year=candidate.year,
+                journal=candidate.journal,
+                url=candidate.url,
+                source_urls={candidate.source: candidate.url} if candidate.url else {},
+            )
+            matched_idx = len(papers)
+            papers.append(paper)
+
+            if candidate.doi:
+                doi_index[candidate.doi.lower()] = matched_idx
+            if candidate.title:
+                title_index[_normalize_title(candidate.title)] = matched_idx
+
+        # Record search result provenance
+        search_results.append(
+            SearchResult(
+                search_id="",  # filled by caller
+                paper_id=papers[matched_idx].id,
+                source=candidate.source,
+                rank=candidate.rank,
+                score=candidate.score,
+                raw_metadata=candidate.raw_data,
+            )
+        )
+
+    return papers, search_results

--- a/src/scitadel/services/export.py
+++ b/src/scitadel/services/export.py
@@ -1,0 +1,113 @@
+"""DB-backed export service (BibTeX, JSON, CSV).
+
+Exports operate on persisted canonical records only —
+no direct export from transient in-memory adapter responses.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import re
+
+from scitadel.domain.models import Paper
+
+
+def export_json(papers: list[Paper], indent: int = 2) -> str:
+    """Export papers as a JSON array."""
+    return json.dumps(
+        [p.model_dump(mode="json") for p in papers],
+        indent=indent,
+        ensure_ascii=False,
+    )
+
+
+def export_csv(papers: list[Paper]) -> str:
+    """Export papers as CSV."""
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow(
+        [
+            "id",
+            "title",
+            "authors",
+            "year",
+            "journal",
+            "doi",
+            "arxiv_id",
+            "pubmed_id",
+            "inspire_id",
+            "openalex_id",
+            "abstract",
+            "url",
+        ]
+    )
+    for p in papers:
+        writer.writerow(
+            [
+                p.id,
+                p.title,
+                "; ".join(p.authors),
+                p.year or "",
+                p.journal or "",
+                p.doi or "",
+                p.arxiv_id or "",
+                p.pubmed_id or "",
+                p.inspire_id or "",
+                p.openalex_id or "",
+                p.abstract,
+                p.url or "",
+            ]
+        )
+    return output.getvalue()
+
+
+def export_bibtex(papers: list[Paper]) -> str:
+    """Export papers as BibTeX entries."""
+    entries = []
+    for paper in papers:
+        key = _generate_bibtex_key(paper)
+        entry_type = "article"
+
+        fields = []
+        fields.append(f"  title = {{{paper.title}}}")
+        if paper.authors:
+            fields.append(f"  author = {{{' and '.join(paper.authors)}}}")
+        if paper.year:
+            fields.append(f"  year = {{{paper.year}}}")
+        if paper.journal:
+            fields.append(f"  journal = {{{paper.journal}}}")
+        if paper.doi:
+            fields.append(f"  doi = {{{paper.doi}}}")
+        if paper.url:
+            fields.append(f"  url = {{{paper.url}}}")
+        if paper.arxiv_id:
+            fields.append(f"  eprint = {{{paper.arxiv_id}}}")
+            fields.append("  archiveprefix = {arXiv}")
+        if paper.abstract:
+            fields.append(f"  abstract = {{{paper.abstract}}}")
+
+        entry = f"@{entry_type}{{{key},\n" + ",\n".join(fields) + "\n}"
+        entries.append(entry)
+
+    return "\n\n".join(entries) + "\n" if entries else ""
+
+
+def _generate_bibtex_key(paper: Paper) -> str:
+    """Generate a BibTeX citation key from paper metadata."""
+    # Use first author's last name + year + first word of title
+    author_part = ""
+    if paper.authors:
+        first_author = paper.authors[0]
+        # Extract last name (before comma or first word)
+        author_part = first_author.split(",")[0].split()[-1].lower()
+        author_part = re.sub(r"[^\w]", "", author_part)
+
+    year_part = str(paper.year) if paper.year else ""
+
+    title_words = re.sub(r"[^\w\s]", "", paper.title).split()
+    title_part = title_words[0].lower() if title_words else ""
+
+    key = f"{author_part}{year_part}{title_part}"
+    return key or paper.id[:8]

--- a/src/scitadel/services/orchestrator.py
+++ b/src/scitadel/services/orchestrator.py
@@ -1,0 +1,97 @@
+"""Federated search orchestrator with partial-failure tolerance.
+
+Executes selected adapters in parallel, applies retry/backoff,
+and records per-source outcomes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+
+from scitadel.adapters.base import SourceAdapter
+from scitadel.domain.models import (
+    CandidatePaper,
+    Search,
+    SourceOutcome,
+    SourceStatus,
+)
+
+logger = logging.getLogger(__name__)
+
+
+async def _run_adapter(
+    adapter: SourceAdapter,
+    query: str,
+    max_results: int,
+    max_retries: int = 3,
+) -> tuple[list[CandidatePaper], SourceOutcome]:
+    """Run a single adapter with retry logic. Never raises."""
+    start = time.monotonic()
+    last_error = ""
+
+    for attempt in range(max_retries):
+        try:
+            candidates = await adapter.search(query, max_results=max_results)
+            elapsed_ms = (time.monotonic() - start) * 1000
+            return candidates, SourceOutcome(
+                source=adapter.name,
+                status=SourceStatus.SUCCESS,
+                result_count=len(candidates),
+                latency_ms=elapsed_ms,
+            )
+        except Exception as exc:
+            last_error = str(exc)
+            logger.warning(
+                "Adapter %s attempt %d/%d failed: %s",
+                adapter.name,
+                attempt + 1,
+                max_retries,
+                last_error,
+            )
+            if attempt < max_retries - 1:
+                await asyncio.sleep(2**attempt)  # exponential backoff
+
+    elapsed_ms = (time.monotonic() - start) * 1000
+    return [], SourceOutcome(
+        source=adapter.name,
+        status=SourceStatus.FAILED,
+        result_count=0,
+        latency_ms=elapsed_ms,
+        error=last_error,
+    )
+
+
+async def run_search(
+    query: str,
+    adapters: list[SourceAdapter],
+    max_results: int = 50,
+    max_retries: int = 3,
+) -> tuple[Search, list[CandidatePaper]]:
+    """Execute a federated search across all adapters in parallel.
+
+    Returns (Search record, all CandidatePapers from all sources).
+    Source failures do not abort the whole search.
+    """
+    tasks = [
+        _run_adapter(adapter, query, max_results, max_retries) for adapter in adapters
+    ]
+    results = await asyncio.gather(*tasks)
+
+    all_candidates: list[CandidatePaper] = []
+    outcomes: list[SourceOutcome] = []
+
+    for candidates, outcome in results:
+        all_candidates.extend(candidates)
+        outcomes.append(outcome)
+
+    search = Search(
+        query=query,
+        sources=[a.name for a in adapters],
+        parameters={"max_results": max_results},
+        source_outcomes=outcomes,
+        total_candidates=len(all_candidates),
+    )
+
+    return search, all_candidates

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1,0 +1,194 @@
+"""Tests for source adapter normalization logic.
+
+Uses fixture data to test parsing without real API calls.
+"""
+
+from scitadel.adapters.arxiv.adapter import _parse_arxiv_atom
+from scitadel.adapters.inspire.adapter import _parse_inspire_results
+from scitadel.adapters.openalex.adapter import _reconstruct_abstract, _work_to_candidate
+from scitadel.adapters.pubmed.adapter import _parse_pubmed_xml
+
+# -- PubMed fixtures --
+
+PUBMED_XML = """<?xml version="1.0" ?>
+<!DOCTYPE PubmedArticleSet PUBLIC "-//NLM//DTD PubMedArticle, 1st January 2024//EN"
+  "https://dtd.nlm.nih.gov/ncbi/pubmed/out/pubmed_240101.dtd">
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation>
+      <PMID>12345678</PMID>
+      <Article>
+        <Journal>
+          <Title>Nature Methods</Title>
+          <JournalIssue>
+            <PubDate><Year>2024</Year></PubDate>
+          </JournalIssue>
+        </Journal>
+        <ArticleTitle>PET Tracer Development for Oncology</ArticleTitle>
+        <Abstract>
+          <AbstractText Label="BACKGROUND">This study examines PET tracers.</AbstractText>
+          <AbstractText Label="RESULTS">We found significant results.</AbstractText>
+        </Abstract>
+        <AuthorList>
+          <Author><LastName>Smith</LastName><ForeName>John</ForeName></Author>
+          <Author><LastName>Doe</LastName><ForeName>Jane</ForeName></Author>
+        </AuthorList>
+        <ELocationID EIdType="doi">10.1038/nmeth.2024</ELocationID>
+      </Article>
+    </MedlineCitation>
+  </PubmedArticle>
+</PubmedArticleSet>"""
+
+
+class TestPubMedParser:
+    def test_parse_basic_article(self):
+        candidates = _parse_pubmed_xml(PUBMED_XML)
+        assert len(candidates) == 1
+        c = candidates[0]
+        assert c.source == "pubmed"
+        assert c.source_id == "12345678"
+        assert c.pubmed_id == "12345678"
+        assert c.title == "PET Tracer Development for Oncology"
+        assert c.doi == "10.1038/nmeth.2024"
+        assert c.year == 2024
+        assert c.journal == "Nature Methods"
+        assert len(c.authors) == 2
+        assert c.authors[0] == "Smith, John"
+        assert "BACKGROUND:" in c.abstract
+        assert c.rank == 1
+
+    def test_parse_empty_response(self):
+        candidates = _parse_pubmed_xml("<PubmedArticleSet></PubmedArticleSet>")
+        assert candidates == []
+
+
+# -- arXiv fixtures --
+
+ARXIV_ATOM = """<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom"
+      xmlns:arxiv="http://arxiv.org/schemas/atom">
+  <entry>
+    <id>http://arxiv.org/abs/2301.12345v1</id>
+    <title>  Quantum Computing
+  for Drug Discovery  </title>
+    <summary>  This paper explores quantum approaches
+  to drug discovery.  </summary>
+    <author><name>Alice Researcher</name></author>
+    <author><name>Bob Scientist</name></author>
+    <published>2023-01-15T00:00:00Z</published>
+    <arxiv:doi>10.1234/quantum.2023</arxiv:doi>
+    <arxiv:journal_ref>Phys. Rev. Lett. 130, 012345 (2023)</arxiv:journal_ref>
+    <link title="pdf" href="http://arxiv.org/pdf/2301.12345v1" rel="related"/>
+  </entry>
+</feed>"""
+
+
+class TestArxivParser:
+    def test_parse_basic_entry(self):
+        candidates = _parse_arxiv_atom(ARXIV_ATOM)
+        assert len(candidates) == 1
+        c = candidates[0]
+        assert c.source == "arxiv"
+        assert c.arxiv_id == "2301.12345"
+        assert c.title == "Quantum Computing for Drug Discovery"
+        assert c.doi == "10.1234/quantum.2023"
+        assert c.year == 2023
+        assert len(c.authors) == 2
+        assert "Alice Researcher" in c.authors
+        assert "drug discovery" in c.abstract
+        assert c.rank == 1
+
+    def test_parse_empty_feed(self):
+        empty = '<?xml version="1.0"?><feed xmlns="http://www.w3.org/2005/Atom"></feed>'
+        assert _parse_arxiv_atom(empty) == []
+
+
+# -- OpenAlex fixtures --
+
+
+class TestOpenAlexParser:
+    def test_reconstruct_abstract(self):
+        inverted = {"Hello": [0], "world": [1], "of": [2], "science": [3]}
+        assert _reconstruct_abstract(inverted) == "Hello world of science"
+
+    def test_reconstruct_abstract_empty(self):
+        assert _reconstruct_abstract({}) == ""
+
+    def test_work_to_candidate(self):
+        work = {
+            "id": "https://openalex.org/W1234567",
+            "title": "Machine Learning in Radiopharma",
+            "display_name": "Machine Learning in Radiopharma",
+            "publication_year": 2024,
+            "doi": "https://doi.org/10.1234/ml-pharma",
+            "authorships": [
+                {"author": {"display_name": "Dr. Alice"}},
+                {"author": {"display_name": "Dr. Bob"}},
+            ],
+            "abstract_inverted_index": {"ML": [0], "is": [1], "great": [2]},
+            "primary_location": {
+                "source": {"display_name": "Science"},
+            },
+            "ids": {"pmid": "https://pubmed.ncbi.nlm.nih.gov/9999"},
+        }
+        c = _work_to_candidate(work, rank=1)
+        assert c.source == "openalex"
+        assert c.openalex_id == "W1234567"
+        assert c.title == "Machine Learning in Radiopharma"
+        assert c.doi == "10.1234/ml-pharma"
+        assert c.year == 2024
+        assert len(c.authors) == 2
+        assert c.pubmed_id == "9999"
+        assert c.abstract == "ML is great"
+        assert c.journal == "Science"
+
+
+# -- INSPIRE fixtures --
+
+INSPIRE_RESPONSE = {
+    "hits": {
+        "hits": [
+            {
+                "id": 9876543,
+                "metadata": {
+                    "titles": [{"title": "Detector Physics at the LHC"}],
+                    "authors": [
+                        {"full_name": "Higgs, Peter"},
+                        {"full_name": "Boson, W."},
+                    ],
+                    "abstracts": [
+                        {"value": "We discuss detector upgrades for HL-LHC."}
+                    ],
+                    "dois": [{"value": "10.1007/lhc-det-2024"}],
+                    "arxiv_eprints": [{"value": "2401.99999"}],
+                    "publication_info": [
+                        {
+                            "year": 2024,
+                            "journal_title": "JINST",
+                        }
+                    ],
+                },
+            }
+        ]
+    }
+}
+
+
+class TestInspireParser:
+    def test_parse_basic_hit(self):
+        candidates = _parse_inspire_results(INSPIRE_RESPONSE)
+        assert len(candidates) == 1
+        c = candidates[0]
+        assert c.source == "inspire"
+        assert c.inspire_id == "9876543"
+        assert c.title == "Detector Physics at the LHC"
+        assert c.doi == "10.1007/lhc-det-2024"
+        assert c.arxiv_id == "2401.99999"
+        assert c.year == 2024
+        assert c.journal == "JINST"
+        assert len(c.authors) == 2
+        assert c.rank == 1
+
+    def test_parse_empty_response(self):
+        empty = {"hits": {"hits": []}}
+        assert _parse_inspire_results(empty) == []

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,37 @@
+"""Tests for CLI entry point."""
+
+from click.testing import CliRunner
+
+from scitadel.cli import cli
+
+
+class TestCLI:
+    def test_version(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--version"])
+        assert result.exit_code == 0
+        assert "0.1.0" in result.output
+
+    def test_help(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0
+        assert "search" in result.output
+        assert "history" in result.output
+        assert "export" in result.output
+
+    def test_search_placeholder(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["search", "PET tracer"])
+        assert result.exit_code == 0
+        assert "Searching" in result.output
+
+    def test_history_placeholder(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["history"])
+        assert result.exit_code == 0
+
+    def test_export_placeholder(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["export", "test-id", "-f", "bibtex"])
+        assert result.exit_code == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,19 +19,33 @@ class TestCLI:
         assert "search" in result.output
         assert "history" in result.output
         assert "export" in result.output
+        assert "init" in result.output
 
-    def test_search_placeholder(self):
+    def test_init_command(self, tmp_path):
         runner = CliRunner()
-        result = runner.invoke(cli, ["search", "PET tracer"])
+        db_path = tmp_path / "test.db"
+        result = runner.invoke(cli, ["init", "--db", str(db_path)])
         assert result.exit_code == 0
-        assert "Searching" in result.output
+        assert "initialized" in result.output
+        assert db_path.exists()
 
-    def test_history_placeholder(self):
+    def test_history_empty(self, tmp_path):
         runner = CliRunner()
-        result = runner.invoke(cli, ["history"])
+        db_path = tmp_path / "test.db"
+        # Init first
+        runner.invoke(cli, ["init", "--db", str(db_path)])
+        result = runner.invoke(cli, ["history"], env={"SCITADEL_DB": str(db_path)})
         assert result.exit_code == 0
+        assert "No search history" in result.output
 
-    def test_export_placeholder(self):
+    def test_export_not_found(self, tmp_path):
         runner = CliRunner()
-        result = runner.invoke(cli, ["export", "test-id", "-f", "bibtex"])
-        assert result.exit_code == 0
+        db_path = tmp_path / "test.db"
+        runner.invoke(cli, ["init", "--db", str(db_path)])
+        result = runner.invoke(
+            cli,
+            ["export", "nonexistent"],
+            env={"SCITADEL_DB": str(db_path)},
+        )
+        assert result.exit_code == 1
+        assert "not found" in result.output

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,22 @@
+"""Tests for configuration loading."""
+
+from scitadel.config import Config, SourceConfig, load_config
+
+
+class TestConfig:
+    def test_default_config(self):
+        config = Config()
+        assert config.db_path.name == "scitadel.db"
+        assert "pubmed" in config.default_sources
+        assert "arxiv" in config.default_sources
+
+    def test_source_config_defaults(self):
+        sc = SourceConfig()
+        assert sc.enabled is True
+        assert sc.timeout == 30.0
+        assert sc.max_retries == 3
+
+    def test_load_config(self):
+        config = load_config()
+        assert isinstance(config, Config)
+        assert config.db_path.is_absolute()

--- a/tests/test_domain_models.py
+++ b/tests/test_domain_models.py
@@ -1,0 +1,124 @@
+"""Tests for domain models."""
+
+from scitadel.domain.models import (
+    Assessment,
+    CandidatePaper,
+    Paper,
+    ResearchQuestion,
+    Search,
+    SearchResult,
+    SearchTerm,
+    SourceOutcome,
+    SourceStatus,
+)
+
+
+class TestPaper:
+    def test_create_paper_minimal(self):
+        paper = Paper(title="Test Paper")
+        assert paper.title == "Test Paper"
+        assert paper.id  # auto-generated
+        assert paper.authors == []
+        assert paper.doi is None
+
+    def test_create_paper_full(self):
+        paper = Paper(
+            title="Full Paper",
+            authors=["Alice", "Bob"],
+            abstract="An abstract.",
+            doi="10.1234/test",
+            year=2025,
+            journal="Nature",
+        )
+        assert paper.doi == "10.1234/test"
+        assert len(paper.authors) == 2
+        assert paper.year == 2025
+
+
+class TestCandidatePaper:
+    def test_create_candidate(self):
+        candidate = CandidatePaper(
+            source="pubmed",
+            source_id="12345",
+            title="Candidate Paper",
+            doi="10.1234/candidate",
+            rank=1,
+        )
+        assert candidate.source == "pubmed"
+        assert candidate.source_id == "12345"
+        assert candidate.rank == 1
+
+
+class TestSearch:
+    def test_create_search(self):
+        search = Search(
+            query="PET tracer radiopharma",
+            sources=["pubmed", "arxiv"],
+        )
+        assert search.id
+        assert search.query == "PET tracer radiopharma"
+        assert search.sources == ["pubmed", "arxiv"]
+
+    def test_search_with_outcomes(self):
+        search = Search(
+            query="test",
+            sources=["pubmed"],
+            source_outcomes=[
+                SourceOutcome(
+                    source="pubmed",
+                    status=SourceStatus.SUCCESS,
+                    result_count=42,
+                    latency_ms=150.0,
+                ),
+            ],
+        )
+        assert search.source_outcomes[0].status == SourceStatus.SUCCESS
+        assert search.source_outcomes[0].result_count == 42
+
+
+class TestSearchResult:
+    def test_create_result(self):
+        result = SearchResult(
+            search_id="search-1",
+            paper_id="paper-1",
+            source="arxiv",
+            rank=3,
+            score=0.95,
+        )
+        assert result.search_id == "search-1"
+        assert result.source == "arxiv"
+
+
+class TestResearchQuestion:
+    def test_create_question(self):
+        q = ResearchQuestion(
+            text="What PET tracers are used in oncology?",
+            description="Focus on FDA-approved tracers.",
+        )
+        assert q.id
+        assert "PET tracers" in q.text
+
+
+class TestSearchTerm:
+    def test_create_term(self):
+        term = SearchTerm(
+            question_id="q-1",
+            terms=["PET", "tracer", "oncology"],
+            query_string="PET tracer oncology",
+        )
+        assert term.question_id == "q-1"
+        assert len(term.terms) == 3
+
+
+class TestAssessment:
+    def test_create_assessment(self):
+        assessment = Assessment(
+            paper_id="p-1",
+            question_id="q-1",
+            score=0.87,
+            reasoning="Highly relevant: discusses PET tracer development.",
+            model="claude-sonnet-4-6",
+            assessor="claude-sonnet-4-6",
+        )
+        assert assessment.score == 0.87
+        assert assessment.paper_id == "p-1"

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -1,0 +1,272 @@
+"""Tests for SQLite repository implementations."""
+
+import pytest
+
+from scitadel.domain.models import (
+    Assessment,
+    Paper,
+    ResearchQuestion,
+    Search,
+    SearchResult,
+    SearchTerm,
+    SourceOutcome,
+    SourceStatus,
+)
+from scitadel.repositories.sqlite import (
+    Database,
+    SQLiteAssessmentRepository,
+    SQLitePaperRepository,
+    SQLiteResearchQuestionRepository,
+    SQLiteSearchRepository,
+)
+
+
+@pytest.fixture()
+def db():
+    database = Database(":memory:")
+    database.migrate()
+    yield database
+    database.close()
+
+
+@pytest.fixture()
+def paper_repo(db):
+    return SQLitePaperRepository(db)
+
+
+@pytest.fixture()
+def search_repo(db):
+    return SQLiteSearchRepository(db)
+
+
+@pytest.fixture()
+def question_repo(db):
+    return SQLiteResearchQuestionRepository(db)
+
+
+@pytest.fixture()
+def assessment_repo(db):
+    return SQLiteAssessmentRepository(db)
+
+
+class TestDatabase:
+    def test_migrate_creates_tables(self, db):
+        tables = db.conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+        table_names = {t["name"] for t in tables}
+        assert "papers" in table_names
+        assert "searches" in table_names
+        assert "search_results" in table_names
+        assert "research_questions" in table_names
+        assert "search_terms" in table_names
+        assert "assessments" in table_names
+
+    def test_schema_version_recorded(self, db):
+        row = db.conn.execute(
+            "SELECT version FROM schema_version ORDER BY version DESC LIMIT 1"
+        ).fetchone()
+        assert row["version"] == 1
+
+
+class TestPaperRepository:
+    def test_save_and_get(self, paper_repo):
+        paper = Paper(
+            id="p1",
+            title="Test Paper",
+            authors=["Alice"],
+            doi="10.1234/test",
+        )
+        paper_repo.save(paper)
+        result = paper_repo.get("p1")
+        assert result is not None
+        assert result.title == "Test Paper"
+        assert result.authors == ["Alice"]
+        assert result.doi == "10.1234/test"
+
+    def test_find_by_doi(self, paper_repo):
+        paper = Paper(id="p2", title="DOI Paper", doi="10.5678/doi")
+        paper_repo.save(paper)
+        result = paper_repo.find_by_doi("10.5678/doi")
+        assert result is not None
+        assert result.id == "p2"
+
+    def test_find_by_doi_not_found(self, paper_repo):
+        assert paper_repo.find_by_doi("nonexistent") is None
+
+    def test_find_by_title(self, paper_repo):
+        paper = Paper(id="p3", title="Unique Title Here")
+        paper_repo.save(paper)
+        result = paper_repo.find_by_title("unique title here")
+        assert result is not None
+        assert result.id == "p3"
+
+    def test_save_many(self, paper_repo):
+        papers = [Paper(id=f"pm{i}", title=f"Paper {i}") for i in range(5)]
+        paper_repo.save_many(papers)
+        all_papers = paper_repo.list_all()
+        assert len(all_papers) == 5
+
+    def test_list_all_with_pagination(self, paper_repo):
+        papers = [Paper(id=f"pl{i}", title=f"Paper {i}") for i in range(10)]
+        paper_repo.save_many(papers)
+        page1 = paper_repo.list_all(limit=5, offset=0)
+        page2 = paper_repo.list_all(limit=5, offset=5)
+        assert len(page1) == 5
+        assert len(page2) == 5
+
+
+class TestSearchRepository:
+    def test_save_and_get(self, search_repo):
+        search = Search(
+            id="s1",
+            query="PET tracer",
+            sources=["pubmed", "arxiv"],
+            source_outcomes=[
+                SourceOutcome(
+                    source="pubmed",
+                    status=SourceStatus.SUCCESS,
+                    result_count=10,
+                    latency_ms=200.0,
+                ),
+            ],
+            total_candidates=10,
+            total_papers=8,
+        )
+        search_repo.save(search)
+        result = search_repo.get("s1")
+        assert result is not None
+        assert result.query == "PET tracer"
+        assert result.sources == ["pubmed", "arxiv"]
+        assert len(result.source_outcomes) == 1
+        assert result.source_outcomes[0].status == SourceStatus.SUCCESS
+
+    def test_save_and_get_results(self, search_repo, paper_repo):
+        paper = Paper(id="p-sr", title="Search Result Paper")
+        paper_repo.save(paper)
+        search = Search(id="s-sr", query="test", sources=["pubmed"])
+        search_repo.save(search)
+
+        results = [
+            SearchResult(
+                search_id="s-sr",
+                paper_id="p-sr",
+                source="pubmed",
+                rank=1,
+                score=0.95,
+            ),
+        ]
+        search_repo.save_results(results)
+        retrieved = search_repo.get_results("s-sr")
+        assert len(retrieved) == 1
+        assert retrieved[0].paper_id == "p-sr"
+        assert retrieved[0].rank == 1
+
+    def test_list_searches(self, search_repo):
+        for i in range(3):
+            search_repo.save(
+                Search(id=f"ls{i}", query=f"query {i}", sources=["pubmed"])
+            )
+        searches = search_repo.list_searches(limit=10)
+        assert len(searches) == 3
+
+    def test_diff_searches(self, search_repo, paper_repo):
+        for pid in ["d1", "d2", "d3"]:
+            paper_repo.save(Paper(id=pid, title=f"Paper {pid}"))
+
+        search_repo.save(Search(id="sa", query="q", sources=["pubmed"]))
+        search_repo.save(Search(id="sb", query="q", sources=["pubmed"]))
+
+        search_repo.save_results(
+            [
+                SearchResult(search_id="sa", paper_id="d1", source="pubmed"),
+                SearchResult(search_id="sa", paper_id="d2", source="pubmed"),
+            ]
+        )
+        search_repo.save_results(
+            [
+                SearchResult(search_id="sb", paper_id="d2", source="pubmed"),
+                SearchResult(search_id="sb", paper_id="d3", source="pubmed"),
+            ]
+        )
+
+        added, removed = search_repo.diff_searches("sa", "sb")
+        assert added == ["d3"]
+        assert removed == ["d1"]
+
+
+class TestResearchQuestionRepository:
+    def test_save_and_get_question(self, question_repo):
+        q = ResearchQuestion(
+            id="q1",
+            text="What PET tracers are used?",
+            description="Focus on oncology.",
+        )
+        question_repo.save_question(q)
+        result = question_repo.get_question("q1")
+        assert result is not None
+        assert "PET tracers" in result.text
+
+    def test_list_questions(self, question_repo):
+        for i in range(3):
+            question_repo.save_question(
+                ResearchQuestion(id=f"lq{i}", text=f"Question {i}")
+            )
+        questions = question_repo.list_questions()
+        assert len(questions) == 3
+
+    def test_save_and_get_terms(self, question_repo):
+        q = ResearchQuestion(id="qt", text="Test question")
+        question_repo.save_question(q)
+
+        term = SearchTerm(
+            id="t1",
+            question_id="qt",
+            terms=["PET", "tracer"],
+            query_string="PET tracer",
+        )
+        question_repo.save_term(term)
+        terms = question_repo.get_terms("qt")
+        assert len(terms) == 1
+        assert terms[0].terms == ["PET", "tracer"]
+
+
+class TestAssessmentRepository:
+    def test_save_and_get(self, assessment_repo, paper_repo, question_repo):
+        paper_repo.save(Paper(id="ap", title="Assessed Paper"))
+        question_repo.save_question(ResearchQuestion(id="aq", text="Question"))
+
+        assessment = Assessment(
+            id="a1",
+            paper_id="ap",
+            question_id="aq",
+            score=0.92,
+            reasoning="Very relevant.",
+            assessor="human",
+        )
+        assessment_repo.save(assessment)
+
+        results = assessment_repo.get_for_paper("ap")
+        assert len(results) == 1
+        assert results[0].score == 0.92
+
+    def test_get_for_paper_with_question(
+        self, assessment_repo, paper_repo, question_repo
+    ):
+        paper_repo.save(Paper(id="ap2", title="Paper 2"))
+        question_repo.save_question(ResearchQuestion(id="aq2", text="Q2"))
+        question_repo.save_question(ResearchQuestion(id="aq3", text="Q3"))
+
+        assessment_repo.save(
+            Assessment(id="a2", paper_id="ap2", question_id="aq2", score=0.8)
+        )
+        assessment_repo.save(
+            Assessment(id="a3", paper_id="ap2", question_id="aq3", score=0.3)
+        )
+
+        all_assessments = assessment_repo.get_for_paper("ap2")
+        assert len(all_assessments) == 2
+
+        filtered = assessment_repo.get_for_paper("ap2", question_id="aq2")
+        assert len(filtered) == 1
+        assert filtered[0].score == 0.8

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,291 @@
+"""Tests for application services: orchestrator, dedup, export."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+
+from scitadel.domain.models import CandidatePaper, Paper, SourceStatus
+from scitadel.services.dedup import _normalize_title, _title_similarity, deduplicate
+from scitadel.services.export import export_bibtex, export_csv, export_json
+from scitadel.services.orchestrator import run_search
+
+
+# -- Dedup tests --
+
+
+class TestNormalization:
+    def test_normalize_title(self):
+        assert _normalize_title("  Hello,  World!  ") == "hello world"
+
+    def test_normalize_unicode(self):
+        assert _normalize_title("café") == "cafe"
+
+    def test_title_similarity_identical(self):
+        assert _title_similarity("PET Tracer Study", "PET Tracer Study") == 1.0
+
+    def test_title_similarity_different(self):
+        assert _title_similarity("Apples", "Oranges") == 0.0
+
+    def test_title_similarity_partial(self):
+        sim = _title_similarity("PET Tracer Study", "PET Tracer Analysis")
+        assert 0.3 < sim < 0.8
+
+
+class TestDedup:
+    def test_doi_dedup(self):
+        candidates = [
+            CandidatePaper(
+                source="pubmed",
+                source_id="pm1",
+                title="Same Paper",
+                doi="10.1234/same",
+            ),
+            CandidatePaper(
+                source="openalex",
+                source_id="oa1",
+                title="Same Paper (OpenAlex)",
+                doi="10.1234/same",
+                year=2024,
+            ),
+        ]
+        papers, results = deduplicate(candidates)
+        assert len(papers) == 1
+        assert len(results) == 2
+        assert papers[0].year == 2024  # merged from openalex
+
+    def test_title_dedup(self):
+        candidates = [
+            CandidatePaper(
+                source="pubmed",
+                source_id="pm2",
+                title="PET Tracer Development for Oncology",
+            ),
+            CandidatePaper(
+                source="arxiv",
+                source_id="ax1",
+                title="PET Tracer Development for Oncology",
+                arxiv_id="2301.00001",
+            ),
+        ]
+        papers, results = deduplicate(candidates)
+        assert len(papers) == 1
+        assert papers[0].arxiv_id == "2301.00001"
+
+    def test_different_papers_not_merged(self):
+        candidates = [
+            CandidatePaper(
+                source="pubmed",
+                source_id="pm3",
+                title="Paper About Cats",
+            ),
+            CandidatePaper(
+                source="arxiv",
+                source_id="ax2",
+                title="Paper About Dogs",
+            ),
+        ]
+        papers, results = deduplicate(candidates)
+        assert len(papers) == 2
+
+    def test_metadata_merge_fills_gaps(self):
+        candidates = [
+            CandidatePaper(
+                source="pubmed",
+                source_id="pm4",
+                title="Merged Paper",
+                doi="10.1234/merged",
+                pubmed_id="pm4",
+                journal="Nature",
+            ),
+            CandidatePaper(
+                source="arxiv",
+                source_id="ax3",
+                title="Merged Paper",
+                doi="10.1234/merged",
+                arxiv_id="2301.99999",
+                abstract="Great abstract.",
+            ),
+        ]
+        papers, _ = deduplicate(candidates)
+        assert len(papers) == 1
+        p = papers[0]
+        assert p.pubmed_id == "pm4"
+        assert p.arxiv_id == "2301.99999"
+        assert p.journal == "Nature"
+        assert p.abstract == "Great abstract."
+
+    def test_source_urls_tracked(self):
+        candidates = [
+            CandidatePaper(
+                source="pubmed",
+                source_id="pm5",
+                title="Multi-Source Paper",
+                doi="10.1234/multi",
+                url="https://pubmed.ncbi.nlm.nih.gov/pm5/",
+            ),
+            CandidatePaper(
+                source="arxiv",
+                source_id="ax4",
+                title="Multi-Source Paper",
+                doi="10.1234/multi",
+                url="https://arxiv.org/abs/2301.00002",
+            ),
+        ]
+        papers, _ = deduplicate(candidates)
+        assert "pubmed" in papers[0].source_urls
+        assert "arxiv" in papers[0].source_urls
+
+
+# -- Export tests --
+
+
+class TestExportJSON:
+    def test_export_json_basic(self):
+        papers = [Paper(id="ej1", title="JSON Paper", year=2024)]
+        result = export_json(papers)
+        data = json.loads(result)
+        assert len(data) == 1
+        assert data[0]["title"] == "JSON Paper"
+
+    def test_export_json_empty(self):
+        assert export_json([]) == "[]"
+
+
+class TestExportCSV:
+    def test_export_csv_basic(self):
+        papers = [
+            Paper(
+                id="ec1",
+                title="CSV Paper",
+                authors=["Alice", "Bob"],
+                year=2024,
+                doi="10.1234/csv",
+            )
+        ]
+        result = export_csv(papers)
+        lines = result.strip().split("\n")
+        assert len(lines) == 2  # header + 1 row
+        assert "CSV Paper" in lines[1]
+        assert "Alice; Bob" in lines[1]
+
+    def test_export_csv_header(self):
+        result = export_csv([])
+        assert result.startswith("id,title,authors")
+
+
+class TestExportBibTeX:
+    def test_export_bibtex_basic(self):
+        papers = [
+            Paper(
+                id="eb1",
+                title="BibTeX Paper",
+                authors=["Smith, John", "Doe, Jane"],
+                year=2024,
+                journal="Nature",
+                doi="10.1234/bibtex",
+            )
+        ]
+        result = export_bibtex(papers)
+        assert "@article{smith2024bibtex" in result
+        assert "title = {BibTeX Paper}" in result
+        assert "Smith, John and Doe, Jane" in result
+        assert "doi = {10.1234/bibtex}" in result
+
+    def test_export_bibtex_empty(self):
+        assert export_bibtex([]) == ""
+
+    def test_export_bibtex_with_arxiv(self):
+        papers = [
+            Paper(
+                id="eb2",
+                title="arXiv Paper",
+                authors=["Researcher, Alice"],
+                arxiv_id="2301.12345",
+            )
+        ]
+        result = export_bibtex(papers)
+        assert "eprint = {2301.12345}" in result
+        assert "archiveprefix = {arXiv}" in result
+
+
+# -- Orchestrator tests --
+
+
+class _MockAdapter:
+    """Mock adapter for testing orchestrator."""
+
+    def __init__(
+        self,
+        name: str,
+        results: list[CandidatePaper] | None = None,
+        error: Exception | None = None,
+    ):
+        self._name = name
+        self._results = results or []
+        self._error = error
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    async def search(self, query: str, max_results: int = 50, **params):
+        if self._error:
+            raise self._error
+        return self._results
+
+
+class TestOrchestrator:
+    def test_basic_search(self):
+        adapter = _MockAdapter(
+            "mock",
+            results=[CandidatePaper(source="mock", source_id="m1", title="Mock Paper")],
+        )
+        search, candidates = asyncio.run(
+            run_search("test query", [adapter], max_results=10)
+        )
+        assert search.query == "test query"
+        assert search.total_candidates == 1
+        assert len(candidates) == 1
+        assert search.source_outcomes[0].status == SourceStatus.SUCCESS
+
+    def test_partial_failure(self):
+        good = _MockAdapter(
+            "good",
+            results=[CandidatePaper(source="good", source_id="g1", title="Good Paper")],
+        )
+        bad = _MockAdapter("bad", error=ConnectionError("timeout"))
+
+        search, candidates = asyncio.run(run_search("test", [good, bad], max_retries=1))
+        assert len(candidates) == 1
+        assert search.source_outcomes[0].status == SourceStatus.SUCCESS
+        assert search.source_outcomes[1].status == SourceStatus.FAILED
+
+    def test_all_sources_fail(self):
+        bad1 = _MockAdapter("bad1", error=RuntimeError("fail"))
+        bad2 = _MockAdapter("bad2", error=RuntimeError("fail"))
+
+        search, candidates = asyncio.run(
+            run_search("test", [bad1, bad2], max_retries=1)
+        )
+        assert len(candidates) == 0
+        assert all(o.status == SourceStatus.FAILED for o in search.source_outcomes)
+
+    def test_parallel_execution(self):
+        adapters = [
+            _MockAdapter(
+                f"source{i}",
+                results=[
+                    CandidatePaper(
+                        source=f"source{i}",
+                        source_id=f"s{i}",
+                        title=f"Paper {i}",
+                    )
+                ],
+            )
+            for i in range(4)
+        ]
+        search, candidates = asyncio.run(run_search("parallel test", adapters))
+        assert search.total_candidates == 4
+        assert len(search.source_outcomes) == 4

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -136,6 +145,15 @@ sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
 ]
+
+[[package]]
+name = "bibtexparser"
+version = "1.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/44/1c/577d3ce406e88f370e80a6ebf76ae52a2866521e0b585e8ec612759894f1/bibtexparser-1.4.4.tar.gz", hash = "sha256:093b6c824f7a71d3a748867c4057b71f77c55b8dbc07efc993b781771520d8fb", size = 55594, upload-time = "2026-01-29T18:58:01.366Z" }
 
 [[package]]
 name = "bleach"
@@ -275,6 +293,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4b/51/8ade005e5ca5b0d80fb4aff72a3775b325bdc3d27408c8113811a7cbe640/charset_normalizer-3.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:8a6562c3700cce886c5be75ade4a5db4214fda19fede41d9792d100288d8f94c", size = 107104, upload-time = "2025-10-14T04:41:51.051Z" },
     { url = "https://files.pythonhosted.org/packages/da/5f/6b8f83a55bb8278772c5ae54a577f3099025f9ade59d0136ac24a0df4bde/charset_normalizer-3.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:de00632ca48df9daf77a2c65a484531649261ec9f25489917f09e455cb09ddb2", size = 100743, upload-time = "2025-10-14T04:41:52.122Z" },
     { url = "https://files.pythonhosted.org/packages/0a/4c/925909008ed5a988ccbb72dcc897407e5d6d3bd72410d69e051fc0c14647/charset_normalizer-3.4.4-py3-none-any.whl", hash = "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f", size = 53402, upload-time = "2025-10-14T04:42:31.76Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
 ]
 
 [[package]]
@@ -1644,12 +1674,111 @@ wheels = [
 ]
 
 [[package]]
+name = "pyalex"
+version = "0.21"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/8a/5e270c3d6021a873667be7469fb95b00e0584593d57b7773ef0db6841cef/pyalex-0.21.tar.gz", hash = "sha256:39f470885187e0e411798d34163453361a3834c4dae53f0a18f272475b749741", size = 52593, upload-time = "2026-02-23T14:11:13.421Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/b6/714246176f5ad319dc1d06607a093570bc3d2c37de6d5583e106762883a5/pyalex-0.21-py3-none-any.whl", hash = "sha256:988c37eb31ee3d23176b431d37f7e18c37817317d976237abcc6f3c02f92396f", size = 15761, upload-time = "2026-02-23T14:11:12.523Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.12.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.41.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/5d/5f6c63eebb5afee93bcaae4ce9a898f3373ca23df3ccaef086d0233a35a7/pydantic_core-2.41.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f41a7489d32336dbf2199c8c0a215390a751c5b014c2c1c5366e817202e9cdf7", size = 2110990, upload-time = "2025-11-04T13:39:58.079Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/32/9c2e8ccb57c01111e0fd091f236c7b371c1bccea0fa85247ac55b1e2b6b6/pydantic_core-2.41.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:070259a8818988b9a84a449a2a7337c7f430a22acc0859c6b110aa7212a6d9c0", size = 1896003, upload-time = "2025-11-04T13:39:59.956Z" },
+    { url = "https://files.pythonhosted.org/packages/68/b8/a01b53cb0e59139fbc9e4fda3e9724ede8de279097179be4ff31f1abb65a/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e96cea19e34778f8d59fe40775a7a574d95816eb150850a85a7a4c8f4b94ac69", size = 1919200, upload-time = "2025-11-04T13:40:02.241Z" },
+    { url = "https://files.pythonhosted.org/packages/38/de/8c36b5198a29bdaade07b5985e80a233a5ac27137846f3bc2d3b40a47360/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ed2e99c456e3fadd05c991f8f437ef902e00eedf34320ba2b0842bd1c3ca3a75", size = 2052578, upload-time = "2025-11-04T13:40:04.401Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b5/0e8e4b5b081eac6cb3dbb7e60a65907549a1ce035a724368c330112adfdd/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:65840751b72fbfd82c3c640cff9284545342a4f1eb1586ad0636955b261b0b05", size = 2208504, upload-time = "2025-11-04T13:40:06.072Z" },
+    { url = "https://files.pythonhosted.org/packages/77/56/87a61aad59c7c5b9dc8caad5a41a5545cba3810c3e828708b3d7404f6cef/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e536c98a7626a98feb2d3eaf75944ef6f3dbee447e1f841eae16f2f0a72d8ddc", size = 2335816, upload-time = "2025-11-04T13:40:07.835Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/76/941cc9f73529988688a665a5c0ecff1112b3d95ab48f81db5f7606f522d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eceb81a8d74f9267ef4081e246ffd6d129da5d87e37a77c9bde550cb04870c1c", size = 2075366, upload-time = "2025-11-04T13:40:09.804Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/43/ebef01f69baa07a482844faaa0a591bad1ef129253ffd0cdaa9d8a7f72d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d38548150c39b74aeeb0ce8ee1d8e82696f4a4e16ddc6de7b1d8823f7de4b9b5", size = 2171698, upload-time = "2025-11-04T13:40:12.004Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/87/41f3202e4193e3bacfc2c065fab7706ebe81af46a83d3e27605029c1f5a6/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c23e27686783f60290e36827f9c626e63154b82b116d7fe9adba1fda36da706c", size = 2132603, upload-time = "2025-11-04T13:40:13.868Z" },
+    { url = "https://files.pythonhosted.org/packages/49/7d/4c00df99cb12070b6bccdef4a195255e6020a550d572768d92cc54dba91a/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:482c982f814460eabe1d3bb0adfdc583387bd4691ef00b90575ca0d2b6fe2294", size = 2329591, upload-time = "2025-11-04T13:40:15.672Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6a/ebf4b1d65d458f3cda6a7335d141305dfa19bdc61140a884d165a8a1bbc7/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:bfea2a5f0b4d8d43adf9d7b8bf019fb46fdd10a2e5cde477fbcb9d1fa08c68e1", size = 2319068, upload-time = "2025-11-04T13:40:17.532Z" },
+    { url = "https://files.pythonhosted.org/packages/49/3b/774f2b5cd4192d5ab75870ce4381fd89cf218af999515baf07e7206753f0/pydantic_core-2.41.5-cp312-cp312-win32.whl", hash = "sha256:b74557b16e390ec12dca509bce9264c3bbd128f8a2c376eaa68003d7f327276d", size = 1985908, upload-time = "2025-11-04T13:40:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/45/00173a033c801cacf67c190fef088789394feaf88a98a7035b0e40d53dc9/pydantic_core-2.41.5-cp312-cp312-win_amd64.whl", hash = "sha256:1962293292865bca8e54702b08a4f26da73adc83dd1fcf26fbc875b35d81c815", size = 2020145, upload-time = "2025-11-04T13:40:21.548Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/22/91fbc821fa6d261b376a3f73809f907cec5ca6025642c463d3488aad22fb/pydantic_core-2.41.5-cp312-cp312-win_arm64.whl", hash = "sha256:1746d4a3d9a794cacae06a5eaaccb4b8643a131d45fbc9af23e353dc0a5ba5c3", size = 1976179, upload-time = "2025-11-04T13:40:23.393Z" },
+    { url = "https://files.pythonhosted.org/packages/87/06/8806241ff1f70d9939f9af039c6c35f2360cf16e93c2ca76f184e76b1564/pydantic_core-2.41.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:941103c9be18ac8daf7b7adca8228f8ed6bb7a1849020f643b3a14d15b1924d9", size = 2120403, upload-time = "2025-11-04T13:40:25.248Z" },
+    { url = "https://files.pythonhosted.org/packages/94/02/abfa0e0bda67faa65fef1c84971c7e45928e108fe24333c81f3bfe35d5f5/pydantic_core-2.41.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:112e305c3314f40c93998e567879e887a3160bb8689ef3d2c04b6cc62c33ac34", size = 1896206, upload-time = "2025-11-04T13:40:27.099Z" },
+    { url = "https://files.pythonhosted.org/packages/15/df/a4c740c0943e93e6500f9eb23f4ca7ec9bf71b19e608ae5b579678c8d02f/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cbaad15cb0c90aa221d43c00e77bb33c93e8d36e0bf74760cd00e732d10a6a0", size = 1919307, upload-time = "2025-11-04T13:40:29.806Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e3/6324802931ae1d123528988e0e86587c2072ac2e5394b4bc2bc34b61ff6e/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:03ca43e12fab6023fc79d28ca6b39b05f794ad08ec2feccc59a339b02f2b3d33", size = 2063258, upload-time = "2025-11-04T13:40:33.544Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/d4/2230d7151d4957dd79c3044ea26346c148c98fbf0ee6ebd41056f2d62ab5/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dc799088c08fa04e43144b164feb0c13f9a0bc40503f8df3e9fde58a3c0c101e", size = 2214917, upload-time = "2025-11-04T13:40:35.479Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9f/eaac5df17a3672fef0081b6c1bb0b82b33ee89aa5cec0d7b05f52fd4a1fa/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97aeba56665b4c3235a0e52b2c2f5ae9cd071b8a8310ad27bddb3f7fb30e9aa2", size = 2332186, upload-time = "2025-11-04T13:40:37.436Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4e/35a80cae583a37cf15604b44240e45c05e04e86f9cfd766623149297e971/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:406bf18d345822d6c21366031003612b9c77b3e29ffdb0f612367352aab7d586", size = 2073164, upload-time = "2025-11-04T13:40:40.289Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e3/f6e262673c6140dd3305d144d032f7bd5f7497d3871c1428521f19f9efa2/pydantic_core-2.41.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b93590ae81f7010dbe380cdeab6f515902ebcbefe0b9327cc4804d74e93ae69d", size = 2179146, upload-time = "2025-11-04T13:40:42.809Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c7/20bd7fc05f0c6ea2056a4565c6f36f8968c0924f19b7d97bbfea55780e73/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740", size = 2137788, upload-time = "2025-11-04T13:40:44.752Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/8d/34318ef985c45196e004bc46c6eab2eda437e744c124ef0dbe1ff2c9d06b/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:6561e94ba9dacc9c61bce40e2d6bdc3bfaa0259d3ff36ace3b1e6901936d2e3e", size = 2340133, upload-time = "2025-11-04T13:40:46.66Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/013626bf8c78a5a5d9350d12e7697d3d4de951a75565496abd40ccd46bee/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:915c3d10f81bec3a74fbd4faebe8391013ba61e5a1a8d48c4455b923bdda7858", size = 2324852, upload-time = "2025-11-04T13:40:48.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d9/c248c103856f807ef70c18a4f986693a46a8ffe1602e5d361485da502d20/pydantic_core-2.41.5-cp313-cp313-win32.whl", hash = "sha256:650ae77860b45cfa6e2cdafc42618ceafab3a2d9a3811fcfbd3bbf8ac3c40d36", size = 1994679, upload-time = "2025-11-04T13:40:50.619Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8b/341991b158ddab181cff136acd2552c9f35bd30380422a639c0671e99a91/pydantic_core-2.41.5-cp313-cp313-win_amd64.whl", hash = "sha256:79ec52ec461e99e13791ec6508c722742ad745571f234ea6255bed38c6480f11", size = 2019766, upload-time = "2025-11-04T13:40:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/73/7d/f2f9db34af103bea3e09735bb40b021788a5e834c81eedb541991badf8f5/pydantic_core-2.41.5-cp313-cp313-win_arm64.whl", hash = "sha256:3f84d5c1b4ab906093bdc1ff10484838aca54ef08de4afa9de0f5f14d69639cd", size = 1981005, upload-time = "2025-11-04T13:40:54.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/28/46b7c5c9635ae96ea0fbb779e271a38129df2550f763937659ee6c5dbc65/pydantic_core-2.41.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3f37a19d7ebcdd20b96485056ba9e8b304e27d9904d233d7b1015db320e51f0a", size = 2119622, upload-time = "2025-11-04T13:40:56.68Z" },
+    { url = "https://files.pythonhosted.org/packages/74/1a/145646e5687e8d9a1e8d09acb278c8535ebe9e972e1f162ed338a622f193/pydantic_core-2.41.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1d1d9764366c73f996edd17abb6d9d7649a7eb690006ab6adbda117717099b14", size = 1891725, upload-time = "2025-11-04T13:40:58.807Z" },
+    { url = "https://files.pythonhosted.org/packages/23/04/e89c29e267b8060b40dca97bfc64a19b2a3cf99018167ea1677d96368273/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25e1c2af0fce638d5f1988b686f3b3ea8cd7de5f244ca147c777769e798a9cd1", size = 1915040, upload-time = "2025-11-04T13:41:00.853Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a3/15a82ac7bd97992a82257f777b3583d3e84bdb06ba6858f745daa2ec8a85/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:506d766a8727beef16b7adaeb8ee6217c64fc813646b424d0804d67c16eddb66", size = 2063691, upload-time = "2025-11-04T13:41:03.504Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/0046701313c6ef08c0c1cf0e028c67c770a4e1275ca73131563c5f2a310a/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4819fa52133c9aa3c387b3328f25c1facc356491e6135b459f1de698ff64d869", size = 2213897, upload-time = "2025-11-04T13:41:05.804Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cd/6bac76ecd1b27e75a95ca3a9a559c643b3afcd2dd62086d4b7a32a18b169/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2b761d210c9ea91feda40d25b4efe82a1707da2ef62901466a42492c028553a2", size = 2333302, upload-time = "2025-11-04T13:41:07.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/d2/ef2074dc020dd6e109611a8be4449b98cd25e1b9b8a303c2f0fca2f2bcf7/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22f0fb8c1c583a3b6f24df2470833b40207e907b90c928cc8d3594b76f874375", size = 2064877, upload-time = "2025-11-04T13:41:09.827Z" },
+    { url = "https://files.pythonhosted.org/packages/18/66/e9db17a9a763d72f03de903883c057b2592c09509ccfe468187f2a2eef29/pydantic_core-2.41.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c870e99878c634505236d81e5443092fba820f0373997ff75f90f68cd553", size = 2180680, upload-time = "2025-11-04T13:41:12.379Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9e/3ce66cebb929f3ced22be85d4c2399b8e85b622db77dad36b73c5387f8f8/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90", size = 2138960, upload-time = "2025-11-04T13:41:14.627Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/62/205a998f4327d2079326b01abee48e502ea739d174f0a89295c481a2272e/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:63510af5e38f8955b8ee5687740d6ebf7c2a0886d15a6d65c32814613681bc07", size = 2339102, upload-time = "2025-11-04T13:41:16.868Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/0d/f05e79471e889d74d3d88f5bd20d0ed189ad94c2423d81ff8d0000aab4ff/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:e56ba91f47764cc14f1daacd723e3e82d1a89d783f0f5afe9c364b8bb491ccdb", size = 2326039, upload-time = "2025-11-04T13:41:18.934Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/e08a6208bb100da7e0c4b288eed624a703f4d129bde2da475721a80cab32/pydantic_core-2.41.5-cp314-cp314-win32.whl", hash = "sha256:aec5cf2fd867b4ff45b9959f8b20ea3993fc93e63c7363fe6851424c8a7e7c23", size = 1995126, upload-time = "2025-11-04T13:41:21.418Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5d/56ba7b24e9557f99c9237e29f5c09913c81eeb2f3217e40e922353668092/pydantic_core-2.41.5-cp314-cp314-win_amd64.whl", hash = "sha256:8e7c86f27c585ef37c35e56a96363ab8de4e549a95512445b85c96d3e2f7c1bf", size = 2015489, upload-time = "2025-11-04T13:41:24.076Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/bb/f7a190991ec9e3e0ba22e4993d8755bbc4a32925c0b5b42775c03e8148f9/pydantic_core-2.41.5-cp314-cp314-win_arm64.whl", hash = "sha256:e672ba74fbc2dc8eea59fb6d4aed6845e6905fc2a8afe93175d94a83ba2a01a0", size = 1977288, upload-time = "2025-11-04T13:41:26.33Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ed/77542d0c51538e32e15afe7899d79efce4b81eee631d99850edc2f5e9349/pydantic_core-2.41.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8566def80554c3faa0e65ac30ab0932b9e3a5cd7f8323764303d468e5c37595a", size = 2120255, upload-time = "2025-11-04T13:41:28.569Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/3d/6913dde84d5be21e284439676168b28d8bbba5600d838b9dca99de0fad71/pydantic_core-2.41.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b80aa5095cd3109962a298ce14110ae16b8c1aece8b72f9dafe81cf597ad80b3", size = 1863760, upload-time = "2025-11-04T13:41:31.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f0/e5e6b99d4191da102f2b0eb9687aaa7f5bea5d9964071a84effc3e40f997/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3006c3dd9ba34b0c094c544c6006cc79e87d8612999f1a5d43b769b89181f23c", size = 1878092, upload-time = "2025-11-04T13:41:33.21Z" },
+    { url = "https://files.pythonhosted.org/packages/71/48/36fb760642d568925953bcc8116455513d6e34c4beaa37544118c36aba6d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72f6c8b11857a856bcfa48c86f5368439f74453563f951e473514579d44aa612", size = 2053385, upload-time = "2025-11-04T13:41:35.508Z" },
+    { url = "https://files.pythonhosted.org/packages/20/25/92dc684dd8eb75a234bc1c764b4210cf2646479d54b47bf46061657292a8/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cb1b2f9742240e4bb26b652a5aeb840aa4b417c7748b6f8387927bc6e45e40d", size = 2218832, upload-time = "2025-11-04T13:41:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/09/f53e0b05023d3e30357d82eb35835d0f6340ca344720a4599cd663dca599/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd3d54f38609ff308209bd43acea66061494157703364ae40c951f83ba99a1a9", size = 2327585, upload-time = "2025-11-04T13:41:40Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4e/2ae1aa85d6af35a39b236b1b1641de73f5a6ac4d5a7509f77b814885760c/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ff4321e56e879ee8d2a879501c8e469414d948f4aba74a2d4593184eb326660", size = 2041078, upload-time = "2025-11-04T13:41:42.323Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/13/2e215f17f0ef326fc72afe94776edb77525142c693767fc347ed6288728d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0d2568a8c11bf8225044aa94409e21da0cb09dcdafe9ecd10250b2baad531a9", size = 2173914, upload-time = "2025-11-04T13:41:45.221Z" },
+    { url = "https://files.pythonhosted.org/packages/02/7a/f999a6dcbcd0e5660bc348a3991c8915ce6599f4f2c6ac22f01d7a10816c/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:a39455728aabd58ceabb03c90e12f71fd30fa69615760a075b9fec596456ccc3", size = 2129560, upload-time = "2025-11-04T13:41:47.474Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/b1/6c990ac65e3b4c079a4fb9f5b05f5b013afa0f4ed6780a3dd236d2cbdc64/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:239edca560d05757817c13dc17c50766136d21f7cd0fac50295499ae24f90fdf", size = 2329244, upload-time = "2025-11-04T13:41:49.992Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/02/3c562f3a51afd4d88fff8dffb1771b30cfdfd79befd9883ee094f5b6c0d8/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:2a5e06546e19f24c6a96a129142a75cee553cc018ffee48a460059b1185f4470", size = 2331955, upload-time = "2025-11-04T13:41:54.079Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/96/5fb7d8c3c17bc8c62fdb031c47d77a1af698f1d7a406b0f79aaa1338f9ad/pydantic_core-2.41.5-cp314-cp314t-win32.whl", hash = "sha256:b4ececa40ac28afa90871c2cc2b9ffd2ff0bf749380fbdf57d165fd23da353aa", size = 1988906, upload-time = "2025-11-04T13:41:56.606Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/182129d83032702912c2e2d8bbe33c036f342cc735737064668585dac28f/pydantic_core-2.41.5-cp314-cp314t-win_amd64.whl", hash = "sha256:80aa89cad80b32a912a65332f64a4450ed00966111b6615ca6816153d3585a8c", size = 1981607, upload-time = "2025-11-04T13:41:58.889Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/ed/068e41660b832bb0b1aa5b58011dea2a3fe0ba7861ff38c4d4904c1c1a99/pydantic_core-2.41.5-cp314-cp314t-win_arm64.whl", hash = "sha256:35b44f37a3199f771c3eaa53051bc8a70cd7b54f333531c59e29fd4db5d15008", size = 1974769, upload-time = "2025-11-04T13:42:01.186Z" },
+    { url = "https://files.pythonhosted.org/packages/09/32/59b0c7e63e277fa7911c2fc70ccfb45ce4b98991e7ef37110663437005af/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:7da7087d756b19037bc2c06edc6c170eeef3c3bafcb8f532ff17d64dc427adfd", size = 2110495, upload-time = "2025-11-04T13:42:49.689Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/81/05e400037eaf55ad400bcd318c05bb345b57e708887f07ddb2d20e3f0e98/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc", size = 1915388, upload-time = "2025-11-04T13:42:52.215Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0d/e3549b2399f71d56476b77dbf3cf8937cec5cd70536bdc0e374a421d0599/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56", size = 1942879, upload-time = "2025-11-04T13:42:56.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/07/34573da085946b6a313d7c42f82f16e8920bfd730665de2d11c0c37a74b5/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b", size = 2139017, upload-time = "2025-11-04T13:42:59.471Z" },
 ]
 
 [[package]]
@@ -2049,6 +2178,13 @@ wheels = [
 name = "scitadel"
 version = "0.1.0"
 source = { editable = "." }
+dependencies = [
+    { name = "bibtexparser" },
+    { name = "click" },
+    { name = "httpx" },
+    { name = "pyalex" },
+    { name = "pydantic" },
+]
 
 [package.optional-dependencies]
 all = [
@@ -2082,11 +2218,16 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "bibtexparser", specifier = ">=1.4" },
+    { name = "click", specifier = ">=8.1" },
+    { name = "httpx", specifier = ">=0.27" },
     { name = "ipykernel", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "jupyter", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "matplotlib", marker = "extra == 'science'", specifier = ">=3.9" },
     { name = "numpy", marker = "extra == 'science'", specifier = ">=2.0" },
     { name = "pandas", marker = "extra == 'science'", specifier = ">=2.2" },
+    { name = "pyalex", specifier = ">=0.14" },
+    { name = "pydantic", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "scipy", marker = "extra == 'science'", specifier = ">=1.14" },
@@ -2220,6 +2361,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2181,6 +2181,7 @@ source = { editable = "." }
 dependencies = [
     { name = "bibtexparser" },
     { name = "click" },
+    { name = "defusedxml" },
     { name = "httpx" },
     { name = "pyalex" },
     { name = "pydantic" },
@@ -2220,6 +2221,7 @@ dev = [
 requires-dist = [
     { name = "bibtexparser", specifier = ">=1.4" },
     { name = "click", specifier = ">=8.1" },
+    { name = "defusedxml", specifier = ">=0.7" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "ipykernel", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "jupyter", marker = "extra == 'dev'", specifier = ">=1.0" },


### PR DESCRIPTION
## Summary

Implements the full Phase 1 MVP for Scitadel as specified in RFC-001, covering issues #2–#13:

- **Bootstrap** (#2): Package structure, config, CLI entrypoint, pyproject.toml with all dependencies
- **Domain models** (#3): Pydantic models for Paper, CandidatePaper, Search, SearchResult, ResearchQuestion, SearchTerm, Assessment; repository port interfaces (Protocols)
- **SQLite persistence** (#4): Schema migration (001_initial.sql), Database class with WAL mode, full repository implementations (Paper, Search, ResearchQuestion, Assessment)
- **PubMed adapter** (#5): E-utilities esearch + efetch with safe XML parsing (defusedxml)
- **arXiv adapter** (#6): Atom feed API with namespace-aware XML parsing
- **OpenAlex adapter** (#7): PyAlex wrapper with inverted-index abstract reconstruction
- **INSPIRE-HEP adapter** (#8, #9): REST API adapter with nested JSON parsing
- **Federated search orchestrator** (#10): Parallel async execution with retry/backoff and partial-failure tolerance
- **Dedup engine** (#11): DOI-first exact match + Jaccard word-overlap fuzzy title fallback, metadata merge
- **Export service** (#12): BibTeX, JSON, CSV formatters with arXiv eprint support
- **CLI commands** (#13): `search`, `history`, `export`, `init` — all wired to real services

### Architecture

Hexagonal (ports & adapters): domain models + Protocol-based repository ports + SQLite adapters + async source adapters + thin CLI shell.

### Test coverage

66 tests across all layers (domain models, config, repositories, adapters, services, CLI integration).

## Test plan

- [x] `pytest tests/` — 66 tests pass (0.26s)
- [ ] Manual: `scitadel init && scitadel search "PET tracer" -s pubmed -n 5`
- [ ] Manual: `scitadel history` / `scitadel export <id> -f bibtex`

Closes #2, closes #3, closes #4, closes #5, closes #6, closes #7, closes #8, closes #9, closes #10, closes #11, closes #12, closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)