### PR TITLE
feat: TUI dashboard with ratatui (WU-03)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,6 +199,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,6 +301,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "console"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,6 +362,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "csv"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -345,6 +405,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -387,6 +481,12 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encode_unicode"
@@ -647,6 +747,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -914,6 +1016,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -947,6 +1055,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "insta"
 version = "1.46.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -957,6 +1074,19 @@ dependencies = [
  "serde",
  "similar",
  "tempfile",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -980,6 +1110,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1028,6 +1167,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -1052,6 +1197,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "matchers"
@@ -1081,6 +1235,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1446,6 +1601,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1586,6 +1762,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -1593,7 +1782,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -1726,6 +1915,7 @@ dependencies = [
  "scitadel-db",
  "scitadel-export",
  "scitadel-scoring",
+ "scitadel-tui",
  "serde_json",
  "tempfile",
  "tokio",
@@ -1815,6 +2005,18 @@ dependencies = [
  "tokio",
  "tracing",
  "wiremock",
+]
+
+[[package]]
+name = "scitadel-tui"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "crossterm",
+ "ratatui",
+ "scitadel-core",
+ "scitadel-db",
+ "tracing",
 ]
 
 [[package]]
@@ -1943,6 +2145,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1987,10 +2210,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "subtle"
@@ -2059,7 +2310,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -2335,6 +2586,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2545,6 +2825,28 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/scitadel-export",
     "crates/scitadel-cli",
     "crates/scitadel-mcp",
+    "crates/scitadel-tui",
 ]
 
 [workspace.package]
@@ -47,6 +48,10 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # CLI
 clap = { version = "4", features = ["derive"] }
+
+# TUI
+ratatui = "0.29"
+crossterm = "0.28"
 
 # MCP
 rmcp = { version = "0.1", features = ["server", "transport-io"] }

--- a/crates/scitadel-cli/Cargo.toml
+++ b/crates/scitadel-cli/Cargo.toml
@@ -14,6 +14,7 @@ scitadel-db = { path = "../scitadel-db" }
 scitadel-adapters = { path = "../scitadel-adapters" }
 scitadel-scoring = { path = "../scitadel-scoring" }
 scitadel-export = { path = "../scitadel-export" }
+scitadel-tui = { path = "../scitadel-tui" }
 clap = { workspace = true }
 tokio = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/scitadel-cli/src/commands.rs
+++ b/crates/scitadel-cli/src/commands.rs
@@ -29,6 +29,12 @@ where
     }
 }
 
