### PR TITLE
feat: Scorer trait + CLI subprocess backend (WU-1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1908,6 +1908,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "chrono",
  "clap",
  "predicates",
  "scitadel-adapters",

--- a/crates/scitadel-cli/Cargo.toml
+++ b/crates/scitadel-cli/Cargo.toml
@@ -15,6 +15,7 @@ scitadel-adapters = { path = "../scitadel-adapters" }
 scitadel-scoring = { path = "../scitadel-scoring" }
 scitadel-export = { path = "../scitadel-export" }
 scitadel-tui = { path = "../scitadel-tui" }
+chrono = { workspace = true }
 clap = { workspace = true }
 tokio = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/scitadel-cli/src/commands.rs
+++ b/crates/scitadel-cli/src/commands.rs
@@ -340,6 +340,7 @@ pub async fn assess(
     question_id: &str,
     model: &str,
     temperature: f64,
+    scorer_backend: &str,
 ) -> Result<()> {
     let db = open_db()?;
     let (paper_repo, search_repo, q_repo, a_repo, _) = db.repositories();
@@ -367,28 +368,56 @@ pub async fn assess(
         .collect();
 
     println!("Scoring {} papers against: \"{}\"", papers.len(), question.text);
-    println!("  Model: {model}  Temperature: {temperature}");
+    println!("  Model: {model}  Temperature: {temperature}  Backend: {scorer_backend}");
 
-    let config = scitadel_scoring::ScoringConfig {
-        model: model.to_string(),
-        temperature,
-        api_key: std::env::var("ANTHROPIC_API_KEY").unwrap_or_default(),
-        ..Default::default()
+    let backend = match scorer_backend {
+        "cli" => scitadel_scoring::ScorerBackend::Cli,
+        "api" => scitadel_scoring::ScorerBackend::Api,
+        _ => scitadel_scoring::ScorerBackend::Auto,
     };
 
-    let scorer = scitadel_scoring::ClaudeScorer::new(config);
+    let options = scitadel_scoring::ScoringOptions {
+        backend,
+        model: model.to_string(),
+        temperature,
+    };
 
-    let assessments = scorer
-        .score_papers(&papers, &question, Some(&|i, total, paper, assessment| {
-            println!(
-                "  [{}/{}] {:.2}  {}",
-                i + 1,
-                total,
-                assessment.score,
-                &paper.title[..paper.title.len().min(60)]
-            );
-        }))
-        .await;
+    let scorer = scitadel_scoring::create_scorer(options)
+        .await
+        .context("failed to create scorer")?;
+
+    let mut assessments = Vec::new();
+    let total = papers.len();
+
+    for (i, paper) in papers.iter().enumerate() {
+        match scorer.score_paper(paper, &question).await {
+            Ok(assessment) => {
+                println!(
+                    "  [{}/{}] {:.2}  {}",
+                    i + 1,
+                    total,
+                    assessment.score,
+                    &paper.title[..paper.title.len().min(60)]
+                );
+                assessments.push(assessment);
+            }
+            Err(e) => {
+                println!("  [{}/{}] FAIL  {}", i + 1, total, e);
+                assessments.push(scitadel_core::models::Assessment {
+                    id: scitadel_core::models::AssessmentId::new(),
+                    paper_id: paper.id.clone(),
+                    question_id: question.id.clone(),
+                    score: 0.0,
+                    reasoning: format!("Scoring failed: {e}"),
+                    model: Some(model.to_string()),
+                    prompt: None,
+                    temperature: Some(temperature),
+                    assessor: format!("{model}:error"),
+                    created_at: chrono::Utc::now(),
+                });
+            }
+        }
+    }
 
     for a in &assessments {
         a_repo.save(a)?;

--- a/crates/scitadel-cli/src/main.rs
+++ b/crates/scitadel-cli/src/main.rs
@@ -82,6 +82,9 @@ enum Commands {
         /// Temperature for scoring
         #[arg(short, long, default_value = "0.0")]
         temperature: f64,
+        /// Scorer backend: auto, cli, api
+        #[arg(long, default_value = "auto")]
+        scorer: String,
     },
     /// Launch interactive TUI dashboard
     Tui,
@@ -176,7 +179,8 @@ async fn main() -> Result<()> {
             question,
             model,
             temperature,
-        } => commands::assess(&search_id, &question, &model, temperature).await,
+            scorer,
+        } => commands::assess(&search_id, &question, &model, temperature, &scorer).await,
         Commands::Snowball {
             search_id,
             question,

--- a/crates/scitadel-scoring/src/claude.rs
+++ b/crates/scitadel-scoring/src/claude.rs
@@ -1,9 +1,11 @@
+use async_trait::async_trait;
 use reqwest::Client;
 use tracing::{info, warn};
 
 use scitadel_core::models::{Assessment, Paper, ResearchQuestion};
 
 use crate::error::ScoringError;
+use crate::scorer::Scorer;
 
 pub const SCORING_SYSTEM_PROMPT: &str = "\
 You are a scientific literature relevance assessor. You evaluate how relevant \
@@ -225,6 +227,17 @@ pub fn parse_scoring_response(text: &str) -> (f64, String) {
     } else {
         warn!("Failed to parse scoring response: {}", &text[..text.len().min(200)]);
         (0.0, format!("Parse error. Raw response: {}", &text[..text.len().min(500)]))
+    }
+}
+
+#[async_trait]
+impl Scorer for ClaudeScorer {
+    async fn score_paper(
+        &self,
+        paper: &Paper,
+        question: &ResearchQuestion,
+    ) -> Result<Assessment, ScoringError> {
+        self.score_paper(paper, question).await
     }
 }
 

--- a/crates/scitadel-scoring/src/cli.rs
+++ b/crates/scitadel-scoring/src/cli.rs
@@ -1,0 +1,71 @@
+use async_trait::async_trait;
+use tracing::debug;
+
+use scitadel_core::models::{Assessment, Paper, ResearchQuestion};
+
+use crate::claude::{build_user_prompt, parse_scoring_response, SCORING_SYSTEM_PROMPT};
+use crate::error::ScoringError;
+use crate::scorer::Scorer;
+
+/// Scorer that invokes the `claude` CLI as a subprocess.
+pub struct CliScorer {
+    model: String,
+    temperature: f64,
+}
+
+impl CliScorer {
+    pub fn new(model: String, temperature: f64) -> Self {
+        Self { model, temperature }
+    }
+}
+
+#[async_trait]
+impl Scorer for CliScorer {
+    async fn score_paper(
+        &self,
+        paper: &Paper,
+        question: &ResearchQuestion,
+    ) -> Result<Assessment, ScoringError> {
+        let user_prompt = build_user_prompt(paper, question);
+
+        let output = tokio::process::Command::new("claude")
+            .arg("--print")
+            .arg("--model")
+            .arg(&self.model)
+            .arg("--output-format")
+            .arg("text")
+            .arg("--system-prompt")
+            .arg(SCORING_SYSTEM_PROMPT)
+            .arg(&user_prompt)
+            .output()
+            .await
+            .map_err(|e| ScoringError::Subprocess(format!("failed to spawn claude CLI: {e}")))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(ScoringError::Subprocess(format!(
+                "claude CLI exited with {}: {}",
+                output.status,
+                stderr.trim()
+            )));
+        }
+
+        let raw_text = String::from_utf8_lossy(&output.stdout).to_string();
+        debug!(raw_len = raw_text.len(), "claude CLI response received");
+
+        let parsed = parse_scoring_response(&raw_text);
+
+        Ok(Assessment {
+            id: scitadel_core::models::AssessmentId::new(),
+            paper_id: paper.id.clone(),
+            question_id: question.id.clone(),
+            score: parsed.0,
+            reasoning: parsed.1,
+            model: Some(self.model.clone()),
+            prompt: Some(user_prompt),
+            temperature: Some(self.temperature),
+            assessor: format!("claude-cli:{}", self.model),
+            created_at: chrono::Utc::now(),
+        })
+    }
+}

--- a/crates/scitadel-scoring/src/error.rs
+++ b/crates/scitadel-scoring/src/error.rs
@@ -13,6 +13,9 @@ pub enum ScoringError {
 
     #[error("parse error: {0}")]
     Parse(String),
+
+    #[error("subprocess error: {0}")]
+    Subprocess(String),
 }
 
 impl From<ScoringError> for scitadel_core::error::CoreError {

--- a/crates/scitadel-scoring/src/lib.rs
+++ b/crates/scitadel-scoring/src/lib.rs
@@ -1,10 +1,18 @@
 #[cfg(feature = "scoring")]
 pub mod claude;
+#[cfg(feature = "scoring")]
+pub mod cli;
 pub mod error;
 pub mod provenance;
+#[cfg(feature = "scoring")]
+pub mod scorer;
 
 #[cfg(feature = "scoring")]
 pub use claude::{
     build_user_prompt, parse_scoring_response, ClaudeScorer, ScoringConfig,
     SCORING_SYSTEM_PROMPT, SCORING_USER_PROMPT,
 };
+#[cfg(feature = "scoring")]
+pub use cli::CliScorer;
+#[cfg(feature = "scoring")]
+pub use scorer::{create_scorer, Scorer, ScorerBackend, ScoringOptions};

--- a/crates/scitadel-scoring/src/scorer.rs
+++ b/crates/scitadel-scoring/src/scorer.rs
@@ -1,0 +1,138 @@
+use async_trait::async_trait;
+use tracing::warn;
+
+use scitadel_core::models::{Assessment, Paper, ResearchQuestion};
+
+use crate::error::ScoringError;
+
+/// Abstraction over different scoring backends (API, CLI subprocess, etc.).
+#[async_trait]
+pub trait Scorer: Send + Sync {
+    /// Score a single paper against a research question.
+    async fn score_paper(
+        &self,
+        paper: &Paper,
+        question: &ResearchQuestion,
+    ) -> Result<Assessment, ScoringError>;
+
+    /// Score multiple papers with optional progress callback.
+    ///
+    /// Default implementation calls `score_paper` in a loop.
+    async fn score_papers(
+        &self,
+        papers: &[Paper],
+        question: &ResearchQuestion,
+    ) -> Vec<Assessment> {
+        let mut assessments = Vec::new();
+        let total = papers.len();
+
+        for (i, paper) in papers.iter().enumerate() {
+            match self.score_paper(paper, question).await {
+                Ok(assessment) => {
+                    assessments.push(assessment);
+                }
+                Err(e) => {
+                    warn!(
+                        paper_idx = i + 1,
+                        total,
+                        error = %e,
+                        "Failed to score paper"
+                    );
+                    assessments.push(Assessment {
+                        id: scitadel_core::models::AssessmentId::new(),
+                        paper_id: paper.id.clone(),
+                        question_id: question.id.clone(),
+                        score: 0.0,
+                        reasoning: format!("Scoring failed: {e}"),
+                        model: None,
+                        prompt: None,
+                        temperature: None,
+                        assessor: "error".to_string(),
+                        created_at: chrono::Utc::now(),
+                    });
+                }
+            }
+        }
+
+        assessments
+    }
+}
+
+/// Which scoring backend to use.
+pub enum ScorerBackend {
+    /// Automatically detect: prefer CLI, fall back to API.
+    Auto,
+    /// Use `claude` CLI subprocess.
+    Cli,
+    /// Use Anthropic HTTP API directly.
+    Api,
+}
+
+/// Options for creating a scorer.
+pub struct ScoringOptions {
+    pub backend: ScorerBackend,
+    pub model: String,
+    pub temperature: f64,
+}
+
+/// Create a scorer based on the requested backend.
+///
+/// For `Auto`: checks if the `claude` CLI is available, prefers `CliScorer`,
+/// falls back to `ClaudeScorer` (API key).
+pub async fn create_scorer(options: ScoringOptions) -> Result<Box<dyn Scorer>, ScoringError> {
+    match options.backend {
+        ScorerBackend::Cli => {
+            if !cli_available().await {
+                return Err(ScoringError::Subprocess(
+                    "claude CLI not found in PATH".to_string(),
+                ));
+            }
+            Ok(Box::new(crate::cli::CliScorer::new(
+                options.model,
+                options.temperature,
+            )))
+        }
+        ScorerBackend::Api => {
+            let api_key = std::env::var("ANTHROPIC_API_KEY").map_err(|_| {
+                ScoringError::Api("ANTHROPIC_API_KEY environment variable not set".to_string())
+            })?;
+            let config = crate::claude::ScoringConfig {
+                model: options.model,
+                temperature: options.temperature,
+                api_key,
+                ..Default::default()
+            };
+            Ok(Box::new(crate::claude::ClaudeScorer::new(config)))
+        }
+        ScorerBackend::Auto => {
+            if cli_available().await {
+                Ok(Box::new(crate::cli::CliScorer::new(
+                    options.model,
+                    options.temperature,
+                )))
+            } else if std::env::var("ANTHROPIC_API_KEY").is_ok() {
+                let config = crate::claude::ScoringConfig {
+                    model: options.model,
+                    temperature: options.temperature,
+                    api_key: std::env::var("ANTHROPIC_API_KEY").unwrap_or_default(),
+                    ..Default::default()
+                };
+                Ok(Box::new(crate::claude::ClaudeScorer::new(config)))
+            } else {
+                Err(ScoringError::Api(
+                    "no scorer available: claude CLI not found and ANTHROPIC_API_KEY not set"
+                        .to_string(),
+                ))
+            }
+        }
+    }
+}
+
+/// Check whether the `claude` CLI binary is available on PATH.
+async fn cli_available() -> bool {
+    tokio::process::Command::new("which")
+        .arg("claude")
+        .output()
+        .await
+        .is_ok_and(|o| o.status.success())
+}


### PR DESCRIPTION
## Summary
- Add `Scorer` trait in `scitadel-scoring` abstracting over scoring backends
- Add `CliScorer` that invokes `claude --print` as a subprocess instead of requiring `ANTHROPIC_API_KEY`
- Add `create_scorer()` factory with `Auto`/`Cli`/`Api` backend selection (auto-detects CLI availability)
- Add `--scorer` arg to `scitadel assess` command (default: `auto`)
- Make `SCORING_SYSTEM_PROMPT`, `SCORING_USER_PROMPT`, `build_user_prompt()`, `parse_scoring_response()` public for reuse
- Add `Subprocess(String)` variant to `ScoringError`

## Test plan
- [x] `cargo test -p scitadel-scoring` passes (4 tests)
- [x] `cargo clippy -p scitadel-scoring -- -D warnings` clean
- [x] `cargo clippy -p scitadel-cli -- -D warnings` clean
- [x] `cargo build --workspace` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)