### PR TITLE
feat(tui): split-pane hierarchical navigation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2017,6 +2017,7 @@ dependencies = [
  "ratatui",
  "scitadel-core",
  "scitadel-db",
+ "serde_json",
  "tracing",
 ]
 

--- a/crates/scitadel-tui/Cargo.toml
+++ b/crates/scitadel-tui/Cargo.toml
@@ -11,6 +11,7 @@ ratatui = { workspace = true }
 crossterm = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }
+serde_json = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/scitadel-tui/src/app.rs
+++ b/crates/scitadel-tui/src/app.rs
@@ -3,243 +3,175 @@ use std::path::Path;
 
 use anyhow::Result;
 use crossterm::event::{self, Event, KeyCode, KeyModifiers};
+use crossterm::execute;
 use crossterm::terminal::{
     disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
 };
-use crossterm::execute;
 use ratatui::backend::CrosstermBackend;
 use ratatui::layout::{Constraint, Direction, Layout};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::Tabs;
+use ratatui::widgets::{Block, Borders, Paragraph};
 use ratatui::Terminal;
 
 use crate::data::DataStore;
-use crate::views::{detail, papers, questions, searches};
+use crate::views::{detail, nav_tree, papers, questions, searches};
 use crate::widgets::status_bar;
 
-/// Active tab in the TUI.
+/// Current hierarchy level in the navigation tree.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Tab {
+pub enum NavLevel {
+    Questions,
     Searches,
     Papers,
-    Questions,
-}
-
-impl Tab {
-    const ALL: [Self; 3] = [Self::Searches, Self::Papers, Self::Questions];
-
-    fn index(self) -> usize {
-        match self {
-            Self::Searches => 0,
-            Self::Papers => 1,
-            Self::Questions => 2,
-        }
-    }
-
-    fn next(self) -> Self {
-        match self {
-            Self::Searches => Self::Papers,
-            Self::Papers => Self::Questions,
-            Self::Questions => Self::Searches,
-        }
-    }
-
-    fn prev(self) -> Self {
-        match self {
-            Self::Searches => Self::Questions,
-            Self::Papers => Self::Searches,
-            Self::Questions => Self::Papers,
-        }
-    }
-}
-
-/// Overlay view shown on top of the current tab.
-#[derive(Debug, Clone)]
-pub enum Overlay {
-    /// Showing a single paper's detail view.
-    PaperDetail { paper_id: String, scroll: u16 },
-    /// Papers filtered by a search ID.
-    SearchPapers { search_id: String, selected: usize },
 }
 
 /// Main application state.
 pub struct App {
-    pub tab: Tab,
+    pub nav_level: NavLevel,
+    pub selected_question: Option<String>,
+    pub selected_search: Option<String>,
+    pub selected_paper: Option<String>,
+    pub left_index: usize,
+    pub right_scroll: u16,
     pub running: bool,
     pub data: DataStore,
-    pub overlay: Option<Overlay>,
-
-    // Per-tab selection indices
-    pub search_selected: usize,
-    pub paper_selected: usize,
-    pub question_selected: usize,
 }
 
 impl App {
     fn new(data: DataStore) -> Self {
         Self {
-            tab: Tab::Searches,
+            nav_level: NavLevel::Questions,
+            selected_question: None,
+            selected_search: None,
+            selected_paper: None,
+            left_index: 0,
+            right_scroll: 0,
             running: true,
             data,
-            overlay: None,
-            search_selected: 0,
-            paper_selected: 0,
-            question_selected: 0,
         }
     }
 
     fn handle_key(&mut self, code: KeyCode, modifiers: KeyModifiers) {
         // Global quit
-        if code == KeyCode::Char('q') && self.overlay.is_none() {
-            self.running = false;
-            return;
-        }
         if code == KeyCode::Char('c') && modifiers.contains(KeyModifiers::CONTROL) {
             self.running = false;
             return;
         }
-
-        // Handle overlay input first
-        if self.overlay.is_some() {
-            self.handle_overlay_key(code);
+        if code == KeyCode::Char('q') {
+            self.running = false;
             return;
         }
 
         match code {
-            KeyCode::Tab => self.tab = self.tab.next(),
-            KeyCode::BackTab => self.tab = self.tab.prev(),
-            _ => self.handle_tab_key(code),
+            KeyCode::Char('j') | KeyCode::Down => self.move_down(),
+            KeyCode::Char('k') | KeyCode::Up => self.move_up(),
+            KeyCode::Enter => self.enter(),
+            KeyCode::Esc => self.go_back(),
+            KeyCode::Char('d') => self.right_scroll = self.right_scroll.saturating_add(10),
+            KeyCode::Char('u') => self.right_scroll = self.right_scroll.saturating_sub(10),
+            _ => {}
         }
     }
 
-    fn handle_overlay_key(&mut self, code: KeyCode) {
-        match self.overlay {
-            Some(Overlay::PaperDetail {
-                ref mut scroll, ..
-            }) => match code {
-                KeyCode::Esc | KeyCode::Char('q') => self.overlay = None,
-                KeyCode::Char('j') | KeyCode::Down => *scroll = scroll.saturating_add(1),
-                KeyCode::Char('k') | KeyCode::Up => *scroll = scroll.saturating_sub(1),
-                KeyCode::Char('d') => *scroll = scroll.saturating_add(10),
-                KeyCode::Char('u') => *scroll = scroll.saturating_sub(10),
-                _ => {}
-            },
-            Some(Overlay::SearchPapers {
-                ref search_id,
-                ref mut selected,
-            }) => match code {
-                KeyCode::Esc | KeyCode::Char('q') => self.overlay = None,
-                KeyCode::Char('j') | KeyCode::Down => {
-                    let count = self
-                        .data
-                        .load_papers_for_search(search_id)
-                        .map(|p| p.len())
-                        .unwrap_or(0);
-                    if count > 0 {
-                        *selected = (*selected + 1).min(count - 1);
-                    }
+    fn move_down(&mut self) {
+        let count = self.left_item_count();
+        if count > 0 {
+            self.left_index = (self.left_index + 1).min(count - 1);
+        }
+        self.right_scroll = 0;
+        self.selected_paper = None;
+    }
+
+    fn move_up(&mut self) {
+        self.left_index = self.left_index.saturating_sub(1);
+        self.right_scroll = 0;
+        self.selected_paper = None;
+    }
+
+    fn enter(&mut self) {
+        match self.nav_level {
+            NavLevel::Questions => {
+                let questions = self.data.load_questions().unwrap_or_default();
+                // Index 0 = "All", rest = questions offset by 1
+                if self.left_index == 0 {
+                    self.selected_question = None;
+                } else if let Some(q) = questions.get(self.left_index - 1) {
+                    self.selected_question = Some(q.id.as_str().to_string());
                 }
-                KeyCode::Char('k') | KeyCode::Up => {
-                    *selected = selected.saturating_sub(1);
+                self.nav_level = NavLevel::Searches;
+                self.left_index = 0;
+                self.right_scroll = 0;
+                self.selected_paper = None;
+            }
+            NavLevel::Searches => {
+                let all_searches = self.current_searches();
+                // Index 0 = "All", rest offset by 1
+                if self.left_index == 0 {
+                    self.selected_search = None;
+                } else if let Some(s) = all_searches.get(self.left_index - 1) {
+                    self.selected_search = Some(s.id.as_str().to_string());
                 }
-                KeyCode::Enter => {
-                    let search_id_clone = search_id.clone();
-                    let sel = *selected;
-                    if let Ok(papers) = self.data.load_papers_for_search(&search_id_clone)
-                        && let Some(paper) = papers.get(sel)
-                    {
-                        self.overlay = Some(Overlay::PaperDetail {
-                            paper_id: paper.id.as_str().to_string(),
-                            scroll: 0,
-                        });
-                    }
+                self.nav_level = NavLevel::Papers;
+                self.left_index = 0;
+                self.right_scroll = 0;
+                self.selected_paper = None;
+            }
+            NavLevel::Papers => {
+                let papers = self.current_papers();
+                if let Some(p) = papers.get(self.left_index) {
+                    self.selected_paper = Some(p.id.as_str().to_string());
+                    self.right_scroll = 0;
                 }
-                _ => {}
-            },
-            None => {}
+            }
         }
     }
 
-    fn handle_tab_key(&mut self, code: KeyCode) {
-        match self.tab {
-            Tab::Searches => {
-                let count = self
-                    .data
-                    .load_searches(100)
-                    .map(|s| s.len())
-                    .unwrap_or(0);
-                match code {
-                    KeyCode::Char('j') | KeyCode::Down => {
-                        if count > 0 {
-                            self.search_selected =
-                                (self.search_selected + 1).min(count - 1);
-                        }
-                    }
-                    KeyCode::Char('k') | KeyCode::Up => {
-                        self.search_selected = self.search_selected.saturating_sub(1);
-                    }
-                    KeyCode::Enter => {
-                        if let Ok(searches) = self.data.load_searches(100)
-                            && let Some(search) = searches.get(self.search_selected)
-                        {
-                            self.overlay = Some(Overlay::SearchPapers {
-                                search_id: search.id.as_str().to_string(),
-                                selected: 0,
-                            });
-                        }
-                    }
-                    _ => {}
-                }
+    fn go_back(&mut self) {
+        if self.selected_paper.is_some() {
+            self.selected_paper = None;
+            self.right_scroll = 0;
+            return;
+        }
+        match self.nav_level {
+            NavLevel::Questions => {}
+            NavLevel::Searches => {
+                self.nav_level = NavLevel::Questions;
+                self.left_index = 0;
+                self.selected_question = None;
+                self.right_scroll = 0;
             }
-            Tab::Papers => {
-                let count = self
-                    .data
-                    .load_papers(1000, 0)
-                    .map(|p| p.len())
-                    .unwrap_or(0);
-                match code {
-                    KeyCode::Char('j') | KeyCode::Down => {
-                        if count > 0 {
-                            self.paper_selected =
-                                (self.paper_selected + 1).min(count - 1);
-                        }
-                    }
-                    KeyCode::Char('k') | KeyCode::Up => {
-                        self.paper_selected = self.paper_selected.saturating_sub(1);
-                    }
-                    KeyCode::Enter => {
-                        if let Ok(papers) = self.data.load_papers(1000, 0)
-                            && let Some(paper) = papers.get(self.paper_selected)
-                        {
-                            self.overlay = Some(Overlay::PaperDetail {
-                                paper_id: paper.id.as_str().to_string(),
-                                scroll: 0,
-                            });
-                        }
-                    }
-                    _ => {}
-                }
+            NavLevel::Papers => {
+                self.nav_level = NavLevel::Searches;
+                self.left_index = 0;
+                self.selected_search = None;
+                self.right_scroll = 0;
             }
-            Tab::Questions => {
-                let count = self
-                    .data
-                    .load_questions()
-                    .map(|q| q.len())
-                    .unwrap_or(0);
-                match code {
-                    KeyCode::Char('j') | KeyCode::Down => {
-                        if count > 0 {
-                            self.question_selected =
-                                (self.question_selected + 1).min(count - 1);
-                        }
-                    }
-                    KeyCode::Char('k') | KeyCode::Up => {
-                        self.question_selected = self.question_selected.saturating_sub(1);
-                    }
-                    _ => {}
-                }
+        }
+    }
+
+    fn left_item_count(&self) -> usize {
+        match self.nav_level {
+            NavLevel::Questions => {
+                // +1 for "All"
+                self.data.load_questions().map(|q| q.len()).unwrap_or(0) + 1
             }
+            NavLevel::Searches => self.current_searches().len() + 1, // +1 for "All"
+            NavLevel::Papers => self.current_papers().len(),
+        }
+    }
+
+    fn current_searches(&self) -> Vec<scitadel_core::models::Search> {
+        match &self.selected_question {
+            Some(qid) => self.data.load_searches_for_question(qid).unwrap_or_default(),
+            None => self.data.load_searches(100).unwrap_or_default(),
+        }
+    }
+
+    fn current_papers(&self) -> Vec<scitadel_core::models::Paper> {
+        match &self.selected_search {
+            Some(sid) => self.data.load_papers_for_search(sid).unwrap_or_default(),
+            None => self.data.load_papers(1000, 0).unwrap_or_default(),
         }
     }
 }
@@ -249,17 +181,14 @@ pub fn run(db_path: &Path) -> Result<()> {
     let data = DataStore::open(db_path)?;
     let mut app = App::new(data);
 
-    // Set up terminal
     enable_raw_mode()?;
     let mut stdout = io::stdout();
     execute!(stdout, EnterAlternateScreen)?;
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
-    // Event loop
     let result = run_loop(&mut terminal, &mut app);
 
-    // Restore terminal
     disable_raw_mode()?;
     execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
     terminal.show_cursor()?;
@@ -285,61 +214,135 @@ fn draw(frame: &mut ratatui::Frame, app: &mut App) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(3), // tabs
-            Constraint::Min(0),   // content
+            Constraint::Length(2), // header
+            Constraint::Min(0),   // content (left + right)
             Constraint::Length(1), // status bar
         ])
         .split(frame.area());
 
-    // Draw tab bar
-    let tab_titles: Vec<Line<'_>> = Tab::ALL
-        .iter()
-        .map(|t| {
-            let label = match t {
-                Tab::Searches => "Searches",
-                Tab::Papers => "Papers",
-                Tab::Questions => "Questions",
-            };
-            Line::from(Span::raw(label))
-        })
-        .collect();
+    // Header
+    draw_header(frame, chunks[0]);
 
-    let tabs = Tabs::new(tab_titles)
-        .select(app.tab.index())
-        .highlight_style(
-            Style::default()
-                .fg(Color::Yellow)
-                .add_modifier(Modifier::BOLD),
-        )
-        .divider(Span::raw(" | "));
+    // Split content: left nav + right detail
+    let content = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Length(28), // left pane
+            Constraint::Min(0),    // right pane
+        ])
+        .split(chunks[1]);
 
-    frame.render_widget(tabs, chunks[0]);
+    draw_left_pane(frame, content[0], app);
+    draw_right_pane(frame, content[1], app);
 
-    // Draw content (overlay takes precedence)
-    match &app.overlay {
-        Some(Overlay::PaperDetail { paper_id, scroll }) => {
-            detail::draw(frame, chunks[1], &app.data, paper_id, *scroll);
-        }
-        Some(Overlay::SearchPapers {
-            search_id,
-            selected,
-        }) => {
-            papers::draw_for_search(frame, chunks[1], &app.data, search_id, *selected);
-        }
-        None => match app.tab {
-            Tab::Searches => searches::draw(frame, chunks[1], &app.data, app.search_selected),
-            Tab::Papers => papers::draw(frame, chunks[1], &app.data, app.paper_selected),
-            Tab::Questions => {
-                questions::draw(frame, chunks[1], &app.data, app.question_selected);
+    // Status bar
+    let help = match app.nav_level {
+        NavLevel::Questions => "j/k: nav | Enter: drill down | q: quit",
+        NavLevel::Searches => "j/k: nav | Enter: drill down | Esc: back | q: quit",
+        NavLevel::Papers => {
+            if app.selected_paper.is_some() {
+                "j/k: nav | d/u: scroll | Esc: back | q: quit"
+            } else {
+                "j/k: nav | Enter: select | Esc: back | q: quit"
             }
-        },
+        }
+    };
+    status_bar::draw(frame, chunks[2], help);
+}
+
+fn draw_header(frame: &mut ratatui::Frame, area: ratatui::layout::Rect) {
+    let title_style = Style::default()
+        .fg(Color::Cyan)
+        .add_modifier(Modifier::BOLD);
+    let quit_style = Style::default().fg(Color::DarkGray);
+
+    let line = Line::from(vec![
+        Span::styled(" SCITADEL", title_style),
+        Span::raw("  "),
+        Span::styled("[q]uit", quit_style),
+    ]);
+
+    let header = Paragraph::new(line).block(
+        Block::default()
+            .borders(Borders::BOTTOM)
+            .border_style(Style::default().fg(Color::DarkGray)),
+    );
+    frame.render_widget(header, area);
+}
+
+fn draw_left_pane(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, app: &mut App) {
+    match app.nav_level {
+        NavLevel::Questions => {
+            let questions = app.data.load_questions().unwrap_or_default();
+            nav_tree::draw_questions(frame, area, &questions, app.left_index);
+        }
+        NavLevel::Searches => {
+            let search_list = app.current_searches();
+            let breadcrumb = match &app.selected_question {
+                Some(qid) => format!("Q:{}", &qid[..qid.len().min(8)]),
+                None => "All Questions".to_string(),
+            };
+            nav_tree::draw_searches(frame, area, &search_list, app.left_index, &breadcrumb);
+        }
+        NavLevel::Papers => {
+            let paper_list = app.current_papers();
+            let breadcrumb = match &app.selected_search {
+                Some(sid) => format!("S:{}", &sid[..sid.len().min(8)]),
+                None => "All Searches".to_string(),
+            };
+            let scores = paper_list
+                .iter()
+                .map(|p| {
+                    app.selected_question.as_ref().and_then(|qid| {
+                        app.data
+                            .load_assessments_for_paper(p.id.as_str(), Some(qid))
+                            .ok()
+                            .and_then(|a| a.first().map(|a| a.score))
+                    })
+                })
+                .collect::<Vec<_>>();
+            nav_tree::draw_papers(frame, area, &paper_list, &scores, app.left_index, &breadcrumb);
+        }
+    }
+}
+
+fn draw_right_pane(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, app: &mut App) {
+    // If a paper is selected, show full detail
+    if let Some(ref paper_id) = app.selected_paper {
+        let question_id = app.selected_question.as_deref();
+        detail::draw(frame, area, &app.data, paper_id, app.right_scroll, question_id);
+        return;
     }
 
-    // Draw status bar
-    let help_text = if app.overlay.is_some() {
-        "Esc: back | j/k: navigate | Enter: select | d/u: page down/up"
-    } else {
-        "Tab/Shift-Tab: switch tabs | j/k: navigate | Enter: select | q: quit"
-    };
-    status_bar::draw(frame, chunks[2], help_text);
+    match app.nav_level {
+        NavLevel::Questions => {
+            let qs = app.data.load_questions().unwrap_or_default();
+            // Index 0 = "All", offset by 1 for actual questions
+            if app.left_index == 0 {
+                questions::draw_summary(frame, area, &app.data, &qs);
+            } else if let Some(q) = qs.get(app.left_index - 1) {
+                questions::draw_detail(frame, area, &app.data, q);
+            }
+        }
+        NavLevel::Searches => {
+            let ss = app.current_searches();
+            if app.left_index == 0 {
+                searches::draw_summary(frame, area, &ss);
+            } else if let Some(s) = ss.get(app.left_index - 1) {
+                searches::draw_detail(frame, area, s);
+            }
+        }
+        NavLevel::Papers => {
+            let ps = app.current_papers();
+            if let Some(p) = ps.get(app.left_index) {
+                papers::draw_preview(frame, area, &app.data, p, app.selected_question.as_deref());
+            } else {
+                let block = Block::default()
+                    .title(" Papers ")
+                    .borders(Borders::ALL);
+                let empty = Paragraph::new("No papers found.").block(block);
+                frame.render_widget(empty, area);
+            }
+        }
+    }
 }

--- a/crates/scitadel-tui/src/data.rs
+++ b/crates/scitadel-tui/src/data.rs
@@ -57,6 +57,19 @@ impl DataStore {
         Ok(q_repo.get_terms(question_id)?)
     }
 
+    pub fn load_searches_for_question(&self, question_id: &str) -> Result<Vec<Search>> {
+        let searches = self.load_searches(100)?;
+        Ok(searches
+            .into_iter()
+            .filter(|s| {
+                s.parameters
+                    .get("question_id")
+                    .and_then(|v| v.as_str())
+                    .is_some_and(|qid| qid == question_id)
+            })
+            .collect())
+    }
+
     pub fn load_assessments_for_paper(
         &self,
         paper_id: &str,

--- a/crates/scitadel-tui/src/views/detail.rs
+++ b/crates/scitadel-tui/src/views/detail.rs
@@ -6,7 +6,14 @@ use ratatui::Frame;
 
 use crate::data::DataStore;
 
-pub fn draw(frame: &mut Frame, area: Rect, data: &DataStore, paper_id: &str, scroll: u16) {
+pub fn draw(
+    frame: &mut Frame,
+    area: Rect,
+    data: &DataStore,
+    paper_id: &str,
+    scroll: u16,
+    question_id: Option<&str>,
+) {
     let Ok(Some(paper)) = data.load_paper(paper_id) else {
         let block = Block::default()
             .title(" Paper Detail ")
@@ -17,7 +24,7 @@ pub fn draw(frame: &mut Frame, area: Rect, data: &DataStore, paper_id: &str, scr
     };
 
     let assessments = data
-        .load_assessments_for_paper(paper_id, None)
+        .load_assessments_for_paper(paper_id, question_id)
         .unwrap_or_default();
 
     let label_style = Style::default()
@@ -93,7 +100,7 @@ pub fn draw(frame: &mut Frame, area: Rect, data: &DataStore, paper_id: &str, scr
                 "  Score: {:.2}  Assessor: {}  Date: {}",
                 a.score,
                 if a.assessor.is_empty() {
-                    "—"
+                    "\u{2014}"
                 } else {
                     &a.assessor
                 },

--- a/crates/scitadel-tui/src/views/mod.rs
+++ b/crates/scitadel-tui/src/views/mod.rs
@@ -1,4 +1,5 @@
 pub mod detail;
+pub mod nav_tree;
 pub mod papers;
 pub mod questions;
 pub mod searches;

--- a/crates/scitadel-tui/src/views/nav_tree.rs
+++ b/crates/scitadel-tui/src/views/nav_tree.rs
@@ -1,0 +1,123 @@
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::Line;
+use ratatui::widgets::{Block, Borders, List, ListItem, ListState};
+use ratatui::Frame;
+
+use scitadel_core::models::{Paper, ResearchQuestion, Search};
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        format!("{}...", &s[..max.saturating_sub(3)])
+    }
+}
+
+pub fn draw_questions(
+    frame: &mut Frame,
+    area: Rect,
+    questions: &[ResearchQuestion],
+    selected: usize,
+) {
+    let mut items = vec![ListItem::new(Line::from("  All"))];
+
+    for q in questions {
+        let label = format!("  {} {}", q.id.short(), truncate(&q.text, 14));
+        items.push(ListItem::new(Line::from(label)));
+    }
+
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .title(" Questions ")
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::DarkGray)),
+        )
+        .highlight_style(
+            Style::default()
+                .bg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("> ");
+
+    let mut state = ListState::default();
+    state.select(Some(selected));
+    frame.render_stateful_widget(list, area, &mut state);
+}
+
+pub fn draw_searches(
+    frame: &mut Frame,
+    area: Rect,
+    searches: &[Search],
+    selected: usize,
+    breadcrumb: &str,
+) {
+    let title = format!(" Searches ({breadcrumb}) ");
+    let mut items = vec![ListItem::new(Line::from("  All"))];
+
+    for s in searches {
+        let label = format!("  {} {}", s.id.short(), truncate(&s.query, 14));
+        items.push(ListItem::new(Line::from(label)));
+    }
+
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .title(title)
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::DarkGray)),
+        )
+        .highlight_style(
+            Style::default()
+                .bg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("> ");
+
+    let mut state = ListState::default();
+    state.select(Some(selected));
+    frame.render_stateful_widget(list, area, &mut state);
+}
+
+pub fn draw_papers(
+    frame: &mut Frame,
+    area: Rect,
+    papers: &[Paper],
+    scores: &[Option<f64>],
+    selected: usize,
+    breadcrumb: &str,
+) {
+    let title = format!(" Papers ({breadcrumb}) ");
+
+    let items: Vec<ListItem<'_>> = papers
+        .iter()
+        .enumerate()
+        .map(|(i, p)| {
+            let score_str = scores
+                .get(i)
+                .and_then(|s| *s)
+                .map_or_else(|| "--".to_string(), |s| format!("{s:.2}"));
+            let label = format!("  {} {}", score_str, truncate(&p.title, 16));
+            ListItem::new(Line::from(label))
+        })
+        .collect();
+
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .title(title)
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::DarkGray)),
+        )
+        .highlight_style(
+            Style::default()
+                .bg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("> ");
+
+    let mut state = ListState::default();
+    state.select(Some(selected));
+    frame.render_stateful_widget(list, area, &mut state);
+}

--- a/crates/scitadel-tui/src/views/papers.rs
+++ b/crates/scitadel-tui/src/views/papers.rs
@@ -1,92 +1,85 @@
-use ratatui::layout::{Constraint, Rect};
+use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
-use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table, TableState};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
 use ratatui::Frame;
 
 use scitadel_core::models::Paper;
 
 use crate::data::DataStore;
 
-pub fn draw(frame: &mut Frame, area: Rect, data: &DataStore, selected: usize) {
-    let papers = data.load_papers(1000, 0).unwrap_or_default();
-    render_paper_table(frame, area, &papers, selected, " Papers ");
-}
-
-pub fn draw_for_search(
+/// Right-pane preview for a highlighted paper (not full detail, just key info).
+pub fn draw_preview(
     frame: &mut Frame,
     area: Rect,
     data: &DataStore,
-    search_id: &str,
-    selected: usize,
+    paper: &Paper,
+    question_id: Option<&str>,
 ) {
-    let papers = data.load_papers_for_search(search_id).unwrap_or_default();
-    let title = format!(" Papers for search {} ", &search_id[..search_id.len().min(8)]);
-    render_paper_table(frame, area, &papers, selected, &title);
-}
+    let label_style = Style::default()
+        .fg(Color::Yellow)
+        .add_modifier(Modifier::BOLD);
 
-fn render_paper_table(
-    frame: &mut Frame,
-    area: Rect,
-    papers: &[Paper],
-    selected: usize,
-    title: &str,
-) {
-    if papers.is_empty() {
-        let block = Block::default().title(title.to_string()).borders(Borders::ALL);
-        let empty = Paragraph::new("No papers found.").block(block);
-        frame.render_widget(empty, area);
-        return;
+    let mut lines = vec![Line::from(vec![
+        Span::styled("Title: ", label_style),
+        Span::raw(&paper.title),
+    ])];
+    lines.push(Line::from(""));
+
+    lines.push(Line::from(vec![
+        Span::styled("Authors: ", label_style),
+        Span::raw(format_authors(&paper.authors)),
+    ]));
+
+    if let Some(year) = paper.year {
+        lines.push(Line::from(vec![
+            Span::styled("Year: ", label_style),
+            Span::raw(year.to_string()),
+        ]));
     }
 
-    let header = Row::new(vec![
-        Cell::from("#"),
-        Cell::from("Title"),
-        Cell::from("Authors"),
-        Cell::from("Year"),
-    ])
-    .style(
-        Style::default()
-            .fg(Color::Yellow)
-            .add_modifier(Modifier::BOLD),
-    );
+    if let Some(ref journal) = paper.journal {
+        lines.push(Line::from(vec![
+            Span::styled("Journal: ", label_style),
+            Span::raw(journal.as_str()),
+        ]));
+    }
 
-    let rows: Vec<Row<'_>> = papers
-        .iter()
-        .enumerate()
-        .map(|(i, p)| {
-            let authors = format_authors(&p.authors);
-            let year = p
-                .year
-                .map_or_else(|| "—".to_string(), |y| y.to_string());
+    // Score for selected question
+    if let Some(qid) = question_id
+        && let Ok(assessments) = data.load_assessments_for_paper(paper.id.as_str(), Some(qid))
+        && let Some(a) = assessments.first()
+    {
+        lines.push(Line::from(vec![
+            Span::styled("Score: ", label_style),
+            Span::raw(format!("{:.2}", a.score)),
+        ]));
+    }
 
-            Row::new(vec![
-                Cell::from((i + 1).to_string()),
-                Cell::from(truncate(&p.title, 60)),
-                Cell::from(truncate(&authors, 30)),
-                Cell::from(year),
-            ])
-        })
-        .collect();
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled("Abstract:", label_style)));
+    if paper.r#abstract.is_empty() {
+        lines.push(Line::from("  (no abstract available)"));
+    } else {
+        // Show truncated abstract for preview
+        let abstract_preview: String = paper
+            .r#abstract
+            .chars()
+            .take(500)
+            .collect();
+        for line in abstract_preview.lines() {
+            lines.push(Line::from(format!("  {line}")));
+        }
+        if paper.r#abstract.len() > 500 {
+            lines.push(Line::from("  ..."));
+        }
+    }
 
-    let widths = [
-        Constraint::Length(5),
-        Constraint::Min(30),
-        Constraint::Length(32),
-        Constraint::Length(6),
-    ];
-
-    let table = Table::new(rows, widths)
-        .header(header)
-        .block(Block::default().title(title.to_string()).borders(Borders::ALL))
-        .row_highlight_style(
-            Style::default()
-                .bg(Color::DarkGray)
-                .add_modifier(Modifier::BOLD),
-        );
-
-    let mut state = TableState::default();
-    state.select(Some(selected));
-    frame.render_stateful_widget(table, area, &mut state);
+    let block = Block::default()
+        .title(" Paper Preview ")
+        .borders(Borders::ALL);
+    let paragraph = Paragraph::new(lines).block(block).wrap(Wrap { trim: false });
+    frame.render_widget(paragraph, area);
 }
 
 fn format_authors(authors: &[String]) -> String {
@@ -95,13 +88,5 @@ fn format_authors(authors: &[String]) -> String {
         1 => authors[0].clone(),
         2 => format!("{}, {}", authors[0], authors[1]),
         _ => format!("{}, {} et al.", authors[0], authors[1]),
-    }
-}
-
-fn truncate(s: &str, max: usize) -> String {
-    if s.len() <= max {
-        s.to_string()
-    } else {
-        format!("{}...", &s[..max.saturating_sub(3)])
     }
 }

--- a/crates/scitadel-tui/src/views/questions.rs
+++ b/crates/scitadel-tui/src/views/questions.rs
@@ -1,76 +1,114 @@
-use ratatui::layout::{Constraint, Rect};
+use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
-use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table, TableState};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
 use ratatui::Frame;
+
+use scitadel_core::models::ResearchQuestion;
 
 use crate::data::DataStore;
 
-pub fn draw(frame: &mut Frame, area: Rect, data: &DataStore, selected: usize) {
-    let questions = data.load_questions().unwrap_or_default();
+/// Right-pane summary when "All" is selected at Questions level.
+pub fn draw_summary(
+    frame: &mut Frame,
+    area: Rect,
+    data: &DataStore,
+    questions: &[ResearchQuestion],
+) {
+    let label_style = Style::default()
+        .fg(Color::Yellow)
+        .add_modifier(Modifier::BOLD);
 
-    if questions.is_empty() {
-        let block = Block::default()
-            .title(" Research Questions ")
-            .borders(Borders::ALL);
-        let empty =
-            Paragraph::new("No research questions yet. Run `scitadel question create` to add one.")
-                .block(block);
-        frame.render_widget(empty, area);
-        return;
+    let mut lines = vec![Line::from(Span::styled(
+        "All Research Questions",
+        label_style,
+    ))];
+    lines.push(Line::from(""));
+    lines.push(Line::from(format!(
+        "Total questions: {}",
+        questions.len()
+    )));
+    lines.push(Line::from(""));
+
+    for q in questions {
+        let term_count = data
+            .load_terms(q.id.as_str())
+            .map(|t| t.len())
+            .unwrap_or(0);
+        lines.push(Line::from(format!(
+            "  {} — {} ({} terms)",
+            q.id.short(),
+            truncate(&q.text, 50),
+            term_count,
+        )));
     }
 
-    let header = Row::new(vec![
-        Cell::from("ID"),
-        Cell::from("Date"),
-        Cell::from("Text"),
-        Cell::from("# Terms"),
-    ])
-    .style(
-        Style::default()
-            .fg(Color::Yellow)
-            .add_modifier(Modifier::BOLD),
-    );
+    let block = Block::default()
+        .title(" Questions Overview ")
+        .borders(Borders::ALL);
+    let paragraph = Paragraph::new(lines).block(block).wrap(Wrap { trim: false });
+    frame.render_widget(paragraph, area);
+}
 
-    let rows: Vec<Row<'_>> = questions
-        .iter()
-        .map(|q| {
-            let term_count = data
-                .load_terms(q.id.as_str())
-                .map(|t| t.len())
-                .unwrap_or(0);
+/// Right-pane detail for a single question.
+pub fn draw_detail(frame: &mut Frame, area: Rect, data: &DataStore, q: &ResearchQuestion) {
+    let label_style = Style::default()
+        .fg(Color::Yellow)
+        .add_modifier(Modifier::BOLD);
 
-            Row::new(vec![
-                Cell::from(q.id.short().to_string()),
-                Cell::from(q.created_at.format("%Y-%m-%d %H:%M").to_string()),
-                Cell::from(truncate(&q.text, 60)),
-                Cell::from(term_count.to_string()),
-            ])
-        })
-        .collect();
-
-    let widths = [
-        Constraint::Length(10),
-        Constraint::Length(18),
-        Constraint::Min(20),
-        Constraint::Length(9),
+    let mut lines = vec![
+        Line::from(vec![
+            Span::styled("Question: ", label_style),
+            Span::raw(&q.text),
+        ]),
+        Line::from(""),
     ];
 
-    let table = Table::new(rows, widths)
-        .header(header)
-        .block(
-            Block::default()
-                .title(" Research Questions ")
-                .borders(Borders::ALL),
-        )
-        .row_highlight_style(
-            Style::default()
-                .bg(Color::DarkGray)
-                .add_modifier(Modifier::BOLD),
-        );
+    if !q.description.is_empty() {
+        lines.push(Line::from(vec![
+            Span::styled("Description: ", label_style),
+            Span::raw(&q.description),
+        ]));
+        lines.push(Line::from(""));
+    }
 
-    let mut state = TableState::default();
-    state.select(Some(selected));
-    frame.render_stateful_widget(table, area, &mut state);
+    lines.push(Line::from(vec![
+        Span::styled("ID: ", label_style),
+        Span::raw(q.id.as_str()),
+    ]));
+    lines.push(Line::from(vec![
+        Span::styled("Created: ", label_style),
+        Span::raw(q.created_at.format("%Y-%m-%d %H:%M").to_string()),
+    ]));
+
+    // Search terms
+    let terms = data.load_terms(q.id.as_str()).unwrap_or_default();
+    if !terms.is_empty() {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled("Search Terms:", label_style)));
+        for t in &terms {
+            if !t.query_string.is_empty() {
+                lines.push(Line::from(format!("  Query: {}", t.query_string)));
+            }
+            if !t.terms.is_empty() {
+                lines.push(Line::from(format!("  Terms: {}", t.terms.join(", "))));
+            }
+        }
+    }
+
+    // Search count
+    let search_count = data
+        .load_searches_for_question(q.id.as_str())
+        .map(|s| s.len())
+        .unwrap_or(0);
+    lines.push(Line::from(""));
+    lines.push(Line::from(format!("Searches linked: {search_count}")));
+
+    let block = Block::default()
+        .title(" Question Detail ")
+        .borders(Borders::ALL);
+    let paragraph = Paragraph::new(lines).block(block).wrap(Wrap { trim: false });
+    frame.render_widget(paragraph, area);
 }
 
 fn truncate(s: &str, max: usize) -> String {

--- a/crates/scitadel-tui/src/views/searches.rs
+++ b/crates/scitadel-tui/src/views/searches.rs
@@ -1,78 +1,102 @@
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
-use ratatui::widgets::{Block, Borders, Cell, Row, Table, TableState};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
 use ratatui::Frame;
 
-use scitadel_core::models::SourceStatus;
+use scitadel_core::models::{Search, SourceStatus};
 
-use crate::data::DataStore;
+/// Right-pane summary when "All" is selected at Searches level.
+pub fn draw_summary(frame: &mut Frame, area: Rect, searches: &[Search]) {
+    let label_style = Style::default()
+        .fg(Color::Yellow)
+        .add_modifier(Modifier::BOLD);
 
-pub fn draw(frame: &mut Frame, area: Rect, data: &DataStore, selected: usize) {
-    let searches = data.load_searches(100).unwrap_or_default();
+    let mut lines = vec![Line::from(Span::styled("All Searches", label_style))];
+    lines.push(Line::from(""));
+    lines.push(Line::from(format!("Total searches: {}", searches.len())));
+    lines.push(Line::from(""));
 
-    if searches.is_empty() {
-        let block = Block::default()
-            .title(" Searches ")
-            .borders(Borders::ALL);
-        let empty = ratatui::widgets::Paragraph::new("No searches yet. Run `scitadel search` to get started.")
-            .block(block);
-        frame.render_widget(empty, area);
-        return;
+    for s in searches {
+        let sources_ok = s
+            .source_outcomes
+            .iter()
+            .filter(|o| o.status == SourceStatus::Success)
+            .count();
+        lines.push(Line::from(format!(
+            "  {} — {} ({} papers, {}/{} sources)",
+            s.id.short(),
+            truncate(&s.query, 40),
+            s.total_papers,
+            sources_ok,
+            s.source_outcomes.len(),
+        )));
     }
 
-    let header = Row::new(vec![
-        Cell::from("ID"),
-        Cell::from("Date"),
-        Cell::from("Query"),
-        Cell::from("Papers"),
-        Cell::from("Sources"),
-    ])
-    .style(
-        Style::default()
-            .fg(Color::Yellow)
-            .add_modifier(Modifier::BOLD),
-    );
+    let block = Block::default()
+        .title(" Searches Overview ")
+        .borders(Borders::ALL);
+    let paragraph = Paragraph::new(lines).block(block).wrap(Wrap { trim: false });
+    frame.render_widget(paragraph, area);
+}
 
-    let rows: Vec<Row<'_>> = searches
+/// Right-pane detail for a single search.
+pub fn draw_detail(frame: &mut Frame, area: Rect, s: &Search) {
+    let label_style = Style::default()
+        .fg(Color::Yellow)
+        .add_modifier(Modifier::BOLD);
+
+    let sources_ok = s
+        .source_outcomes
         .iter()
-        .map(|s| {
-            let success = s
-                .source_outcomes
-                .iter()
-                .filter(|o| o.status == SourceStatus::Success)
-                .count();
-            let total = s.source_outcomes.len();
+        .filter(|o| o.status == SourceStatus::Success)
+        .count();
 
-            Row::new(vec![
-                Cell::from(s.id.short().to_string()),
-                Cell::from(s.created_at.format("%Y-%m-%d %H:%M").to_string()),
-                Cell::from(truncate(&s.query, 50)),
-                Cell::from(s.total_papers.to_string()),
-                Cell::from(format!("{success}/{total}")),
-            ])
-        })
-        .collect();
-
-    let widths = [
-        ratatui::layout::Constraint::Length(10),
-        ratatui::layout::Constraint::Length(18),
-        ratatui::layout::Constraint::Min(20),
-        ratatui::layout::Constraint::Length(8),
-        ratatui::layout::Constraint::Length(10),
+    let lines = vec![
+        Line::from(vec![
+            Span::styled("Query: ", label_style),
+            Span::raw(&s.query),
+        ]),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("ID: ", label_style),
+            Span::raw(s.id.as_str()),
+        ]),
+        Line::from(vec![
+            Span::styled("Date: ", label_style),
+            Span::raw(s.created_at.format("%Y-%m-%d %H:%M").to_string()),
+        ]),
+        Line::from(vec![
+            Span::styled("Sources: ", label_style),
+            Span::raw(if s.sources.is_empty() {
+                "—".to_string()
+            } else {
+                s.sources.join(", ")
+            }),
+        ]),
+        Line::from(vec![
+            Span::styled("Source Results: ", label_style),
+            Span::raw(format!(
+                "{}/{} succeeded",
+                sources_ok,
+                s.source_outcomes.len()
+            )),
+        ]),
+        Line::from(vec![
+            Span::styled("Papers Found: ", label_style),
+            Span::raw(s.total_papers.to_string()),
+        ]),
+        Line::from(vec![
+            Span::styled("Candidates: ", label_style),
+            Span::raw(s.total_candidates.to_string()),
+        ]),
     ];
 
-    let table = Table::new(rows, widths)
-        .header(header)
-        .block(Block::default().title(" Searches ").borders(Borders::ALL))
-        .row_highlight_style(
-            Style::default()
-                .bg(Color::DarkGray)
-                .add_modifier(Modifier::BOLD),
-        );
-
-    let mut state = TableState::default();
-    state.select(Some(selected));
-    frame.render_stateful_widget(table, area, &mut state);
+    let block = Block::default()
+        .title(" Search Detail ")
+        .borders(Borders::ALL);
+    let paragraph = Paragraph::new(lines).block(block).wrap(Wrap { trim: false });
+    frame.render_widget(paragraph, area);
 }
 
 fn truncate(s: &str, max: usize) -> String {


### PR DESCRIPTION
## Summary
- Replace flat tab-based TUI with split-pane layout: left nav tree + right detail viewer
- Hierarchical drill-down navigation: Questions → Searches → Papers (Enter to descend, Esc to ascend)
- Right pane shows context-sensitive preview/detail for the currently highlighted item, with score display when a question is selected
- New `nav_tree` view module for left-pane rendering; simplified `questions`, `searches`, `papers` views as right-pane renderers
- Added `load_searches_for_question` to DataStore for question→search filtering via `parameters.question_id`

## Test plan
- [ ] Run `cargo clippy -p scitadel-tui -- -D warnings` — passes clean
- [ ] Run `cargo build --workspace` — compiles without errors
- [ ] Launch TUI with a populated database and verify Questions list appears in left pane
- [ ] Navigate with j/k, Enter to drill into Searches, then Papers
- [ ] Verify Esc returns up one level at each stage
- [ ] Verify right pane shows detail for highlighted item at each level
- [ ] Verify score column appears in paper list when a question is selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)