+pub fn tui() -> Result<()> {
+    let config = load_config();
+    scitadel_tui::run(&config.db_path)?;
+    Ok(())
+}
+
 pub fn init(db_path: Option<PathBuf>) -> Result<()> {
     let config = load_config();
     let path = db_path.unwrap_or(config.db_path);

--- a/crates/scitadel-cli/src/main.rs
+++ b/crates/scitadel-cli/src/main.rs
@@ -83,6 +83,8 @@ enum Commands {
         #[arg(short, long, default_value = "0.0")]
         temperature: f64,
     },
+    /// Launch interactive TUI dashboard
+    Tui,
     /// Run citation chaining (snowballing)
     Snowball {
         /// Search ID
@@ -168,6 +170,7 @@ async fn main() -> Result<()> {
                 query,
             } => commands::question_add_terms(&question_id, &terms, query),
         },
+        Commands::Tui => commands::tui(),
         Commands::Assess {
             search_id,
             question,

--- a/crates/scitadel-tui/Cargo.toml
+++ b/crates/scitadel-tui/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "scitadel-tui"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+scitadel-core = { path = "../scitadel-core" }
+scitadel-db = { path = "../scitadel-db" }
+ratatui = { workspace = true }
+crossterm = { workspace = true }
+anyhow = { workspace = true }
+tracing = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/scitadel-tui/src/app.rs
+++ b/crates/scitadel-tui/src/app.rs
@@ -1,0 +1,345 @@
+use std::io;
+use std::path::Path;
+
+use anyhow::Result;
+use crossterm::event::{self, Event, KeyCode, KeyModifiers};
+use crossterm::terminal::{
+    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+};
+use crossterm::execute;
+use ratatui::backend::CrosstermBackend;
+use ratatui::layout::{Constraint, Direction, Layout};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::Tabs;
+use ratatui::Terminal;
+
+use crate::data::DataStore;
+use crate::views::{detail, papers, questions, searches};
+use crate::widgets::status_bar;
+
+/// Active tab in the TUI.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Tab {
+    Searches,
+    Papers,
+    Questions,
+}
+
+impl Tab {
+    const ALL: [Self; 3] = [Self::Searches, Self::Papers, Self::Questions];
+
+    fn index(self) -> usize {
+        match self {
+            Self::Searches => 0,
+            Self::Papers => 1,
+            Self::Questions => 2,
+        }
+    }
+
+    fn next(self) -> Self {
+        match self {
+            Self::Searches => Self::Papers,
+            Self::Papers => Self::Questions,
+            Self::Questions => Self::Searches,
+        }
+    }
+
+    fn prev(self) -> Self {
+        match self {
+            Self::Searches => Self::Questions,
+            Self::Papers => Self::Searches,
+            Self::Questions => Self::Papers,
+        }
+    }
+}
+
+/// Overlay view shown on top of the current tab.
+#[derive(Debug, Clone)]
+pub enum Overlay {
+    /// Showing a single paper's detail view.
+    PaperDetail { paper_id: String, scroll: u16 },
+    /// Papers filtered by a search ID.
+    SearchPapers { search_id: String, selected: usize },
+}
+
+/// Main application state.
+pub struct App {
+    pub tab: Tab,
+    pub running: bool,
+    pub data: DataStore,
+    pub overlay: Option<Overlay>,
+
+    // Per-tab selection indices
+    pub search_selected: usize,
+    pub paper_selected: usize,
+    pub question_selected: usize,
+}
+
+impl App {
+    fn new(data: DataStore) -> Self {
+        Self {
+            tab: Tab::Searches,
+            running: true,
+            data,
+            overlay: None,
+            search_selected: 0,
+            paper_selected: 0,
+            question_selected: 0,
+        }
+    }
+
+    fn handle_key(&mut self, code: KeyCode, modifiers: KeyModifiers) {
+        // Global quit
+        if code == KeyCode::Char('q') && self.overlay.is_none() {
+            self.running = false;
+            return;
+        }
+        if code == KeyCode::Char('c') && modifiers.contains(KeyModifiers::CONTROL) {
+            self.running = false;
+            return;
+        }
+
+        // Handle overlay input first
+        if self.overlay.is_some() {
+            self.handle_overlay_key(code);
+            return;
+        }
+
+        match code {
+            KeyCode::Tab => self.tab = self.tab.next(),
+            KeyCode::BackTab => self.tab = self.tab.prev(),
+            _ => self.handle_tab_key(code),
+        }
+    }
+
+    fn handle_overlay_key(&mut self, code: KeyCode) {
+        match self.overlay {
+            Some(Overlay::PaperDetail {
+                ref mut scroll, ..
+            }) => match code {
+                KeyCode::Esc | KeyCode::Char('q') => self.overlay = None,
+                KeyCode::Char('j') | KeyCode::Down => *scroll = scroll.saturating_add(1),
+                KeyCode::Char('k') | KeyCode::Up => *scroll = scroll.saturating_sub(1),
+                KeyCode::Char('d') => *scroll = scroll.saturating_add(10),
+                KeyCode::Char('u') => *scroll = scroll.saturating_sub(10),
+                _ => {}
+            },
+            Some(Overlay::SearchPapers {
+                ref search_id,
+                ref mut selected,
+            }) => match code {
+                KeyCode::Esc | KeyCode::Char('q') => self.overlay = None,
+                KeyCode::Char('j') | KeyCode::Down => {
+                    let count = self
+                        .data
+                        .load_papers_for_search(search_id)
+                        .map(|p| p.len())
+                        .unwrap_or(0);
+                    if count > 0 {
+                        *selected = (*selected + 1).min(count - 1);
+                    }
+                }
+                KeyCode::Char('k') | KeyCode::Up => {
+                    *selected = selected.saturating_sub(1);
+                }
+                KeyCode::Enter => {
+                    let search_id_clone = search_id.clone();
+                    let sel = *selected;
+                    if let Ok(papers) = self.data.load_papers_for_search(&search_id_clone)
+                        && let Some(paper) = papers.get(sel)
+                    {
+                        self.overlay = Some(Overlay::PaperDetail {
+                            paper_id: paper.id.as_str().to_string(),
+                            scroll: 0,
+                        });
+                    }
+                }
+                _ => {}
+            },
+            None => {}
+        }
+    }
+
+    fn handle_tab_key(&mut self, code: KeyCode) {
+        match self.tab {
+            Tab::Searches => {
+                let count = self
+                    .data
+                    .load_searches(100)
+                    .map(|s| s.len())
+                    .unwrap_or(0);
+                match code {
+                    KeyCode::Char('j') | KeyCode::Down => {
+                        if count > 0 {
+                            self.search_selected =
+                                (self.search_selected + 1).min(count - 1);
+                        }
+                    }
+                    KeyCode::Char('k') | KeyCode::Up => {
+                        self.search_selected = self.search_selected.saturating_sub(1);
+                    }
+                    KeyCode::Enter => {
+                        if let Ok(searches) = self.data.load_searches(100)
+                            && let Some(search) = searches.get(self.search_selected)
+                        {
+                            self.overlay = Some(Overlay::SearchPapers {
+                                search_id: search.id.as_str().to_string(),
+                                selected: 0,
+                            });
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            Tab::Papers => {
+                let count = self
+                    .data
+                    .load_papers(1000, 0)
+                    .map(|p| p.len())
+                    .unwrap_or(0);
+                match code {
+                    KeyCode::Char('j') | KeyCode::Down => {
+                        if count > 0 {
+                            self.paper_selected =
+                                (self.paper_selected + 1).min(count - 1);
+                        }
+                    }
+                    KeyCode::Char('k') | KeyCode::Up => {
+                        self.paper_selected = self.paper_selected.saturating_sub(1);
+                    }
+                    KeyCode::Enter => {
+                        if let Ok(papers) = self.data.load_papers(1000, 0)
+                            && let Some(paper) = papers.get(self.paper_selected)
+                        {
+                            self.overlay = Some(Overlay::PaperDetail {
+                                paper_id: paper.id.as_str().to_string(),
+                                scroll: 0,
+                            });
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            Tab::Questions => {
+                let count = self
+                    .data
+                    .load_questions()
+                    .map(|q| q.len())
+                    .unwrap_or(0);
+                match code {
+                    KeyCode::Char('j') | KeyCode::Down => {
+                        if count > 0 {
+                            self.question_selected =
+                                (self.question_selected + 1).min(count - 1);
+                        }
+                    }
+                    KeyCode::Char('k') | KeyCode::Up => {
+                        self.question_selected = self.question_selected.saturating_sub(1);
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+}
+
+/// Entry point: set up terminal, run event loop, restore terminal.
+pub fn run(db_path: &Path) -> Result<()> {
+    let data = DataStore::open(db_path)?;
+    let mut app = App::new(data);
+
+    // Set up terminal
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    // Event loop
+    let result = run_loop(&mut terminal, &mut app);
+
+    // Restore terminal
+    disable_raw_mode()?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+    terminal.show_cursor()?;
+
+    result
+}
+
+fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &mut App) -> Result<()> {
+    while app.running {
+        terminal.draw(|frame| draw(frame, app))?;
+
+        if event::poll(std::time::Duration::from_millis(100))?
+            && let Event::Key(key) = event::read()?
+            && key.kind == event::KeyEventKind::Press
+        {
+            app.handle_key(key.code, key.modifiers);
+        }
+    }
+    Ok(())
+}
+
+fn draw(frame: &mut ratatui::Frame, app: &mut App) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3), // tabs
+            Constraint::Min(0),   // content
+            Constraint::Length(1), // status bar
+        ])
+        .split(frame.area());
+
+    // Draw tab bar
+    let tab_titles: Vec<Line<'_>> = Tab::ALL
+        .iter()
+        .map(|t| {
+            let label = match t {
+                Tab::Searches => "Searches",
+                Tab::Papers => "Papers",
+                Tab::Questions => "Questions",
+            };
+            Line::from(Span::raw(label))
+        })
+        .collect();
+
+    let tabs = Tabs::new(tab_titles)
+        .select(app.tab.index())
+        .highlight_style(
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        )
+        .divider(Span::raw(" | "));
+
+    frame.render_widget(tabs, chunks[0]);
+
+    // Draw content (overlay takes precedence)
+    match &app.overlay {
+        Some(Overlay::PaperDetail { paper_id, scroll }) => {
+            detail::draw(frame, chunks[1], &app.data, paper_id, *scroll);
+        }
+        Some(Overlay::SearchPapers {
+            search_id,
+            selected,
+        }) => {
+            papers::draw_for_search(frame, chunks[1], &app.data, search_id, *selected);
+        }
+        None => match app.tab {
+            Tab::Searches => searches::draw(frame, chunks[1], &app.data, app.search_selected),
+            Tab::Papers => papers::draw(frame, chunks[1], &app.data, app.paper_selected),
+            Tab::Questions => {
+                questions::draw(frame, chunks[1], &app.data, app.question_selected);
+            }
+        },
+    }
+
+    // Draw status bar
+    let help_text = if app.overlay.is_some() {
+        "Esc: back | j/k: navigate | Enter: select | d/u: page down/up"
+    } else {
+        "Tab/Shift-Tab: switch tabs | j/k: navigate | Enter: select | q: quit"
+    };
+    status_bar::draw(frame, chunks[2], help_text);
+}

--- a/crates/scitadel-tui/src/data.rs
+++ b/crates/scitadel-tui/src/data.rs
@@ -1,0 +1,68 @@
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+use scitadel_core::models::{Assessment, Paper, ResearchQuestion, Search, SearchTerm};
+use scitadel_core::ports::{
+    AssessmentRepository, PaperRepository, QuestionRepository, SearchRepository,
+};
+use scitadel_db::sqlite::Database;
+
+/// Wrapper around the database that loads data for each TUI view.
+pub struct DataStore {
+    db: Database,
+}
+
+impl DataStore {
+    pub fn open(db_path: &Path) -> Result<Self> {
+        let db = Database::open(db_path).context("failed to open database")?;
+        db.migrate().context("migration failed")?;
+        Ok(Self { db })
+    }
+
+    pub fn load_searches(&self, limit: i64) -> Result<Vec<Search>> {
+        let (_, search_repo, _, _, _) = self.db.repositories();
+        Ok(search_repo.list_searches(limit)?)
+    }
+
+    pub fn load_papers(&self, limit: i64, offset: i64) -> Result<Vec<Paper>> {
+        let (paper_repo, _, _, _, _) = self.db.repositories();
+        Ok(paper_repo.list_all(limit, offset)?)
+    }
+
+    pub fn load_paper(&self, paper_id: &str) -> Result<Option<Paper>> {
+        let (paper_repo, _, _, _, _) = self.db.repositories();
+        Ok(paper_repo.get(paper_id)?)
+    }
+
+    pub fn load_papers_for_search(&self, search_id: &str) -> Result<Vec<Paper>> {
+        let (paper_repo, search_repo, _, _, _) = self.db.repositories();
+        let results = search_repo.get_results(search_id)?;
+        let mut papers = Vec::new();
+        for r in &results {
+            if let Ok(Some(paper)) = paper_repo.get(r.paper_id.as_str()) {
+                papers.push(paper);
+            }
+        }
+        Ok(papers)
+    }
+
+    pub fn load_questions(&self) -> Result<Vec<ResearchQuestion>> {
+        let (_, _, q_repo, _, _) = self.db.repositories();
+        Ok(q_repo.list_questions()?)
+    }
+
+    pub fn load_terms(&self, question_id: &str) -> Result<Vec<SearchTerm>> {
+        let (_, _, q_repo, _, _) = self.db.repositories();
+        Ok(q_repo.get_terms(question_id)?)
+    }
+
+    pub fn load_assessments_for_paper(
+        &self,
+        paper_id: &str,
+        question_id: Option<&str>,
+    ) -> Result<Vec<Assessment>> {
+        let (_, _, _, a_repo, _) = self.db.repositories();
+        Ok(a_repo.get_for_paper(paper_id, question_id)?)
+    }
+}

--- a/crates/scitadel-tui/src/lib.rs
+++ b/crates/scitadel-tui/src/lib.rs
@@ -1,0 +1,6 @@
+mod app;
+mod data;
+mod views;
+mod widgets;
+
+pub use app::run;

--- a/crates/scitadel-tui/src/views/detail.rs
+++ b/crates/scitadel-tui/src/views/detail.rs
@@ -1,0 +1,120 @@
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
+use ratatui::Frame;
+
+use crate::data::DataStore;
+
+pub fn draw(frame: &mut Frame, area: Rect, data: &DataStore, paper_id: &str, scroll: u16) {
+    let Ok(Some(paper)) = data.load_paper(paper_id) else {
+        let block = Block::default()
+            .title(" Paper Detail ")
+            .borders(Borders::ALL);
+        let msg = Paragraph::new("Paper not found.").block(block);
+        frame.render_widget(msg, area);
+        return;
+    };
+
+    let assessments = data
+        .load_assessments_for_paper(paper_id, None)
+        .unwrap_or_default();
+
+    let label_style = Style::default()
+        .fg(Color::Yellow)
+        .add_modifier(Modifier::BOLD);
+
+    let mut lines: Vec<Line<'_>> = Vec::new();
+
+    lines.push(Line::from(vec![
+        Span::styled("Title: ", label_style),
+        Span::raw(&paper.title),
+    ]));
+    lines.push(Line::from(""));
+
+    lines.push(Line::from(vec![
+        Span::styled("Authors: ", label_style),
+        Span::raw(if paper.authors.is_empty() {
+            "Unknown".to_string()
+        } else {
+            paper.authors.join(", ")
+        }),
+    ]));
+
+    if let Some(year) = paper.year {
+        lines.push(Line::from(vec![
+            Span::styled("Year: ", label_style),
+            Span::raw(year.to_string()),
+        ]));
+    }
+
+    if let Some(ref journal) = paper.journal {
+        lines.push(Line::from(vec![
+            Span::styled("Journal: ", label_style),
+            Span::raw(journal.as_str()),
+        ]));
+    }
+
+    if let Some(ref doi) = paper.doi {
+        lines.push(Line::from(vec![
+            Span::styled("DOI: ", label_style),
+            Span::raw(doi.as_str()),
+        ]));
+    }
+
+    if let Some(ref url) = paper.url {
+        lines.push(Line::from(vec![
+            Span::styled("URL: ", label_style),
+            Span::raw(url.as_str()),
+        ]));
+    }
+
+    lines.push(Line::from(vec![
+        Span::styled("ID: ", label_style),
+        Span::raw(paper.id.as_str()),
+    ]));
+
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled("Abstract:", label_style)));
+
+    if paper.r#abstract.is_empty() {
+        lines.push(Line::from("  (no abstract available)"));
+    } else {
+        for line in paper.r#abstract.lines() {
+            lines.push(Line::from(format!("  {line}")));
+        }
+    }
+
+    if !assessments.is_empty() {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled("Assessments:", label_style)));
+        for a in &assessments {
+            lines.push(Line::from(format!(
+                "  Score: {:.2}  Assessor: {}  Date: {}",
+                a.score,
+                if a.assessor.is_empty() {
+                    "—"
+                } else {
+                    &a.assessor
+                },
+                a.created_at.format("%Y-%m-%d %H:%M"),
+            )));
+            if !a.reasoning.is_empty() {
+                for rline in a.reasoning.lines() {
+                    lines.push(Line::from(format!("    {rline}")));
+                }
+            }
+        }
+    }
+
+    let paragraph = Paragraph::new(lines)
+        .block(
+            Block::default()
+                .title(" Paper Detail ")
+                .borders(Borders::ALL),
+        )
+        .wrap(Wrap { trim: false })
+        .scroll((scroll, 0));
+
+    frame.render_widget(paragraph, area);
+}

--- a/crates/scitadel-tui/src/views/mod.rs
+++ b/crates/scitadel-tui/src/views/mod.rs
@@ -1,0 +1,4 @@
+pub mod detail;
+pub mod papers;
+pub mod questions;
+pub mod searches;

--- a/crates/scitadel-tui/src/views/papers.rs
+++ b/crates/scitadel-tui/src/views/papers.rs
@@ -1,0 +1,107 @@
+use ratatui::layout::{Constraint, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table, TableState};
+use ratatui::Frame;
+
+use scitadel_core::models::Paper;
+
+use crate::data::DataStore;
+
+pub fn draw(frame: &mut Frame, area: Rect, data: &DataStore, selected: usize) {
+    let papers = data.load_papers(1000, 0).unwrap_or_default();
+    render_paper_table(frame, area, &papers, selected, " Papers ");
+}
+
+pub fn draw_for_search(
+    frame: &mut Frame,
+    area: Rect,
+    data: &DataStore,
+    search_id: &str,
+    selected: usize,
+) {
+    let papers = data.load_papers_for_search(search_id).unwrap_or_default();
+    let title = format!(" Papers for search {} ", &search_id[..search_id.len().min(8)]);
+    render_paper_table(frame, area, &papers, selected, &title);
+}
+
+fn render_paper_table(
+    frame: &mut Frame,
+    area: Rect,
+    papers: &[Paper],
+    selected: usize,
+    title: &str,
+) {
+    if papers.is_empty() {
+        let block = Block::default().title(title.to_string()).borders(Borders::ALL);
+        let empty = Paragraph::new("No papers found.").block(block);
+        frame.render_widget(empty, area);
+        return;
+    }
+
+    let header = Row::new(vec![
+        Cell::from("#"),
+        Cell::from("Title"),
+        Cell::from("Authors"),
+        Cell::from("Year"),
+    ])
+    .style(
+        Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD),
+    );
+
+    let rows: Vec<Row<'_>> = papers
+        .iter()
+        .enumerate()
+        .map(|(i, p)| {
+            let authors = format_authors(&p.authors);
+            let year = p
+                .year
+                .map_or_else(|| "—".to_string(), |y| y.to_string());
+
+            Row::new(vec![
+                Cell::from((i + 1).to_string()),
+                Cell::from(truncate(&p.title, 60)),
+                Cell::from(truncate(&authors, 30)),
+                Cell::from(year),
+            ])
+        })
+        .collect();
+
+    let widths = [
+        Constraint::Length(5),
+        Constraint::Min(30),
+        Constraint::Length(32),
+        Constraint::Length(6),
+    ];
+
+    let table = Table::new(rows, widths)
+        .header(header)
+        .block(Block::default().title(title.to_string()).borders(Borders::ALL))
+        .row_highlight_style(
+            Style::default()
+                .bg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
+        );
+
+    let mut state = TableState::default();
+    state.select(Some(selected));
+    frame.render_stateful_widget(table, area, &mut state);
+}
+
+fn format_authors(authors: &[String]) -> String {
+    match authors.len() {
+        0 => "Unknown".to_string(),
+        1 => authors[0].clone(),
+        2 => format!("{}, {}", authors[0], authors[1]),
+        _ => format!("{}, {} et al.", authors[0], authors[1]),
+    }
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        format!("{}...", &s[..max.saturating_sub(3)])
+    }
+}

--- a/crates/scitadel-tui/src/views/questions.rs
+++ b/crates/scitadel-tui/src/views/questions.rs
@@ -1,0 +1,82 @@
+use ratatui::layout::{Constraint, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table, TableState};
+use ratatui::Frame;
+
+use crate::data::DataStore;
+
+pub fn draw(frame: &mut Frame, area: Rect, data: &DataStore, selected: usize) {
+    let questions = data.load_questions().unwrap_or_default();
+
+    if questions.is_empty() {
+        let block = Block::default()
+            .title(" Research Questions ")
+            .borders(Borders::ALL);
+        let empty =
+            Paragraph::new("No research questions yet. Run `scitadel question create` to add one.")
+                .block(block);
+        frame.render_widget(empty, area);
+        return;
+    }
+
+    let header = Row::new(vec![
+        Cell::from("ID"),
+        Cell::from("Date"),
+        Cell::from("Text"),
+        Cell::from("# Terms"),
+    ])
+    .style(
+        Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD),
+    );
+
+    let rows: Vec<Row<'_>> = questions
+        .iter()
+        .map(|q| {
+            let term_count = data
+                .load_terms(q.id.as_str())
+                .map(|t| t.len())
+                .unwrap_or(0);
+
+            Row::new(vec![
+                Cell::from(q.id.short().to_string()),
+                Cell::from(q.created_at.format("%Y-%m-%d %H:%M").to_string()),
+                Cell::from(truncate(&q.text, 60)),
+                Cell::from(term_count.to_string()),
+            ])
+        })
+        .collect();
+
+    let widths = [
+        Constraint::Length(10),
+        Constraint::Length(18),
+        Constraint::Min(20),
+        Constraint::Length(9),
+    ];
+
+    let table = Table::new(rows, widths)
+        .header(header)
+        .block(
+            Block::default()
+                .title(" Research Questions ")
+                .borders(Borders::ALL),
+        )
+        .row_highlight_style(
+            Style::default()
+                .bg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
+        );
+
+    let mut state = TableState::default();
+    state.select(Some(selected));
+    frame.render_stateful_widget(table, area, &mut state);
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        format!("{}...", &s[..max.saturating_sub(3)])
+    }
+}

--- a/crates/scitadel-tui/src/views/searches.rs
+++ b/crates/scitadel-tui/src/views/searches.rs
@@ -1,0 +1,84 @@
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::widgets::{Block, Borders, Cell, Row, Table, TableState};
+use ratatui::Frame;
+
+use scitadel_core::models::SourceStatus;
+
+use crate::data::DataStore;
+
+pub fn draw(frame: &mut Frame, area: Rect, data: &DataStore, selected: usize) {
+    let searches = data.load_searches(100).unwrap_or_default();
+
+    if searches.is_empty() {
+        let block = Block::default()
+            .title(" Searches ")
+            .borders(Borders::ALL);
+        let empty = ratatui::widgets::Paragraph::new("No searches yet. Run `scitadel search` to get started.")
+            .block(block);
+        frame.render_widget(empty, area);
+        return;
+    }
+
+    let header = Row::new(vec![
+        Cell::from("ID"),
+        Cell::from("Date"),
+        Cell::from("Query"),
+        Cell::from("Papers"),
+        Cell::from("Sources"),
+    ])
+    .style(
+        Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD),
+    );
+
+    let rows: Vec<Row<'_>> = searches
+        .iter()
+        .map(|s| {
+            let success = s
+                .source_outcomes
+                .iter()
+                .filter(|o| o.status == SourceStatus::Success)
+                .count();
+            let total = s.source_outcomes.len();
+
+            Row::new(vec![
+                Cell::from(s.id.short().to_string()),
+                Cell::from(s.created_at.format("%Y-%m-%d %H:%M").to_string()),
+                Cell::from(truncate(&s.query, 50)),
+                Cell::from(s.total_papers.to_string()),
+                Cell::from(format!("{success}/{total}")),
+            ])
+        })
+        .collect();
+
+    let widths = [
+        ratatui::layout::Constraint::Length(10),
+        ratatui::layout::Constraint::Length(18),
+        ratatui::layout::Constraint::Min(20),
+        ratatui::layout::Constraint::Length(8),
+        ratatui::layout::Constraint::Length(10),
+    ];
+
+    let table = Table::new(rows, widths)
+        .header(header)
+        .block(Block::default().title(" Searches ").borders(Borders::ALL))
+        .row_highlight_style(
+            Style::default()
+                .bg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
+        );
+
+    let mut state = TableState::default();
+    state.select(Some(selected));
+    frame.render_stateful_widget(table, area, &mut state);
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        format!("{}...", &s[..max.saturating_sub(3)])
+    }
+}

--- a/crates/scitadel-tui/src/widgets/mod.rs
+++ b/crates/scitadel-tui/src/widgets/mod.rs
@@ -1,0 +1,1 @@
+pub mod status_bar;

--- a/crates/scitadel-tui/src/widgets/status_bar.rs
+++ b/crates/scitadel-tui/src/widgets/status_bar.rs
@@ -1,0 +1,9 @@
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Style};
+use ratatui::widgets::Paragraph;
+use ratatui::Frame;
+
+pub fn draw(frame: &mut Frame, area: Rect, help_text: &str) {
+    let bar = Paragraph::new(help_text).style(Style::default().fg(Color::DarkGray));
+    frame.render_widget(bar, area);
+}


### PR DESCRIPTION
## Summary
- Add `scitadel-tui` crate with ratatui-based terminal dashboard featuring three tabs: Searches, Papers, and Research Questions
- Each tab renders a navigable table; Enter drills into search papers or paper detail (scrollable view with abstract and assessment scores)
- Integrate as `scitadel tui` CLI subcommand; add `ratatui 0.29` and `crossterm 0.28` to workspace dependencies

## Test plan
- [x] `cargo test -p scitadel-tui` passes (no runtime tests yet — TUI is interactive)
- [x] `cargo clippy -p scitadel-tui -- -D warnings` clean
- [x] `cargo clippy -p scitadel-cli -- -D warnings` clean
- [x] `cargo build --workspace` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)