### PR TITLE
docs: CHANGELOG entry for 0.1.0

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -3,16 +3,8 @@ name: Rust CI
 on:
   push:
     branches: [main, dev, "rust-rewrite*"]
-    paths:
-      - 'crates/**'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
   pull_request:
     branches: [main, dev]
-    paths:
-      - 'crates/**'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
 
 env:
   CARGO_TERM_COLOR: always

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Security
+
+## [0.1.0] - 2026-04-18
+
+Initial release. Rust workspace implementing the scitadel MVP: federated
+scientific literature search with structured storage and retrieval/assessment
+tooling across CLI, MCP server, and TUI surfaces.
+
+### Added
+
+- **Core domain** (`scitadel-core`): paper / search / question / assessment
+  models, keychain + env-var credential resolution, strict DOI validation and
+  canonicalization.
+- **SQLite persistence** (`scitadel-db`): schema + migrations, deduplication on
+  DOI / OpenAlex / arxiv identifiers, upsert with conflict resolution (#40).
+- **Source adapters** (`scitadel-adapters`): PubMed, arXiv, OpenAlex,
+  INSPIRE-HEP, EPO OPS, PatentsView, Lens. Paper download chain (arxiv →
+  OpenAlex → Unpaywall → publisher HTML) with paywall detection.
+- **Scoring** (`scitadel-scoring`): Claude API scorer for automated relevance
+  assessment.
+- **Export** (`scitadel-export`): BibTeX, JSON, CSV.
+- **CLI** (`scitadel-cli`): `search`, `history`, `export`, `download`, `score`,
+  `auth`, `tui`, `mcp` subcommands.
+- **MCP server** (`scitadel-mcp`): 14 tools for agent-driven literature
+  workflows, including `search`, `get_papers`, `assess_paper`,
+  `prepare_assessment`, `download_paper`, `read_paper`.
+- **TUI** (`scitadel-tui`): ratatui-based browser with Searches / Papers /
+  Questions tabs, async download task panel, paper reader, vim-ish keybindings.
+- **Nix flake + direnv** reproducible devshell.
+- **vig-os/devcontainer 0.3.3** workflow/release standards.
+- **Dual-license**: MIT OR Apache-2.0.
+
+### Known limitations
+
+- No citation graph / snowball (planned for 0.4.0, see #59).
+- No in-TUI annotations (planned for 0.2.0, see #49).
+- No prebuilt binaries; install via `cargo install --path crates/scitadel-cli`
+  (cargo-dist tracked in #64).
+- Not yet published to crates.io (tracked in #65).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,10 @@ redundant_closure_for_method_calls = "allow"
 needless_lifetimes = "allow"
 unnecessary_literal_bound = "allow"
 uninlined_format_args = "allow"
+manual_let_else = "allow"
+needless_pass_by_value = "allow"
+unreadable_literal = "allow"
+unnecessary_wraps = "allow"
 
 [profile.release]
 lto = true

--- a/crates/scitadel-adapters/src/arxiv.rs
+++ b/crates/scitadel-adapters/src/arxiv.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
-use quick_xml::events::Event;
 use quick_xml::Reader;
+use quick_xml::events::Event;
 use reqwest::Client;
 
 use scitadel_core::error::CoreError;
@@ -33,8 +33,7 @@ impl SourceAdapter for ArxivAdapter {
         let client = Client::builder()
             .timeout(std::time::Duration::from_secs_f64(self.timeout))
             .build()
-            .map_err(|e| CoreError::Adapter("arxiv".into(), e.to_string(),
-            ))?;
+            .map_err(|e| CoreError::Adapter("arxiv".into(), e.to_string()))?;
 
         let params = [
             ("search_query", format!("all:{query}")),
@@ -49,11 +48,12 @@ impl SourceAdapter for ArxivAdapter {
             .query(&params)
             .send()
             .await
-            .map_err(|e| CoreError::Adapter("arxiv".into(), e.to_string(),
-            ))?;
+            .map_err(|e| CoreError::Adapter("arxiv".into(), e.to_string()))?;
 
-        let xml_text = resp.text().await.map_err(|e| CoreError::Adapter("arxiv".into(), e.to_string(),
-        ))?;
+        let xml_text = resp
+            .text()
+            .await
+            .map_err(|e| CoreError::Adapter("arxiv".into(), e.to_string()))?;
 
         Ok(parse_arxiv_atom(&xml_text))
     }
@@ -149,8 +149,7 @@ pub fn parse_arxiv_atom(xml_text: &str) -> Vec<CandidatePaper> {
                     current_summary.push_str(&text);
                 } else if in_author_name {
                     current_authors.push(text);
-                } else if in_published && current_year.is_none()
-                    && text.len() >= 4 {
+                } else if in_published && current_year.is_none() && text.len() >= 4 {
                     current_year = text[..4].parse().ok();
                 }
             }
@@ -168,10 +167,14 @@ pub fn parse_arxiv_atom(xml_text: &str) -> Vec<CandidatePaper> {
                             rank += 1;
                             let arxiv_id = extract_arxiv_id(&current_id);
                             // Collapse whitespace
-                            let title: String =
-                                current_title.split_whitespace().collect::<Vec<_>>().join(" ");
-                            let abstract_text: String =
-                                current_summary.split_whitespace().collect::<Vec<_>>().join(" ");
+                            let title: String = current_title
+                                .split_whitespace()
+                                .collect::<Vec<_>>()
+                                .join(" ");
+                            let abstract_text: String = current_summary
+                                .split_whitespace()
+                                .collect::<Vec<_>>()
+                                .join(" ");
 
                             candidates.push(CandidatePaper {
                                 source: "arxiv".into(),

--- a/crates/scitadel-adapters/src/download.rs
+++ b/crates/scitadel-adapters/src/download.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use scitadel_core::models::{doi_to_filename, validate_doi, Paper};
+use scitadel_core::models::{Paper, doi_to_filename, validate_doi};
 
 use crate::error::AdapterError;
 
@@ -150,7 +150,10 @@ impl PaperDownloader {
         let normalized = scitadel_core::models::normalize_doi(doi);
 
         tokio::fs::create_dir_all(output_dir).await.map_err(|e| {
-            AdapterError::Io(format!("failed to create output dir {}: {e}", output_dir.display()))
+            AdapterError::Io(format!(
+                "failed to create output dir {}: {e}",
+                output_dir.display()
+            ))
         })?;
 
         match self.try_unpaywall(&normalized, output_dir).await {
@@ -176,7 +179,10 @@ impl PaperDownloader {
         output_dir: &Path,
     ) -> Result<DownloadResult, AdapterError> {
         tokio::fs::create_dir_all(output_dir).await.map_err(|e| {
-            AdapterError::Io(format!("failed to create output dir {}: {e}", output_dir.display()))
+            AdapterError::Io(format!(
+                "failed to create output dir {}: {e}",
+                output_dir.display()
+            ))
         })?;
 
         let stem = file_stem_for(paper);
@@ -199,11 +205,15 @@ impl PaperDownloader {
             let normalized = scitadel_core::models::normalize_doi(doi);
             match self.try_unpaywall(&normalized, output_dir).await {
                 Ok(r) => return Ok(r),
-                Err(e) => tracing::info!(doi = %normalized, error = %e, "unpaywall fallback failed"),
+                Err(e) => {
+                    tracing::info!(doi = %normalized, error = %e, "unpaywall fallback failed")
+                }
             }
             match self.download_publisher_html(&normalized, output_dir).await {
                 Ok(r) => return Ok(r),
-                Err(e) => tracing::info!(doi = %normalized, error = %e, "publisher html fallback failed"),
+                Err(e) => {
+                    tracing::info!(doi = %normalized, error = %e, "publisher html fallback failed")
+                }
             }
         }
 
@@ -222,10 +232,7 @@ impl PaperDownloader {
         doi: &str,
         output_dir: &Path,
     ) -> Result<DownloadResult, AdapterError> {
-        let url = format!(
-            "https://api.unpaywall.org/v2/{}?email={}",
-            doi, self.email
-        );
+        let url = format!("https://api.unpaywall.org/v2/{}?email={}", doi, self.email);
 
         let resp = self
             .client
@@ -279,9 +286,9 @@ impl PaperDownloader {
 
         let filename = format!("{}.pdf", doi_to_filename(doi));
         let path = output_dir.join(&filename);
-        tokio::fs::write(&path, &bytes).await.map_err(|e| {
-            AdapterError::Io(format!("failed to write {}: {e}", path.display()))
-        })?;
+        tokio::fs::write(&path, &bytes)
+            .await
+            .map_err(|e| AdapterError::Io(format!("failed to write {}: {e}", path.display())))?;
 
         Ok(DownloadResult {
             doi: doi.to_string(),
@@ -326,9 +333,9 @@ impl PaperDownloader {
 
         let filename = format!("{}.html", doi_to_filename(doi));
         let path = output_dir.join(&filename);
-        tokio::fs::write(&path, &bytes).await.map_err(|e| {
-            AdapterError::Io(format!("failed to write {}: {e}", path.display()))
-        })?;
+        tokio::fs::write(&path, &bytes)
+            .await
+            .map_err(|e| AdapterError::Io(format!("failed to write {}: {e}", path.display())))?;
 
         Ok(DownloadResult {
             doi: doi.to_string(),
@@ -368,9 +375,9 @@ impl PaperDownloader {
             .map_err(|e| AdapterError::Network(format!("failed to read arXiv PDF: {e}")))?;
 
         let path = output_dir.join(format!("{stem}.pdf"));
-        tokio::fs::write(&path, &bytes).await.map_err(|e| {
-            AdapterError::Io(format!("failed to write {}: {e}", path.display()))
-        })?;
+        tokio::fs::write(&path, &bytes)
+            .await
+            .map_err(|e| AdapterError::Io(format!("failed to write {}: {e}", path.display())))?;
 
         Ok(DownloadResult {
             doi: arxiv_id.to_string(),
@@ -420,9 +427,7 @@ impl PaperDownloader {
                     .and_then(|oa| oa.get("oa_url"))
                     .and_then(serde_json::Value::as_str)
             })
-            .ok_or_else(|| {
-                AdapterError::NotFound("OpenAlex reports no OA location".into())
-            })?
+            .ok_or_else(|| AdapterError::NotFound("OpenAlex reports no OA location".into()))?
             .to_string();
 
         let file_resp = self
@@ -461,9 +466,9 @@ impl PaperDownloader {
         };
 
         let path = output_dir.join(format!("{stem}.{ext}"));
-        tokio::fs::write(&path, &bytes).await.map_err(|e| {
-            AdapterError::Io(format!("failed to write {}: {e}", path.display()))
-        })?;
+        tokio::fs::write(&path, &bytes)
+            .await
+            .map_err(|e| AdapterError::Io(format!("failed to write {}: {e}", path.display())))?;
 
         Ok(DownloadResult {
             doi: openalex_id.to_string(),
@@ -506,9 +511,9 @@ impl PaperDownloader {
             .unwrap_or(AccessStatus::Unknown);
 
         let path = output_dir.join(format!("{stem}.html"));
-        tokio::fs::write(&path, &bytes).await.map_err(|e| {
-            AdapterError::Io(format!("failed to write {}: {e}", path.display()))
-        })?;
+        tokio::fs::write(&path, &bytes)
+            .await
+            .map_err(|e| AdapterError::Io(format!("failed to write {}: {e}", path.display())))?;
 
         Ok(DownloadResult {
             doi: url.to_string(),
@@ -561,7 +566,13 @@ pub fn file_stem_for(paper: &Paper) -> String {
 
 fn sanitize_filename(s: &str) -> String {
     s.chars()
-        .map(|c| if c.is_ascii_alphanumeric() || matches!(c, '-' | '.' | '_') { c } else { '_' })
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '-' | '.' | '_') {
+                c
+            } else {
+                '_'
+            }
+        })
         .collect()
 }
 

--- a/crates/scitadel-adapters/src/download.rs
+++ b/crates/scitadel-adapters/src/download.rs
@@ -206,13 +206,13 @@ impl PaperDownloader {
             match self.try_unpaywall(&normalized, output_dir).await {
                 Ok(r) => return Ok(r),
                 Err(e) => {
-                    tracing::info!(doi = %normalized, error = %e, "unpaywall fallback failed")
+                    tracing::info!(doi = %normalized, error = %e, "unpaywall fallback failed");
                 }
             }
             match self.download_publisher_html(&normalized, output_dir).await {
                 Ok(r) => return Ok(r),
                 Err(e) => {
-                    tracing::info!(doi = %normalized, error = %e, "publisher html fallback failed")
+                    tracing::info!(doi = %normalized, error = %e, "publisher html fallback failed");
                 }
             }
         }
@@ -327,9 +327,8 @@ impl PaperDownloader {
             .await
             .map_err(|e| AdapterError::Network(format!("failed to read HTML: {e}")))?;
 
-        let access = std::str::from_utf8(&bytes)
-            .map(detect_access_status)
-            .unwrap_or(AccessStatus::Unknown);
+        let access =
+            std::str::from_utf8(&bytes).map_or(AccessStatus::Unknown, detect_access_status);
 
         let filename = format!("{}.html", doi_to_filename(doi));
         let path = output_dir.join(&filename);
@@ -459,9 +458,8 @@ impl PaperDownloader {
         let (ext, format, access) = if is_pdf {
             ("pdf", DownloadFormat::Pdf, AccessStatus::FullText)
         } else {
-            let access = std::str::from_utf8(&bytes)
-                .map(detect_access_status)
-                .unwrap_or(AccessStatus::Unknown);
+            let access =
+                std::str::from_utf8(&bytes).map_or(AccessStatus::Unknown, detect_access_status);
             ("html", DownloadFormat::Html, access)
         };
 
@@ -506,9 +504,8 @@ impl PaperDownloader {
             .await
             .map_err(|e| AdapterError::Network(format!("failed to read bytes: {e}")))?;
 
-        let access = std::str::from_utf8(&bytes)
-            .map(detect_access_status)
-            .unwrap_or(AccessStatus::Unknown);
+        let access =
+            std::str::from_utf8(&bytes).map_or(AccessStatus::Unknown, detect_access_status);
 
         let path = output_dir.join(format!("{stem}.html"));
         tokio::fs::write(&path, &bytes)
@@ -582,11 +579,11 @@ mod tests {
 
     #[test]
     fn classifies_obvious_paywall() {
-        let html = r#"<html><body>
+        let html = r"<html><body>
             <h1>Access options</h1>
             <button>Purchase access</button>
             <button>Institutional sign in</button>
-            </body></html>"#;
+            </body></html>";
         assert_eq!(detect_access_status(html), AccessStatus::Paywall);
     }
 

--- a/crates/scitadel-adapters/src/epo.rs
+++ b/crates/scitadel-adapters/src/epo.rs
@@ -69,17 +69,22 @@ impl EpoOpsAdapter {
         let access_token = data
             .get("access_token")
             .and_then(|v| v.as_str())
-            .ok_or_else(|| CoreError::Adapter("epo".into(), "no access_token in auth response".into()))?
+            .ok_or_else(|| {
+                CoreError::Adapter("epo".into(), "no access_token in auth response".into())
+            })?
             .to_string();
 
         let expires_in = data
             .get("expires_in")
-            .and_then(|v| v.as_u64().or_else(|| v.as_str().and_then(|s| s.parse().ok())))
+            .and_then(|v| {
+                v.as_u64()
+                    .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+            })
             .unwrap_or(1200);
 
         // Cache with 60s safety margin
-        let expires_at =
-            std::time::Instant::now() + std::time::Duration::from_secs(expires_in.saturating_sub(60));
+        let expires_at = std::time::Instant::now()
+            + std::time::Duration::from_secs(expires_in.saturating_sub(60));
 
         let mut guard = self.token.write().await;
         *guard = Some(TokenData {
@@ -200,7 +205,11 @@ fn extract_documents(data: &serde_json::Value) -> Vec<serde_json::Value> {
 
     if let Some(arr) = docs.as_array() {
         arr.iter()
-            .filter_map(|d| d.get("exchange-document").cloned().or_else(|| Some(d.clone())))
+            .filter_map(|d| {
+                d.get("exchange-document")
+                    .cloned()
+                    .or_else(|| Some(d.clone()))
+            })
             .collect()
     } else if let Some(doc) = docs.get("exchange-document") {
         vec![doc.clone()]
@@ -211,7 +220,10 @@ fn extract_documents(data: &serde_json::Value) -> Vec<serde_json::Value> {
 
 fn document_to_candidate(doc: &serde_json::Value, rank: i32) -> CandidatePaper {
     let country = doc.get("@country").and_then(|v| v.as_str()).unwrap_or("");
-    let doc_number = doc.get("@doc-number").and_then(|v| v.as_str()).unwrap_or("");
+    let doc_number = doc
+        .get("@doc-number")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
     let kind = doc.get("@kind").and_then(|v| v.as_str()).unwrap_or("");
 
     let patent_id = format!("{country}{doc_number}.{kind}");
@@ -309,11 +321,7 @@ fn extract_abstract(doc: &serde_json::Value) -> String {
 
 fn extract_abstract_text(abs: &serde_json::Value) -> String {
     abs.get("p")
-        .and_then(|p| {
-            p.get("$")
-                .and_then(|v| v.as_str())
-                .or_else(|| p.as_str())
-        })
+        .and_then(|p| p.get("$").and_then(|v| v.as_str()).or_else(|| p.as_str()))
         .unwrap_or("")
         .to_string()
 }

--- a/crates/scitadel-adapters/src/epo.rs
+++ b/crates/scitadel-adapters/src/epo.rs
@@ -36,10 +36,10 @@ impl EpoOpsAdapter {
         // Check cached token
         {
             let guard = self.token.read().await;
-            if let Some(ref td) = *guard {
-                if td.expires_at > std::time::Instant::now() {
-                    return Ok(td.access_token.clone());
-                }
+            if let Some(ref td) = *guard
+                && td.expires_at > std::time::Instant::now()
+            {
+                return Ok(td.access_token.clone());
             }
         }
 
@@ -279,10 +279,10 @@ fn extract_title(biblio: &serde_json::Value) -> String {
     if let Some(arr) = titles.as_array() {
         // Prefer English title
         for t in arr {
-            if t.get("@lang").and_then(|v| v.as_str()) == Some("en") {
-                if let Some(text) = t.get("$").and_then(|v| v.as_str()) {
-                    return text.to_string();
-                }
+            if t.get("@lang").and_then(|v| v.as_str()) == Some("en")
+                && let Some(text) = t.get("$").and_then(|v| v.as_str())
+            {
+                return text.to_string();
             }
         }
         // Fallback to first

--- a/crates/scitadel-adapters/src/inspire.rs
+++ b/crates/scitadel-adapters/src/inspire.rs
@@ -31,8 +31,7 @@ impl SourceAdapter for InspireAdapter {
         let client = Client::builder()
             .timeout(std::time::Duration::from_secs_f64(self.timeout))
             .build()
-            .map_err(|e| CoreError::Adapter("inspire".into(), e.to_string(),
-            ))?;
+            .map_err(|e| CoreError::Adapter("inspire".into(), e.to_string()))?;
 
         let params = [
             ("q", query.to_string()),
@@ -49,11 +48,12 @@ impl SourceAdapter for InspireAdapter {
             .query(&params)
             .send()
             .await
-            .map_err(|e| CoreError::Adapter("inspire".into(), e.to_string(),
-            ))?;
+            .map_err(|e| CoreError::Adapter("inspire".into(), e.to_string()))?;
 
-        let data: serde_json::Value = resp.json().await.map_err(|e| CoreError::Adapter("inspire".into(), e.to_string(),
-        ))?;
+        let data: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| CoreError::Adapter("inspire".into(), e.to_string()))?;
 
         Ok(parse_inspire_results(&data))
     }
@@ -73,7 +73,11 @@ pub fn parse_inspire_results(data: &serde_json::Value) -> Vec<CandidatePaper> {
             let meta = hit.get("metadata").cloned().unwrap_or_default();
             let inspire_id = hit
                 .get("id")
-                .and_then(|v| v.as_i64().map(|n| n.to_string()).or_else(|| v.as_str().map(String::from)))
+                .and_then(|v| {
+                    v.as_i64()
+                        .map(|n| n.to_string())
+                        .or_else(|| v.as_str().map(String::from))
+                })
                 .unwrap_or_default();
 
             let title = meta
@@ -90,7 +94,11 @@ pub fn parse_inspire_results(data: &serde_json::Value) -> Vec<CandidatePaper> {
                 .and_then(|a| a.as_array())
                 .map(|arr| {
                     arr.iter()
-                        .filter_map(|a| a.get("full_name").and_then(|n| n.as_str()).map(String::from))
+                        .filter_map(|a| {
+                            a.get("full_name")
+                                .and_then(|n| n.as_str())
+                                .map(String::from)
+                        })
                         .collect()
                 })
                 .unwrap_or_default();
@@ -127,7 +135,10 @@ pub fn parse_inspire_results(data: &serde_json::Value) -> Vec<CandidatePaper> {
 
             let year = pub_info
                 .and_then(|p| p.get("year"))
-                .and_then(|v| v.as_i64().or_else(|| v.as_str().and_then(|s| s.parse().ok())))
+                .and_then(|v| {
+                    v.as_i64()
+                        .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+                })
                 .map(|y| y as i32);
 
             let journal = pub_info

--- a/crates/scitadel-adapters/src/lens.rs
+++ b/crates/scitadel-adapters/src/lens.rs
@@ -107,10 +107,7 @@ impl SourceAdapter for LensAdapter {
 }
 
 fn patent_to_candidate(patent: &serde_json::Value, rank: i32) -> CandidatePaper {
-    let lens_id = patent
-        .get("lens_id")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
+    let lens_id = patent.get("lens_id").and_then(|v| v.as_str()).unwrap_or("");
 
     let doc_number = patent
         .get("doc_number")

--- a/crates/scitadel-adapters/src/lens.rs
+++ b/crates/scitadel-adapters/src/lens.rs
@@ -145,31 +145,31 @@ fn patent_to_candidate(patent: &serde_json::Value, rank: i32) -> CandidatePaper 
     // Extract non-patent literature citations (links patents to scholarly papers)
     let npl_citations = extract_npl_citations(patent);
 
-    let source_id = if !lens_id.is_empty() {
-        lens_id.to_string()
-    } else {
+    let source_id = if lens_id.is_empty() {
         doc_number.to_string()
+    } else {
+        lens_id.to_string()
     };
 
-    let url = if !lens_id.is_empty() {
-        Some(format!("https://www.lens.org/lens/patent/{lens_id}"))
-    } else {
+    let url = if lens_id.is_empty() {
         None
+    } else {
+        Some(format!("https://www.lens.org/lens/patent/{lens_id}"))
     };
 
     let mut raw = patent.clone();
-    if !npl_citations.is_empty() {
-        if let Some(obj) = raw.as_object_mut() {
-            obj.insert(
-                "npl_citations".into(),
-                serde_json::Value::Array(
-                    npl_citations
-                        .iter()
-                        .map(|c| serde_json::Value::String(c.clone()))
-                        .collect(),
-                ),
-            );
-        }
+    if !npl_citations.is_empty()
+        && let Some(obj) = raw.as_object_mut()
+    {
+        obj.insert(
+            "npl_citations".into(),
+            serde_json::Value::Array(
+                npl_citations
+                    .iter()
+                    .map(|c| serde_json::Value::String(c.clone()))
+                    .collect(),
+            ),
+        );
     }
 
     CandidatePaper {

--- a/crates/scitadel-adapters/src/lib.rs
+++ b/crates/scitadel-adapters/src/lib.rs
@@ -1,12 +1,12 @@
-pub mod error;
-pub mod pubmed;
 pub mod arxiv;
-pub mod openalex;
-pub mod inspire;
-pub mod patentsview;
-pub mod lens;
-pub mod epo;
 pub mod download;
+pub mod epo;
+pub mod error;
+pub mod inspire;
+pub mod lens;
+pub mod openalex;
+pub mod patentsview;
+pub mod pubmed;
 
 use scitadel_core::ports::SourceAdapter;
 

--- a/crates/scitadel-adapters/src/openalex.rs
+++ b/crates/scitadel-adapters/src/openalex.rs
@@ -32,8 +32,7 @@ impl SourceAdapter for OpenAlexAdapter {
         let client = Client::builder()
             .timeout(std::time::Duration::from_secs_f64(self.timeout))
             .build()
-            .map_err(|e| CoreError::Adapter("openalex".into(), e.to_string(),
-            ))?;
+            .map_err(|e| CoreError::Adapter("openalex".into(), e.to_string()))?;
 
         let mut params = vec![
             ("search", query.to_string()),
@@ -48,11 +47,12 @@ impl SourceAdapter for OpenAlexAdapter {
             .query(&params)
             .send()
             .await
-            .map_err(|e| CoreError::Adapter("openalex".into(), e.to_string(),
-            ))?;
+            .map_err(|e| CoreError::Adapter("openalex".into(), e.to_string()))?;
 
-        let data: serde_json::Value = resp.json().await.map_err(|e| CoreError::Adapter("openalex".into(), e.to_string(),
-        ))?;
+        let data: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| CoreError::Adapter("openalex".into(), e.to_string()))?;
 
         let works = data
             .get("results")

--- a/crates/scitadel-adapters/src/patentsview.rs
+++ b/crates/scitadel-adapters/src/patentsview.rs
@@ -221,7 +221,10 @@ mod tests {
         assert_eq!(c.year, Some(2023));
         assert_eq!(c.authors, vec!["Alice Smith", "Bob Jones"]);
         assert_eq!(c.journal, Some("Quantum Corp (utility B2)".to_string()));
-        assert_eq!(c.url, Some("https://patents.google.com/patent/US11234567".to_string()));
+        assert_eq!(
+            c.url,
+            Some("https://patents.google.com/patent/US11234567".to_string())
+        );
         assert_eq!(c.rank, Some(1));
     }
 

--- a/crates/scitadel-adapters/src/pubmed.rs
+++ b/crates/scitadel-adapters/src/pubmed.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
-use quick_xml::events::Event;
 use quick_xml::Reader;
+use quick_xml::events::Event;
 use reqwest::Client;
 
 use scitadel_core::error::CoreError;
@@ -35,8 +35,7 @@ impl SourceAdapter for PubMedAdapter {
         let client = Client::builder()
             .timeout(std::time::Duration::from_secs_f64(self.timeout))
             .build()
-            .map_err(|e| CoreError::Adapter("pubmed".into(), e.to_string(),
-            ))?;
+            .map_err(|e| CoreError::Adapter("pubmed".into(), e.to_string()))?;
 
         let pmids = esearch(&client, query, max_results, &self.api_key).await?;
         if pmids.is_empty() {
@@ -68,11 +67,12 @@ async fn esearch(
         .query(&params)
         .send()
         .await
-        .map_err(|e| CoreError::Adapter("pubmed".into(), e.to_string(),
-        ))?;
+        .map_err(|e| CoreError::Adapter("pubmed".into(), e.to_string()))?;
 
-    let data: serde_json::Value = resp.json().await.map_err(|e| CoreError::Adapter("pubmed".into(), e.to_string(),
-    ))?;
+    let data: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| CoreError::Adapter("pubmed".into(), e.to_string()))?;
 
     let ids = data
         .get("esearchresult")
@@ -107,11 +107,12 @@ async fn efetch(
         .query(&params)
         .send()
         .await
-        .map_err(|e| CoreError::Adapter("pubmed".into(), e.to_string(),
-        ))?;
+        .map_err(|e| CoreError::Adapter("pubmed".into(), e.to_string()))?;
 
-    let xml_text = resp.text().await.map_err(|e| CoreError::Adapter("pubmed".into(), e.to_string(),
-    ))?;
+    let xml_text = resp
+        .text()
+        .await
+        .map_err(|e| CoreError::Adapter("pubmed".into(), e.to_string()))?;
 
     Ok(parse_pubmed_xml(&xml_text))
 }
@@ -230,7 +231,9 @@ pub fn parse_pubmed_xml(xml_text: &str) -> Vec<CandidatePaper> {
                         format!("{}: {text}", current_abstract_label)
                     };
                     current_abstract_parts.push(part);
-                } else if in_elocation_id && current_elocation_type == "doi" && current_doi.is_none()
+                } else if in_elocation_id
+                    && current_elocation_type == "doi"
+                    && current_doi.is_none()
                 {
                     current_doi = Some(text);
                 } else if in_journal_title {
@@ -344,9 +347,6 @@ mod tests {
         assert_eq!(c.r#abstract, "This paper reviews ML methods.");
         assert_eq!(c.doi, Some("10.1234/test.2024".to_string()));
         assert_eq!(c.year, Some(2024));
-        assert_eq!(
-            c.journal,
-            Some("Nature Reviews Drug Discovery".to_string())
-        );
+        assert_eq!(c.journal, Some("Nature Reviews Drug Discovery".to_string()));
     }
 }

--- a/crates/scitadel-adapters/src/pubmed.rs
+++ b/crates/scitadel-adapters/src/pubmed.rs
@@ -251,15 +251,13 @@ pub fn parse_pubmed_xml(xml_text: &str) -> Vec<CandidatePaper> {
                     "ForeName" => {
                         in_fore_name = false;
                     }
-                    "Author" => {
-                        if !current_last_name.is_empty() {
-                            let name = if current_fore_name.is_empty() {
-                                current_last_name.clone()
-                            } else {
-                                format!("{}, {}", current_last_name, current_fore_name)
-                            };
-                            current_authors.push(name);
-                        }
+                    "Author" if !current_last_name.is_empty() => {
+                        let name = if current_fore_name.is_empty() {
+                            current_last_name.clone()
+                        } else {
+                            format!("{}, {}", current_last_name, current_fore_name)
+                        };
+                        current_authors.push(name);
                     }
                     "AbstractText" => in_abstract_text = false,
                     "ELocationID" => in_elocation_id = false,

--- a/crates/scitadel-cli/src/commands.rs
+++ b/crates/scitadel-cli/src/commands.rs
@@ -555,8 +555,8 @@ pub fn auth_status() -> Result<()> {
                 "keychain"
             } else if std::env::var(key.env_var)
                 .ok()
-                .filter(|v| !v.is_empty())
-                .is_some()
+                .as_ref()
+                .is_some_and(|v| !v.is_empty())
             {
                 "env"
             } else {

--- a/crates/scitadel-cli/src/commands.rs
+++ b/crates/scitadel-cli/src/commands.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 use std::path::PathBuf;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 
 use scitadel_core::config::load_config;
 use scitadel_core::credentials;
@@ -23,7 +23,10 @@ fn resolve_prefix<'a, T, F>(items: &'a [T], prefix: &str, get_id: F) -> Result<&
 where
     F: Fn(&T) -> &str,
 {
-    let matches: Vec<&T> = items.iter().filter(|item| get_id(item).starts_with(prefix)).collect();
+    let matches: Vec<&T> = items
+        .iter()
+        .filter(|item| get_id(item).starts_with(prefix))
+        .collect();
     match matches.len() {
         0 => bail!("no match for prefix '{prefix}'"),
         1 => Ok(matches[0]),
@@ -167,7 +170,10 @@ pub async fn search(
             && let Ok(Some(existing)) = paper_repo.find_by_doi(doi)
             && existing.id != paper.id
         {
-            id_map.insert(paper.id.as_str().to_string(), existing.id.as_str().to_string());
+            id_map.insert(
+                paper.id.as_str().to_string(),
+                existing.id.as_str().to_string(),
+            );
         }
     }
 
@@ -347,7 +353,11 @@ pub fn question_add_terms(
     term.query_string.clone_from(&query_str);
     q_repo.save_term(&term)?;
 
-    println!("  Terms added to question {}: {:?}", question.id.short(), terms);
+    println!(
+        "  Terms added to question {}: {:?}",
+        question.id.short(),
+        terms
+    );
     println!("  Query string: {query_str}");
     Ok(())
 }
@@ -384,7 +394,11 @@ pub async fn assess(
         .filter_map(|id| paper_repo.get(id).ok().flatten())
         .collect();
 
-    println!("Scoring {} papers against: \"{}\"", papers.len(), question.text);
+    println!(
+        "Scoring {} papers against: \"{}\"",
+        papers.len(),
+        question.text
+    );
     println!("  Model: {model}  Temperature: {temperature}  Backend: {scorer_backend}");
 
     let backend = match scorer_backend {
@@ -459,10 +473,8 @@ pub async fn download(doi: &str, output_dir: Option<PathBuf>) -> Result<()> {
     let config = load_config();
     let out_dir = output_dir.unwrap_or_else(|| config.papers_dir());
 
-    let downloader = scitadel_adapters::download::PaperDownloader::new(
-        config.openalex.api_key.clone(),
-        60.0,
-    );
+    let downloader =
+        scitadel_adapters::download::PaperDownloader::new(config.openalex.api_key.clone(), 60.0);
 
     println!("Downloading paper: {doi}");
     println!("  Output dir: {}", out_dir.display());
@@ -504,8 +516,7 @@ pub fn auth_login(source: &str) -> Result<()> {
 
     for key in creds.keys {
         let value = prompt_credential(key.label, key.secret)?;
-        credentials::store(key.keychain_key, &value)
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        credentials::store(key.keychain_key, &value).map_err(|e| anyhow::anyhow!("{e}"))?;
         println!("  Stored: {}", key.keychain_key);
     }
 
@@ -542,7 +553,11 @@ pub fn auth_status() -> Result<()> {
         for key in creds.keys {
             let loc = if credentials::get_keychain(key.keychain_key).is_some() {
                 "keychain"
-            } else if std::env::var(key.env_var).ok().filter(|v| !v.is_empty()).is_some() {
+            } else if std::env::var(key.env_var)
+                .ok()
+                .filter(|v| !v.is_empty())
+                .is_some()
+            {
                 "env"
             } else {
                 "missing"
@@ -563,10 +578,7 @@ fn find_source_credentials(source: &str) -> Result<&'static credentials::SourceC
         .copied()
         .ok_or_else(|| {
             let names: Vec<&str> = credentials::ALL_SOURCES.iter().map(|c| c.source).collect();
-            anyhow::anyhow!(
-                "Unknown source '{source}'. Available: {}",
-                names.join(", ")
-            )
+            anyhow::anyhow!("Unknown source '{source}'. Available: {}", names.join(", "))
         })
 }
 

--- a/crates/scitadel-cli/src/main.rs
+++ b/crates/scitadel-cli/src/main.rs
@@ -7,7 +7,11 @@ use tracing_subscriber::EnvFilter;
 mod commands;
 
 #[derive(Parser)]
-#[command(name = "scitadel", version, about = "Programmable, reproducible scientific literature retrieval")]
+#[command(
+    name = "scitadel",
+    version,
+    about = "Programmable, reproducible scientific literature retrieval"
+)]
 struct Cli {
     #[command(subcommand)]
     command: Commands,
@@ -189,10 +193,7 @@ async fn main() -> Result<()> {
             format,
             output,
         } => commands::export(&search_id, &format, output),
-        Commands::Diff {
-            search_a,
-            search_b,
-        } => commands::diff(&search_a, &search_b),
+        Commands::Diff { search_a, search_b } => commands::diff(&search_a, &search_b),
         Commands::Question { command } => match command {
             QuestionCommands::Create { text, description } => {
                 commands::question_create(&text, &description)
@@ -226,8 +227,6 @@ async fn main() -> Result<()> {
             threshold,
             direction,
             model,
-        } => {
-            commands::snowball(&search_id, &question, depth, threshold, &direction, &model)
-        }
+        } => commands::snowball(&search_id, &question, depth, threshold, &direction, &model),
     }
 }

--- a/crates/scitadel-core/src/config.rs
+++ b/crates/scitadel-core/src/config.rs
@@ -143,8 +143,7 @@ impl Config {
 
 impl Default for Config {
     fn default() -> Self {
-        let workspace =
-            find_workspace_root().unwrap_or_else(|| std::env::current_dir().unwrap());
+        let workspace = find_workspace_root().unwrap_or_else(|| std::env::current_dir().unwrap());
         Self {
             db_path: default_db_path(&workspace),
             default_sources: default_sources(),
@@ -199,8 +198,7 @@ fn default_db_path(workspace: &Path) -> PathBuf {
 pub fn load_config() -> Config {
     use crate::credentials::resolve;
 
-    let workspace =
-        find_workspace_root().unwrap_or_else(|| std::env::current_dir().unwrap());
+    let workspace = find_workspace_root().unwrap_or_else(|| std::env::current_dir().unwrap());
     let db_path = default_db_path(&workspace);
 
     // Try loading TOML config file as base

--- a/crates/scitadel-core/src/config.rs
+++ b/crates/scitadel-core/src/config.rs
@@ -257,15 +257,15 @@ pub fn load_config() -> Config {
     if let Ok(model) = std::env::var("SCITADEL_CHAT_MODEL") {
         config.chat.model = model;
     }
-    if let Ok(tokens) = std::env::var("SCITADEL_CHAT_MAX_TOKENS") {
-        if let Ok(v) = tokens.parse() {
-            config.chat.max_tokens = v;
-        }
+    if let Ok(tokens) = std::env::var("SCITADEL_CHAT_MAX_TOKENS")
+        && let Ok(v) = tokens.parse()
+    {
+        config.chat.max_tokens = v;
     }
-    if let Ok(conc) = std::env::var("SCITADEL_SCORING_CONCURRENCY") {
-        if let Ok(v) = conc.parse() {
-            config.chat.scoring_concurrency = v;
-        }
+    if let Ok(conc) = std::env::var("SCITADEL_SCORING_CONCURRENCY")
+        && let Ok(v) = conc.parse()
+    {
+        config.chat.scoring_concurrency = v;
     }
 
     config

--- a/crates/scitadel-core/src/credentials.rs
+++ b/crates/scitadel-core/src/credentials.rs
@@ -68,9 +68,12 @@ pub fn store(key: &str, value: &str) -> Result<(), String> {
     let output = std::process::Command::new("security")
         .args([
             "add-generic-password",
-            "-s", SERVICE,
-            "-a", key,
-            "-w", value,
+            "-s",
+            SERVICE,
+            "-a",
+            key,
+            "-w",
+            value,
             "-U", // update if exists
         ])
         .output()

--- a/crates/scitadel-core/src/credentials.rs
+++ b/crates/scitadel-core/src/credentials.rs
@@ -44,10 +44,10 @@ pub fn resolve(keychain_key: &str, env_var: &str, config_fallback: &str) -> Opti
     }
 
     // 2. Environment variable
-    if let Ok(val) = std::env::var(env_var) {
-        if !val.is_empty() {
-            return Some(val);
-        }
+    if let Ok(val) = std::env::var(env_var)
+        && !val.is_empty()
+    {
+        return Some(val);
     }
 
     // 3. Config fallback

--- a/crates/scitadel-core/src/models/mod.rs
+++ b/crates/scitadel-core/src/models/mod.rs
@@ -1,16 +1,16 @@
-mod paper;
-mod search;
-mod question;
 mod assessment;
 mod citation;
 mod doi;
+mod paper;
+mod question;
+mod search;
 
-pub use paper::{Paper, CandidatePaper};
-pub use doi::{validate_doi, normalize_doi, doi_to_filename};
-pub use search::{Search, SearchResult, SourceOutcome, SourceStatus};
-pub use question::{ResearchQuestion, SearchTerm};
 pub use assessment::Assessment;
 pub use citation::{Citation, CitationDirection, SnowballRun};
+pub use doi::{doi_to_filename, normalize_doi, validate_doi};
+pub use paper::{CandidatePaper, Paper};
+pub use question::{ResearchQuestion, SearchTerm};
+pub use search::{Search, SearchResult, SourceOutcome, SourceStatus};
 
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;

--- a/crates/scitadel-core/src/models/paper.rs
+++ b/crates/scitadel-core/src/models/paper.rs
@@ -85,7 +85,11 @@ pub struct CandidatePaper {
 
 impl CandidatePaper {
     #[must_use]
-    pub fn new(source: impl Into<String>, source_id: impl Into<String>, title: impl Into<String>) -> Self {
+    pub fn new(
+        source: impl Into<String>,
+        source_id: impl Into<String>,
+        title: impl Into<String>,
+    ) -> Self {
         Self {
             source: source.into(),
             source_id: source_id.into(),

--- a/crates/scitadel-core/src/ports/mod.rs
+++ b/crates/scitadel-core/src/ports/mod.rs
@@ -2,7 +2,6 @@ mod repository;
 mod source;
 
 pub use repository::{
-    AssessmentRepository, CitationRepository, PaperRepository, QuestionRepository,
-    SearchRepository,
+    AssessmentRepository, CitationRepository, PaperRepository, QuestionRepository, SearchRepository,
 };
 pub use source::SourceAdapter;

--- a/crates/scitadel-core/src/services/dedup.rs
+++ b/crates/scitadel-core/src/services/dedup.rs
@@ -40,12 +40,11 @@ fn title_similarity(a: &str, b: &str) -> f64 {
 
 /// Merge a candidate's metadata into an existing paper (fill gaps).
 fn merge_candidate_into_paper(paper: &mut Paper, candidate: &CandidatePaper) {
-    if paper.doi.is_none() {
-        if let Some(doi) = candidate.doi.as_deref() {
-            if validate_doi(doi) {
-                paper.doi = Some(normalize_doi(doi));
-            }
-        }
+    if paper.doi.is_none()
+        && let Some(doi) = candidate.doi.as_deref()
+        && validate_doi(doi)
+    {
+        paper.doi = Some(normalize_doi(doi));
     }
     if paper.arxiv_id.is_none() && candidate.arxiv_id.is_some() {
         paper.arxiv_id.clone_from(&candidate.arxiv_id);
@@ -112,10 +111,10 @@ pub fn deduplicate(
         });
 
         // 1. DOI exact match
-        if let Some(ref doi) = valid_doi {
-            if let Some(&idx) = doi_index.get(doi) {
-                matched_idx = Some(idx);
-            }
+        if let Some(ref doi) = valid_doi
+            && let Some(&idx) = doi_index.get(doi)
+        {
+            matched_idx = Some(idx);
         }
 
         // 2. Fuzzy title match (only if no DOI match)
@@ -139,7 +138,7 @@ pub fn deduplicate(
             let mut paper = Paper::new(&candidate.title);
             paper.authors.clone_from(&candidate.authors);
             paper.r#abstract.clone_from(&candidate.r#abstract);
-            paper.doi = valid_doi.clone();
+            paper.doi.clone_from(&valid_doi);
             paper.arxiv_id.clone_from(&candidate.arxiv_id);
             paper.pubmed_id.clone_from(&candidate.pubmed_id);
             paper.inspire_id.clone_from(&candidate.inspire_id);

--- a/crates/scitadel-core/src/services/dedup.rs
+++ b/crates/scitadel-core/src/services/dedup.rs
@@ -2,14 +2,20 @@ use std::collections::HashMap;
 
 use tracing::warn;
 
-use crate::models::{CandidatePaper, Paper, SearchResult, SearchId, validate_doi, normalize_doi};
+use crate::models::{CandidatePaper, Paper, SearchId, SearchResult, normalize_doi, validate_doi};
 
 /// Normalize title for fuzzy matching: lowercase, strip punctuation/whitespace.
 fn normalize_title(title: &str) -> String {
     let lowered = title.to_lowercase();
     let stripped: String = lowered
         .chars()
-        .map(|c: char| if c.is_alphanumeric() || c.is_whitespace() { c } else { ' ' })
+        .map(|c: char| {
+            if c.is_alphanumeric() || c.is_whitespace() {
+                c
+            } else {
+                ' '
+            }
+        })
         .collect();
     stripped.split_whitespace().collect::<Vec<_>>().join(" ")
 }
@@ -66,7 +72,9 @@ fn merge_candidate_into_paper(paper: &mut Paper, candidate: &CandidatePaper) {
         paper.authors.clone_from(&candidate.authors);
     }
     if let Some(url) = &candidate.url {
-        paper.source_urls.insert(candidate.source.clone(), url.clone());
+        paper
+            .source_urls
+            .insert(candidate.source.clone(), url.clone());
     }
 }
 
@@ -140,7 +148,9 @@ pub fn deduplicate(
             paper.journal.clone_from(&candidate.journal);
             paper.url.clone_from(&candidate.url);
             if let Some(url) = &candidate.url {
-                paper.source_urls.insert(candidate.source.clone(), url.clone());
+                paper
+                    .source_urls
+                    .insert(candidate.source.clone(), url.clone());
             }
 
             let idx = papers.len();
@@ -182,7 +192,10 @@ mod tests {
 
     #[test]
     fn test_title_similarity_identical() {
-        let sim = title_similarity("Machine Learning for Science", "Machine Learning for Science");
+        let sim = title_similarity(
+            "Machine Learning for Science",
+            "Machine Learning for Science",
+        );
         assert!((sim - 1.0).abs() < f64::EPSILON);
     }
 

--- a/crates/scitadel-core/src/services/orchestrator.rs
+++ b/crates/scitadel-core/src/services/orchestrator.rs
@@ -22,9 +22,7 @@ async fn run_adapter(
                 let count = candidates.len() as i32;
                 info!(
                     source = adapter.name(),
-                    count,
-                    elapsed_ms,
-                    "Adapter returned results"
+                    count, elapsed_ms, "Adapter returned results"
                 );
                 return (
                     candidates,
@@ -149,8 +147,7 @@ mod tests {
             _max_results: usize,
         ) -> Result<Vec<CandidatePaper>, CoreError> {
             if self.should_fail {
-                Err(CoreError::Adapter(self.name.clone(), "mock failure".into(),
-                ))
+                Err(CoreError::Adapter(self.name.clone(), "mock failure".into()))
             } else {
                 Ok(self.results.clone())
             }
@@ -190,8 +187,16 @@ mod tests {
         assert_eq!(candidates.len(), 1);
         assert_eq!(search.source_outcomes.len(), 2);
 
-        let good = search.source_outcomes.iter().find(|o| o.source == "good").unwrap();
-        let bad = search.source_outcomes.iter().find(|o| o.source == "bad").unwrap();
+        let good = search
+            .source_outcomes
+            .iter()
+            .find(|o| o.source == "good")
+            .unwrap();
+        let bad = search
+            .source_outcomes
+            .iter()
+            .find(|o| o.source == "bad")
+            .unwrap();
         assert_eq!(good.status, SourceStatus::Success);
         assert_eq!(bad.status, SourceStatus::Failed);
     }

--- a/crates/scitadel-db/src/sqlite/citations.rs
+++ b/crates/scitadel-db/src/sqlite/citations.rs
@@ -1,4 +1,4 @@
-use rusqlite::{params, OptionalExtension};
+use rusqlite::{OptionalExtension, params};
 use scitadel_core::error::CoreError;
 use scitadel_core::models::{
     Citation, CitationDirection, PaperId, QuestionId, SearchId, SnowballRun, SnowballRunId,
@@ -75,7 +75,10 @@ impl CitationRepository for SqliteCitationRepository {
                 citation.direction.to_string(),
                 citation.discovered_by,
                 citation.depth,
-                citation.snowball_run_id.as_ref().map(|id| id.as_str().to_string()),
+                citation
+                    .snowball_run_id
+                    .as_ref()
+                    .map(|id| id.as_str().to_string()),
             ],
         )
         .map_err(DbError::Sqlite)?;
@@ -104,9 +107,7 @@ impl CitationRepository for SqliteCitationRepository {
     fn get_references(&self, paper_id: &str) -> Result<Vec<Citation>, CoreError> {
         let conn = self.db.conn()?;
         let mut stmt = conn
-            .prepare(
-                "SELECT * FROM citations WHERE source_paper_id = ?1 AND direction = ?2",
-            )
+            .prepare("SELECT * FROM citations WHERE source_paper_id = ?1 AND direction = ?2")
             .map_err(DbError::Sqlite)?;
         let citations = stmt
             .query_map(
@@ -122,9 +123,7 @@ impl CitationRepository for SqliteCitationRepository {
     fn get_citations(&self, paper_id: &str) -> Result<Vec<Citation>, CoreError> {
         let conn = self.db.conn()?;
         let mut stmt = conn
-            .prepare(
-                "SELECT * FROM citations WHERE target_paper_id = ?1 AND direction = ?2",
-            )
+            .prepare("SELECT * FROM citations WHERE target_paper_id = ?1 AND direction = ?2")
             .map_err(DbError::Sqlite)?;
         let citations = stmt
             .query_map(
@@ -236,9 +235,11 @@ mod tests {
         assert_eq!(refs.len(), 1);
         assert_eq!(refs[0].target_paper_id, paper_b.id);
 
-        assert!(citation_repo
-            .exists(paper_a.id.as_str(), paper_b.id.as_str(), "references")
-            .unwrap());
+        assert!(
+            citation_repo
+                .exists(paper_a.id.as_str(), paper_b.id.as_str(), "references")
+                .unwrap()
+        );
     }
 
     #[test]

--- a/crates/scitadel-db/src/sqlite/migrations.rs
+++ b/crates/scitadel-db/src/sqlite/migrations.rs
@@ -6,11 +6,7 @@ const MIGRATION_001: &str = include_str!("../../migrations/001_initial.sql");
 const MIGRATION_002: &str = include_str!("../../migrations/002_citations.sql");
 const MIGRATION_003: &str = include_str!("../../migrations/003_full_text.sql");
 
-const MIGRATIONS: &[(i64, &str)] = &[
-    (1, MIGRATION_001),
-    (2, MIGRATION_002),
-    (3, MIGRATION_003),
-];
+const MIGRATIONS: &[(i64, &str)] = &[(1, MIGRATION_001), (2, MIGRATION_002), (3, MIGRATION_003)];
 
 /// Run all pending migrations, skipping already-applied ones.
 pub fn run_migrations(conn: &Connection) -> Result<(), DbError> {

--- a/crates/scitadel-db/src/sqlite/mod.rs
+++ b/crates/scitadel-db/src/sqlite/mod.rs
@@ -1,20 +1,20 @@
-mod migrations;
-mod papers;
-mod searches;
-mod questions;
 mod assessments;
 mod citations;
+mod migrations;
+mod papers;
+mod questions;
+mod searches;
 
-pub use migrations::run_migrations;
-pub use papers::SqlitePaperRepository;
-pub use searches::SqliteSearchRepository;
-pub use questions::SqliteQuestionRepository;
 pub use assessments::SqliteAssessmentRepository;
 pub use citations::SqliteCitationRepository;
+pub use migrations::run_migrations;
+pub use papers::SqlitePaperRepository;
+pub use questions::SqliteQuestionRepository;
+pub use searches::SqliteSearchRepository;
 
-use std::path::Path;
 use r2d2::Pool;
 use r2d2_sqlite::SqliteConnectionManager;
+use std::path::Path;
 
 use crate::error::DbError;
 
@@ -38,37 +38,31 @@ impl Database {
                 .map_err(|e| DbError::Migration(format!("failed to create db directory: {e}")))?;
         }
 
-        let manager = SqliteConnectionManager::file(path)
-            .with_init(|conn| {
-                conn.execute_batch(
-                    "PRAGMA journal_mode=WAL;
+        let manager = SqliteConnectionManager::file(path).with_init(|conn| {
+            conn.execute_batch(
+                "PRAGMA journal_mode=WAL;
                      PRAGMA foreign_keys=ON;
                      PRAGMA busy_timeout=5000;",
-                )?;
-                Ok(())
-            });
+            )?;
+            Ok(())
+        });
 
-        let pool = Pool::builder()
-            .max_size(4)
-            .build(manager)?;
+        let pool = Pool::builder().max_size(4).build(manager)?;
 
         Ok(Self { pool })
     }
 
     /// Open an in-memory database (for testing).
     pub fn open_in_memory() -> Result<Self, DbError> {
-        let manager = SqliteConnectionManager::memory()
-            .with_init(|conn| {
-                conn.execute_batch(
-                    "PRAGMA journal_mode=WAL;
+        let manager = SqliteConnectionManager::memory().with_init(|conn| {
+            conn.execute_batch(
+                "PRAGMA journal_mode=WAL;
                      PRAGMA foreign_keys=ON;",
-                )?;
-                Ok(())
-            });
+            )?;
+            Ok(())
+        });
 
-        let pool = Pool::builder()
-            .max_size(1)
-            .build(manager)?;
+        let pool = Pool::builder().max_size(1).build(manager)?;
 
         Ok(Self { pool })
     }
@@ -85,7 +79,9 @@ impl Database {
     }
 
     /// Create all repository instances sharing this database.
-    pub fn repositories(&self) -> (
+    pub fn repositories(
+        &self,
+    ) -> (
         SqlitePaperRepository,
         SqliteSearchRepository,
         SqliteQuestionRepository,

--- a/crates/scitadel-db/src/sqlite/papers.rs
+++ b/crates/scitadel-db/src/sqlite/papers.rs
@@ -43,7 +43,10 @@ impl SqlitePaperRepository {
 
     /// If a paper with the same DOI already exists, return a clone with the existing ID
     /// so the upsert merges into the existing row instead of violating the DOI unique index.
-    fn resolve_doi_conflict(conn: &rusqlite::Connection, paper: &Paper) -> Result<Paper, CoreError> {
+    fn resolve_doi_conflict(
+        conn: &rusqlite::Connection,
+        paper: &Paper,
+    ) -> Result<Paper, CoreError> {
         if let Some(doi) = &paper.doi {
             let existing_id: Option<String> = conn
                 .query_row(
@@ -62,7 +65,10 @@ impl SqlitePaperRepository {
         Ok(paper.clone())
     }
 
-    fn resolve_doi_conflict_tx(tx: &rusqlite::Transaction<'_>, paper: &Paper) -> Result<Paper, CoreError> {
+    fn resolve_doi_conflict_tx(
+        tx: &rusqlite::Transaction<'_>,
+        paper: &Paper,
+    ) -> Result<Paper, CoreError> {
         if let Some(doi) = &paper.doi {
             let existing_id: Option<String> = tx
                 .query_row(
@@ -338,7 +344,11 @@ mod tests {
         let loaded = repo.find_by_doi("10.1234/conflict").unwrap().unwrap();
         assert_eq!(loaded.id, paper1.id, "should reuse original paper ID");
         assert_eq!(loaded.title, "Updated Title", "should update title");
-        assert_eq!(loaded.arxiv_id, Some("2301.99999".to_string()), "should merge arxiv_id");
+        assert_eq!(
+            loaded.arxiv_id,
+            Some("2301.99999".to_string()),
+            "should merge arxiv_id"
+        );
     }
 
     #[test]
@@ -419,14 +429,28 @@ mod tests {
             },
         ];
         let (papers_2, results_2) = deduplicate(&candidates_2, 0.85);
-        assert_eq!(papers_2.len(), 3, "dedup sees them as distinct (different IDs)");
+        assert_eq!(
+            papers_2.len(),
+            3,
+            "dedup sees them as distinct (different IDs)"
+        );
 
         let remap_2 = repo.save_many(&papers_2).unwrap();
-        assert_eq!(remap_2.len(), 2, "alpha and gamma should remap to existing IDs");
+        assert_eq!(
+            remap_2.len(),
+            2,
+            "alpha and gamma should remap to existing IDs"
+        );
 
         // Verify the remap points to the original paper IDs
-        let alpha_original = papers_1.iter().find(|p| p.doi.as_deref() == Some("10.1000/alpha")).unwrap();
-        let alpha_new = papers_2.iter().find(|p| p.doi.as_deref() == Some("10.1000/alpha")).unwrap();
+        let alpha_original = papers_1
+            .iter()
+            .find(|p| p.doi.as_deref() == Some("10.1000/alpha"))
+            .unwrap();
+        let alpha_new = papers_2
+            .iter()
+            .find(|p| p.doi.as_deref() == Some("10.1000/alpha"))
+            .unwrap();
         assert_eq!(remap_2[&alpha_new.id], alpha_original.id);
 
         // Verify DB state: should have 4 papers total, not 6
@@ -436,7 +460,11 @@ mod tests {
         // Verify metadata was merged
         let alpha = repo.find_by_doi("10.1000/alpha").unwrap().unwrap();
         assert_eq!(alpha.id, alpha_original.id, "kept original ID");
-        assert_eq!(alpha.arxiv_id, Some("2301.00001".into()), "merged arxiv_id from second search");
+        assert_eq!(
+            alpha.arxiv_id,
+            Some("2301.00001".into()),
+            "merged arxiv_id from second search"
+        );
 
         // Verify search_results can be remapped correctly
         for sr in &results_2 {

--- a/crates/scitadel-db/src/sqlite/questions.rs
+++ b/crates/scitadel-db/src/sqlite/questions.rs
@@ -1,4 +1,4 @@
-use rusqlite::{params, OptionalExtension};
+use rusqlite::{OptionalExtension, params};
 use scitadel_core::error::CoreError;
 use scitadel_core::models::{QuestionId, ResearchQuestion, SearchTerm, SearchTermId};
 use scitadel_core::ports::QuestionRepository;

--- a/crates/scitadel-db/src/sqlite/searches.rs
+++ b/crates/scitadel-db/src/sqlite/searches.rs
@@ -1,8 +1,6 @@
-use rusqlite::{params, OptionalExtension};
+use rusqlite::{OptionalExtension, params};
 use scitadel_core::error::CoreError;
-use scitadel_core::models::{
-    PaperId, Search, SearchId, SearchResult, SourceOutcome,
-};
+use scitadel_core::models::{PaperId, Search, SearchId, SearchResult, SourceOutcome};
 use scitadel_core::ports::SearchRepository;
 
 use super::Database;
@@ -154,17 +152,18 @@ impl SearchRepository for SqliteSearchRepository {
     ) -> Result<(Vec<String>, Vec<String>), CoreError> {
         let conn = self.db.conn()?;
 
-        let get_paper_ids = |search_id: &str| -> Result<std::collections::HashSet<String>, DbError> {
-            let mut stmt = conn
-                .prepare("SELECT DISTINCT paper_id FROM search_results WHERE search_id = ?1")
-                .map_err(DbError::Sqlite)?;
-            let ids: std::collections::HashSet<String> = stmt
-                .query_map(params![search_id], |row| row.get(0))
-                .map_err(DbError::Sqlite)?
-                .filter_map(Result::ok)
-                .collect();
-            Ok(ids)
-        };
+        let get_paper_ids =
+            |search_id: &str| -> Result<std::collections::HashSet<String>, DbError> {
+                let mut stmt = conn
+                    .prepare("SELECT DISTINCT paper_id FROM search_results WHERE search_id = ?1")
+                    .map_err(DbError::Sqlite)?;
+                let ids: std::collections::HashSet<String> = stmt
+                    .query_map(params![search_id], |row| row.get(0))
+                    .map_err(DbError::Sqlite)?
+                    .filter_map(Result::ok)
+                    .collect();
+                Ok(ids)
+            };
 
         let papers_a = get_paper_ids(search_id_a).map_err(Into::<CoreError>::into)?;
         let papers_b = get_paper_ids(search_id_b).map_err(Into::<CoreError>::into)?;

--- a/crates/scitadel-export/src/bibtex.rs
+++ b/crates/scitadel-export/src/bibtex.rs
@@ -48,7 +48,9 @@ fn generate_bibtex_key(paper: &Paper) -> String {
         .map(|a| {
             let name = a.split(',').next().unwrap_or(a);
             let last = name.split_whitespace().last().unwrap_or("").to_lowercase();
-            last.chars().filter(|c| c.is_alphanumeric()).collect::<String>()
+            last.chars()
+                .filter(|c| c.is_alphanumeric())
+                .collect::<String>()
         })
         .unwrap_or_default();
 

--- a/crates/scitadel-mcp/src/server.rs
+++ b/crates/scitadel-mcp/src/server.rs
@@ -12,7 +12,9 @@ use crate::tools;
 pub struct SearchRequest {
     #[schemars(description = "Search query string")]
     pub query: String,
-    #[schemars(description = "Comma-separated list of sources (e.g. pubmed,arxiv,openalex,inspire)")]
+    #[schemars(
+        description = "Comma-separated list of sources (e.g. pubmed,arxiv,openalex,inspire)"
+    )]
     pub sources: String,
     #[schemars(description = "Maximum results per source")]
     pub max_results: usize,
@@ -66,10 +68,7 @@ pub struct ScitadelServer;
 #[tool(tool_box)]
 impl ScitadelServer {
     #[tool(description = "Search scientific literature across multiple sources")]
-    async fn search(
-        &self,
-        #[tool(aggr)] req: SearchRequest,
-    ) -> Result<String, String> {
+    async fn search(&self, #[tool(aggr)] req: SearchRequest) -> Result<String, String> {
         tools::search_tool(req.query, req.sources, req.max_results, req.question_id).await
     }
 
@@ -135,18 +134,12 @@ impl ScitadelServer {
     }
 
     #[tool(description = "Add search terms linked to a research question")]
-    fn add_search_terms(
-        &self,
-        #[tool(aggr)] req: AddSearchTermsRequest,
-    ) -> Result<String, String> {
+    fn add_search_terms(&self, #[tool(aggr)] req: AddSearchTermsRequest) -> Result<String, String> {
         tools::add_search_terms_tool(&req.question_id, &req.terms, &req.query_string)
     }
 
     #[tool(description = "Record a paper assessment with score and reasoning")]
-    fn assess_paper(
-        &self,
-        #[tool(aggr)] req: AssessPaperRequest,
-    ) -> Result<String, String> {
+    fn assess_paper(&self, #[tool(aggr)] req: AssessPaperRequest) -> Result<String, String> {
         tools::assess_paper_tool(
             &req.paper_id,
             &req.question_id,
@@ -184,18 +177,19 @@ impl ScitadelServer {
     }
 
     #[tool(description = "Save an MCP-native assessment scored by the host LLM")]
-    fn save_assessment(
-        &self,
-        #[tool(aggr)] req: SaveAssessmentRequest,
-    ) -> Result<String, String> {
+    fn save_assessment(&self, #[tool(aggr)] req: SaveAssessmentRequest) -> Result<String, String> {
         tools::save_assessment_tool(&req.paper_id, &req.question_id, req.score, &req.reasoning)
     }
 
-    #[tool(description = "Download a paper (PDF or HTML). Prefer passing paper_id to leverage all stored identifiers (arxiv/openalex/doi); doi is a fallback for ad-hoc lookups.")]
+    #[tool(
+        description = "Download a paper (PDF or HTML). Prefer passing paper_id to leverage all stored identifiers (arxiv/openalex/doi); doi is a fallback for ad-hoc lookups."
+    )]
     async fn download_paper(
         &self,
         #[tool(param)]
-        #[schemars(description = "Paper ID from the scitadel DB (preferred — unlocks arxiv/openalex/Unpaywall chain)")]
+        #[schemars(
+            description = "Paper ID from the scitadel DB (preferred — unlocks arxiv/openalex/Unpaywall chain)"
+        )]
         paper_id: Option<String>,
         #[tool(param)]
         #[schemars(description = "DOI (used only if paper_id is not provided)")]
@@ -204,15 +198,12 @@ impl ScitadelServer {
         #[schemars(description = "Output directory (optional, defaults to .scitadel/papers/)")]
         output_dir: Option<String>,
     ) -> Result<String, String> {
-        tools::download_paper_tool(
-            paper_id.as_deref(),
-            doi.as_deref(),
-            output_dir.as_deref(),
-        )
-        .await
+        tools::download_paper_tool(paper_id.as_deref(), doi.as_deref(), output_dir.as_deref()).await
     }
 
-    #[tool(description = "Extract the text from an already-downloaded paper's PDF or HTML. Call download_paper first.")]
+    #[tool(
+        description = "Extract the text from an already-downloaded paper's PDF or HTML. Call download_paper first."
+    )]
     async fn read_paper(
         &self,
         #[tool(param)]
@@ -243,9 +234,7 @@ impl ScitadelServer {
 impl ServerHandler for ScitadelServer {
     fn get_info(&self) -> ServerInfo {
         ServerInfo {
-            instructions: Some(
-                "Scitadel: scientific literature retrieval and assessment".into(),
-            ),
+            instructions: Some("Scitadel: scientific literature retrieval and assessment".into()),
             capabilities: ServerCapabilities::builder().enable_tools().build(),
             ..Default::default()
         }

--- a/crates/scitadel-mcp/src/tools.rs
+++ b/crates/scitadel-mcp/src/tools.rs
@@ -13,7 +13,7 @@ use scitadel_core::ports::{
     AssessmentRepository, PaperRepository, QuestionRepository, SearchRepository,
 };
 use scitadel_db::sqlite::Database;
-use scitadel_scoring::{build_user_prompt, SCORING_SYSTEM_PROMPT};
+use scitadel_scoring::{SCORING_SYSTEM_PROMPT, build_user_prompt};
 
 fn open_db() -> Result<Database, String> {
     let config = load_config();
@@ -48,7 +48,9 @@ pub async fn search_tool(
         );
 
         if query.is_none() {
-            let terms = q_repo.get_terms(question.id.as_str()).map_err(|e| e.to_string())?;
+            let terms = q_repo
+                .get_terms(question.id.as_str())
+                .map_err(|e| e.to_string())?;
             if terms.is_empty() {
                 return Err(format!(
                     "No search terms linked to question '{}'.",
@@ -90,7 +92,9 @@ pub async fn search_tool(
     let (paper_repo, search_repo, _, _, _) = db.repositories();
 
     let id_remap = paper_repo.save_many(&papers).map_err(|e| e.to_string())?;
-    search_repo.save(&search_record).map_err(|e| e.to_string())?;
+    search_repo
+        .save(&search_record)
+        .map_err(|e| e.to_string())?;
 
     for sr in &mut search_results {
         sr.search_id = search_record.id.clone();
@@ -126,7 +130,9 @@ pub async fn search_tool(
 pub fn list_searches_tool(limit: i64) -> Result<String, String> {
     let db = open_db()?;
     let (_, search_repo, _, _, _) = db.repositories();
-    let searches = search_repo.list_searches(limit).map_err(|e| e.to_string())?;
+    let searches = search_repo
+        .list_searches(limit)
+        .map_err(|e| e.to_string())?;
 
     if searches.is_empty() {
         return Ok("No search history found.".into());
@@ -183,7 +189,13 @@ pub fn get_papers_tool(search_id: &str) -> Result<String, String> {
     )];
 
     for (i, p) in papers.iter().enumerate() {
-        let authors = p.authors.iter().take(3).cloned().collect::<Vec<_>>().join("; ");
+        let authors = p
+            .authors
+            .iter()
+            .take(3)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join("; ");
         let authors_suffix = if p.authors.len() > 3 {
             format!(" et al. ({} total)", p.authors.len())
         } else {
@@ -259,7 +271,10 @@ pub fn create_question_tool(text: &str, description: &str) -> Result<String, Str
     question.description = description.to_string();
     q_repo.save_question(&question).map_err(|e| e.to_string())?;
 
-    Ok(format!("Question created: {}\nText: {text}", question.id.short()))
+    Ok(format!(
+        "Question created: {}\nText: {text}",
+        question.id.short()
+    ))
 }
 
 pub fn list_questions_tool() -> Result<String, String> {
@@ -382,7 +397,10 @@ pub fn get_assessments_tool(
                 .get(a.paper_id.as_str())
                 .ok()
                 .flatten()
-                .map_or_else(|| "Unknown".into(), |p| p.title[..p.title.len().min(50)].to_string());
+                .map_or_else(
+                    || "Unknown".into(),
+                    |p| p.title[..p.title.len().min(50)].to_string(),
+                );
             format!(
                 "Score: {:.2}  Paper: {}  Assessor: {}  {}\n  Reasoning: {}",
                 a.score,
@@ -442,9 +460,7 @@ pub fn save_assessment_tool(
     reasoning: &str,
 ) -> Result<String, String> {
     if !(0.0..=1.0).contains(&score) {
-        return Err(format!(
-            "Score must be between 0.0 and 1.0, got {score:.2}"
-        ));
+        return Err(format!("Score must be between 0.0 and 1.0, got {score:.2}"));
     }
 
     let db = open_db()?;
@@ -489,10 +505,8 @@ pub async fn download_paper_tool(
         .map(std::path::PathBuf::from)
         .unwrap_or_else(|| config.papers_dir());
 
-    let downloader = scitadel_adapters::download::PaperDownloader::new(
-        config.openalex.api_key.clone(),
-        60.0,
-    );
+    let downloader =
+        scitadel_adapters::download::PaperDownloader::new(config.openalex.api_key.clone(), 60.0);
 
     let result = if let Some(pid) = paper_id {
         let db = open_db()?;
@@ -530,10 +544,7 @@ pub async fn download_paper_tool(
 /// Looks up the paper in the DB, locates its cached file under `papers_dir()`,
 /// and returns the extracted text. Truncated to `max_chars` (default 20_000) to
 /// keep responses manageable for the host LLM.
-pub async fn read_paper_tool(
-    paper_id: &str,
-    max_chars: Option<usize>,
-) -> Result<String, String> {
+pub async fn read_paper_tool(paper_id: &str, max_chars: Option<usize>) -> Result<String, String> {
     let config = load_config();
     let db = open_db()?;
     let (paper_repo, _, _, _, _) = db.repositories();
@@ -543,9 +554,7 @@ pub async fn read_paper_tool(
         .ok_or_else(|| format!("paper not found: {paper_id}"))?;
 
     let path = scitadel_adapters::download::find_cached_file(&paper, &config.papers_dir())
-        .ok_or_else(|| {
-            "paper not downloaded yet. Call download_paper first.".to_string()
-        })?;
+        .ok_or_else(|| "paper not downloaded yet. Call download_paper first.".to_string())?;
 
     let text = match path.extension().and_then(|e| e.to_str()) {
         Some("pdf") => {

--- a/crates/scitadel-mcp/src/tools.rs
+++ b/crates/scitadel-mcp/src/tools.rs
@@ -501,9 +501,7 @@ pub async fn download_paper_tool(
     output_dir: Option<&str>,
 ) -> Result<String, String> {
     let config = load_config();
-    let out_dir = output_dir
-        .map(std::path::PathBuf::from)
-        .unwrap_or_else(|| config.papers_dir());
+    let out_dir = output_dir.map_or_else(|| config.papers_dir(), std::path::PathBuf::from);
 
     let downloader =
         scitadel_adapters::download::PaperDownloader::new(config.openalex.api_key.clone(), 60.0);
@@ -616,20 +614,6 @@ fn html_to_text(html: &str) -> String {
     text
 }
 
-#[cfg(test)]
-mod tests {
-    use super::html_to_text;
-
-    #[test]
-    fn strips_tags_and_script() {
-        let html = "<html><body><p>Hello <b>world</b>.</p><script>var x=1;</script></body></html>";
-        let out = html_to_text(html);
-        assert!(out.contains("Hello"));
-        assert!(out.contains("world"));
-        assert!(!out.contains("var x"));
-    }
-}
-
 /// Prepare batch assessments for all papers in a search.
 ///
 /// Returns the rubric once, then a summary of each paper so the host LLM can
@@ -732,4 +716,18 @@ pub fn prepare_batch_assessments_tool(
     ));
 
     Ok(out.join("\n"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::html_to_text;
+
+    #[test]
+    fn strips_tags_and_script() {
+        let html = "<html><body><p>Hello <b>world</b>.</p><script>var x=1;</script></body></html>";
+        let out = html_to_text(html);
+        assert!(out.contains("Hello"));
+        assert!(out.contains("world"));
+        assert!(!out.contains("var x"));
+    }
 }

--- a/crates/scitadel-scoring/src/claude.rs
+++ b/crates/scitadel-scoring/src/claude.rs
@@ -178,7 +178,13 @@ pub fn build_user_prompt(paper: &Paper, question: &ResearchQuestion) -> String {
         format!("Context: {}", question.description)
     };
 
-    let authors = paper.authors.iter().take(5).cloned().collect::<Vec<_>>().join("; ");
+    let authors = paper
+        .authors
+        .iter()
+        .take(5)
+        .cloned()
+        .collect::<Vec<_>>()
+        .join("; ");
     let abstract_text = if paper.r#abstract.len() > 2000 {
         &paper.r#abstract[..2000]
     } else if paper.r#abstract.is_empty() {
@@ -192,7 +198,10 @@ pub fn build_user_prompt(paper: &Paper, question: &ResearchQuestion) -> String {
         .replace("{question_description}", &description)
         .replace("{title}", &paper.title)
         .replace("{authors}", &authors)
-        .replace("{year}", &paper.year.map_or_else(|| "N/A".into(), |y| y.to_string()))
+        .replace(
+            "{year}",
+            &paper.year.map_or_else(|| "N/A".into(), |y| y.to_string()),
+        )
         .replace("{journal}", paper.journal.as_deref().unwrap_or("N/A"))
         .replace("{abstract}", abstract_text)
 }
@@ -225,8 +234,17 @@ pub fn parse_scoring_response(text: &str) -> (f64, String) {
             .to_string();
         (score, reasoning)
     } else {
-        warn!("Failed to parse scoring response: {}", &text[..text.len().min(200)]);
-        (0.0, format!("Parse error. Raw response: {}", &text[..text.len().min(500)]))
+        warn!(
+            "Failed to parse scoring response: {}",
+            &text[..text.len().min(200)]
+        );
+        (
+            0.0,
+            format!(
+                "Parse error. Raw response: {}",
+                &text[..text.len().min(500)]
+            ),
+        )
     }
 }
 

--- a/crates/scitadel-scoring/src/cli.rs
+++ b/crates/scitadel-scoring/src/cli.rs
@@ -3,7 +3,7 @@ use tracing::debug;
 
 use scitadel_core::models::{Assessment, Paper, ResearchQuestion};
 
-use crate::claude::{build_user_prompt, parse_scoring_response, SCORING_SYSTEM_PROMPT};
+use crate::claude::{SCORING_SYSTEM_PROMPT, build_user_prompt, parse_scoring_response};
 use crate::error::ScoringError;
 use crate::scorer::Scorer;
 

--- a/crates/scitadel-scoring/src/lib.rs
+++ b/crates/scitadel-scoring/src/lib.rs
@@ -9,10 +9,10 @@ pub mod scorer;
 
 #[cfg(feature = "scoring")]
 pub use claude::{
-    build_user_prompt, parse_scoring_response, ClaudeScorer, ScoringConfig,
-    SCORING_SYSTEM_PROMPT, SCORING_USER_PROMPT,
+    ClaudeScorer, SCORING_SYSTEM_PROMPT, SCORING_USER_PROMPT, ScoringConfig, build_user_prompt,
+    parse_scoring_response,
 };
 #[cfg(feature = "scoring")]
 pub use cli::CliScorer;
 #[cfg(feature = "scoring")]
-pub use scorer::{create_scorer, Scorer, ScorerBackend, ScoringOptions};
+pub use scorer::{Scorer, ScorerBackend, ScoringOptions, create_scorer};

--- a/crates/scitadel-scoring/src/scorer.rs
+++ b/crates/scitadel-scoring/src/scorer.rs
@@ -18,11 +18,7 @@ pub trait Scorer: Send + Sync {
     /// Score multiple papers with optional progress callback.
     ///
     /// Default implementation calls `score_paper` in a loop.
-    async fn score_papers(
-        &self,
-        papers: &[Paper],
-        question: &ResearchQuestion,
-    ) -> Vec<Assessment> {
+    async fn score_papers(&self, papers: &[Paper], question: &ResearchQuestion) -> Vec<Assessment> {
         let mut assessments = Vec::new();
         let total = papers.len();
 

--- a/crates/scitadel-tui/src/app.rs
+++ b/crates/scitadel-tui/src/app.rs
@@ -167,8 +167,7 @@ impl App {
                     let count = self
                         .data
                         .load_papers_for_search(search_id)
-                        .map(|p| p.len())
-                        .unwrap_or(0);
+                        .map_or(0, |p| p.len());
                     if count > 0 {
                         *selected = (*selected + 1).min(count - 1);
                     }
@@ -210,12 +209,10 @@ impl App {
     fn handle_tab_key(&mut self, code: KeyCode) {
         match self.tab {
             Tab::Searches => {
-                let count = self.data.load_searches(100).map(|s| s.len()).unwrap_or(0);
+                let count = self.data.load_searches(100).map_or(0, |s| s.len());
                 match code {
-                    KeyCode::Char('j') | KeyCode::Down => {
-                        if count > 0 {
-                            self.search_selected = (self.search_selected + 1).min(count - 1);
-                        }
+                    KeyCode::Char('j') | KeyCode::Down if count > 0 => {
+                        self.search_selected = (self.search_selected + 1).min(count - 1);
                     }
                     KeyCode::Char('k') | KeyCode::Up => {
                         self.search_selected = self.search_selected.saturating_sub(1);
@@ -234,12 +231,10 @@ impl App {
                 }
             }
             Tab::Papers => {
-                let count = self.data.load_papers(1000, 0).map(|p| p.len()).unwrap_or(0);
+                let count = self.data.load_papers(1000, 0).map_or(0, |p| p.len());
                 match code {
-                    KeyCode::Char('j') | KeyCode::Down => {
-                        if count > 0 {
-                            self.paper_selected = (self.paper_selected + 1).min(count - 1);
-                        }
+                    KeyCode::Char('j') | KeyCode::Down if count > 0 => {
+                        self.paper_selected = (self.paper_selected + 1).min(count - 1);
                     }
                     KeyCode::Char('k') | KeyCode::Up => {
                         self.paper_selected = self.paper_selected.saturating_sub(1);
@@ -258,12 +253,10 @@ impl App {
                 }
             }
             Tab::Questions => {
-                let count = self.data.load_questions().map(|q| q.len()).unwrap_or(0);
+                let count = self.data.load_questions().map_or(0, |q| q.len());
                 match code {
-                    KeyCode::Char('j') | KeyCode::Down => {
-                        if count > 0 {
-                            self.question_selected = (self.question_selected + 1).min(count - 1);
-                        }
+                    KeyCode::Char('j') | KeyCode::Down if count > 0 => {
+                        self.question_selected = (self.question_selected + 1).min(count - 1);
                     }
                     KeyCode::Char('k') | KeyCode::Up => {
                         self.question_selected = self.question_selected.saturating_sub(1);

--- a/crates/scitadel-tui/src/app.rs
+++ b/crates/scitadel-tui/src/app.rs
@@ -3,20 +3,20 @@ use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use crossterm::event::{self, Event, KeyCode, KeyModifiers};
-use crossterm::terminal::{
-    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
-};
 use crossterm::execute;
+use crossterm::terminal::{
+    EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
+};
+use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
 use ratatui::layout::{Constraint, Direction, Layout};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Tabs;
-use ratatui::Terminal;
 use tokio::sync::mpsc;
 
 use crate::data::DataStore;
-use crate::tasks::{spawn_download_paper, Task, TaskUpdate};
+use crate::tasks::{Task, TaskUpdate, spawn_download_paper};
 use crate::views::{detail, papers, questions, searches, tasks as tasks_view};
 use crate::widgets::status_bar;
 
@@ -210,16 +210,11 @@ impl App {
     fn handle_tab_key(&mut self, code: KeyCode) {
         match self.tab {
             Tab::Searches => {
-                let count = self
-                    .data
-                    .load_searches(100)
-                    .map(|s| s.len())
-                    .unwrap_or(0);
+                let count = self.data.load_searches(100).map(|s| s.len()).unwrap_or(0);
                 match code {
                     KeyCode::Char('j') | KeyCode::Down => {
                         if count > 0 {
-                            self.search_selected =
-                                (self.search_selected + 1).min(count - 1);
+                            self.search_selected = (self.search_selected + 1).min(count - 1);
                         }
                     }
                     KeyCode::Char('k') | KeyCode::Up => {
@@ -239,16 +234,11 @@ impl App {
                 }
             }
             Tab::Papers => {
-                let count = self
-                    .data
-                    .load_papers(1000, 0)
-                    .map(|p| p.len())
-                    .unwrap_or(0);
+                let count = self.data.load_papers(1000, 0).map(|p| p.len()).unwrap_or(0);
                 match code {
                     KeyCode::Char('j') | KeyCode::Down => {
                         if count > 0 {
-                            self.paper_selected =
-                                (self.paper_selected + 1).min(count - 1);
+                            self.paper_selected = (self.paper_selected + 1).min(count - 1);
                         }
                     }
                     KeyCode::Char('k') | KeyCode::Up => {
@@ -268,16 +258,11 @@ impl App {
                 }
             }
             Tab::Questions => {
-                let count = self
-                    .data
-                    .load_questions()
-                    .map(|q| q.len())
-                    .unwrap_or(0);
+                let count = self.data.load_questions().map(|q| q.len()).unwrap_or(0);
                 match code {
                     KeyCode::Char('j') | KeyCode::Down => {
                         if count > 0 {
-                            self.question_selected =
-                                (self.question_selected + 1).min(count - 1);
+                            self.question_selected = (self.question_selected + 1).min(count - 1);
                         }
                     }
                     KeyCode::Char('k') | KeyCode::Up => {
@@ -329,10 +314,10 @@ fn draw(frame: &mut ratatui::Frame, app: &mut App) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(3),                // tabs
-            Constraint::Min(0),                   // content
-            Constraint::Length(task_panel_height),// task panel (0 when empty)
-            Constraint::Length(1),                // status bar
+            Constraint::Length(3),                 // tabs
+            Constraint::Min(0),                    // content
+            Constraint::Length(task_panel_height), // task panel (0 when empty)
+            Constraint::Length(1),                 // status bar
         ])
         .split(frame.area());
 
@@ -383,9 +368,7 @@ fn draw(frame: &mut ratatui::Frame, app: &mut App) {
     }
 
     let help_text = match &app.overlay {
-        Some(Overlay::PaperDetail { .. }) => {
-            "Esc/q: back | j/k: scroll | d/u: page | D: download"
-        }
+        Some(Overlay::PaperDetail { .. }) => "Esc/q: back | j/k: scroll | d/u: page | D: download",
         Some(Overlay::SearchPapers { .. }) => "Esc/q: back | j/k: navigate | Enter: open paper",
         None => "Tab/Shift-Tab: switch tabs | j/k: navigate | Enter: select | q: quit",
     };

--- a/crates/scitadel-tui/src/views/detail.rs
+++ b/crates/scitadel-tui/src/views/detail.rs
@@ -1,8 +1,8 @@
+use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
-use ratatui::Frame;
 
 use crate::data::DataStore;
 

--- a/crates/scitadel-tui/src/views/papers.rs
+++ b/crates/scitadel-tui/src/views/papers.rs
@@ -1,7 +1,7 @@
+use ratatui::Frame;
 use ratatui::layout::{Constraint, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table, TableState};
-use ratatui::Frame;
 
 use scitadel_core::models::Paper;
 
@@ -36,7 +36,9 @@ fn render_paper_table(
     title: &str,
 ) {
     if papers.is_empty() {
-        let block = Block::default().title(title.to_string()).borders(Borders::ALL);
+        let block = Block::default()
+            .title(title.to_string())
+            .borders(Borders::ALL);
         let empty = Paragraph::new("No papers found.").block(block);
         frame.render_widget(empty, area);
         return;
@@ -59,9 +61,7 @@ fn render_paper_table(
         .enumerate()
         .map(|(i, p)| {
             let authors = format_authors(&p.authors);
-            let year = p
-                .year
-                .map_or_else(|| "—".to_string(), |y| y.to_string());
+            let year = p.year.map_or_else(|| "—".to_string(), |y| y.to_string());
 
             Row::new(vec![
                 Cell::from((i + 1).to_string()),
@@ -81,7 +81,11 @@ fn render_paper_table(
 
     let table = Table::new(rows, widths)
         .header(header)
-        .block(Block::default().title(title.to_string()).borders(Borders::ALL))
+        .block(
+            Block::default()
+                .title(title.to_string())
+                .borders(Borders::ALL),
+        )
         .row_highlight_style(
             Style::default()
                 .bg(Color::DarkGray)
@@ -101,4 +105,3 @@ fn format_authors(authors: &[String]) -> String {
         _ => format!("{}, {} et al.", authors[0], authors[1]),
     }
 }
-

--- a/crates/scitadel-tui/src/views/questions.rs
+++ b/crates/scitadel-tui/src/views/questions.rs
@@ -35,7 +35,7 @@ pub fn draw(frame: &mut Frame, area: Rect, data: &DataStore, selected: usize) {
     let rows: Vec<Row<'_>> = questions
         .iter()
         .map(|q| {
-            let term_count = data.load_terms(q.id.as_str()).map(|t| t.len()).unwrap_or(0);
+            let term_count = data.load_terms(q.id.as_str()).map_or(0, |t| t.len());
 
             Row::new(vec![
                 Cell::from(q.id.short().to_string()),

--- a/crates/scitadel-tui/src/views/questions.rs
+++ b/crates/scitadel-tui/src/views/questions.rs
@@ -1,7 +1,7 @@
+use ratatui::Frame;
 use ratatui::layout::{Constraint, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table, TableState};
-use ratatui::Frame;
 
 use crate::data::DataStore;
 use crate::views::util::truncate;
@@ -35,10 +35,7 @@ pub fn draw(frame: &mut Frame, area: Rect, data: &DataStore, selected: usize) {
     let rows: Vec<Row<'_>> = questions
         .iter()
         .map(|q| {
-            let term_count = data
-                .load_terms(q.id.as_str())
-                .map(|t| t.len())
-                .unwrap_or(0);
+            let term_count = data.load_terms(q.id.as_str()).map(|t| t.len()).unwrap_or(0);
 
             Row::new(vec![
                 Cell::from(q.id.short().to_string()),
@@ -73,4 +70,3 @@ pub fn draw(frame: &mut Frame, area: Rect, data: &DataStore, selected: usize) {
     state.select(Some(selected));
     frame.render_stateful_widget(table, area, &mut state);
 }
-

--- a/crates/scitadel-tui/src/views/searches.rs
+++ b/crates/scitadel-tui/src/views/searches.rs
@@ -1,7 +1,7 @@
+use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::widgets::{Block, Borders, Cell, Row, Table, TableState};
-use ratatui::Frame;
 
 use scitadel_core::models::SourceStatus;
 
@@ -12,11 +12,11 @@ pub fn draw(frame: &mut Frame, area: Rect, data: &DataStore, selected: usize) {
     let searches = data.load_searches(100).unwrap_or_default();
 
     if searches.is_empty() {
-        let block = Block::default()
-            .title(" Searches ")
-            .borders(Borders::ALL);
-        let empty = ratatui::widgets::Paragraph::new("No searches yet. Run `scitadel search` to get started.")
-            .block(block);
+        let block = Block::default().title(" Searches ").borders(Borders::ALL);
+        let empty = ratatui::widgets::Paragraph::new(
+            "No searches yet. Run `scitadel search` to get started.",
+        )
+        .block(block);
         frame.render_widget(empty, area);
         return;
     }
@@ -75,4 +75,3 @@ pub fn draw(frame: &mut Frame, area: Rect, data: &DataStore, selected: usize) {
     state.select(Some(selected));
     frame.render_stateful_widget(table, area, &mut state);
 }
-

--- a/crates/scitadel-tui/src/views/tasks.rs
+++ b/crates/scitadel-tui/src/views/tasks.rs
@@ -1,8 +1,8 @@
+use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, List, ListItem};
-use ratatui::Frame;
 
 use crate::tasks::{Task, TaskKind, TaskStatus};
 use crate::views::util::truncate;
@@ -19,8 +19,7 @@ pub fn panel_height(tasks: &[Task]) -> u16 {
 
 pub fn draw(frame: &mut Frame, area: Rect, tasks: &[Task]) {
     let items: Vec<ListItem<'_>> = tasks.iter().map(render_row).collect();
-    let list = List::new(items)
-        .block(Block::default().title(" Tasks ").borders(Borders::ALL));
+    let list = List::new(items).block(Block::default().title(" Tasks ").borders(Borders::ALL));
     frame.render_widget(list, area);
 }
 
@@ -44,10 +43,7 @@ fn render_row(task: &Task) -> ListItem<'_> {
             access,
             path,
         } => {
-            let name = path
-                .file_name()
-                .and_then(|n| n.to_str())
-                .unwrap_or("saved");
+            let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("saved");
             format!("{format} · {access} · {name}")
         }
         TaskStatus::Failed(e) => format!("failed: {}", truncate(e, 60)),
@@ -60,10 +56,7 @@ fn render_row(task: &Task) -> ListItem<'_> {
         ),
         Span::raw(title),
         Span::raw("  "),
-        Span::styled(
-            format!("[{ref_id}] "),
-            Style::default().fg(Color::Blue),
-        ),
+        Span::styled(format!("[{ref_id}] "), Style::default().fg(Color::Blue)),
         Span::styled(status_tail, Style::default().fg(Color::DarkGray)),
     ]))
 }

--- a/crates/scitadel-tui/src/widgets/status_bar.rs
+++ b/crates/scitadel-tui/src/widgets/status_bar.rs
@@ -1,7 +1,7 @@
+use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Style};
 use ratatui::widgets::Paragraph;
-use ratatui::Frame;
 
 pub fn draw(frame: &mut Frame, area: Rect, help_text: &str) {
     let bar = Paragraph::new(help_text).style(Style::default().fg(Color::DarkGray));


### PR DESCRIPTION
## Summary
- Adds 0.1.0 entry to CHANGELOG summarizing what ships in the initial Rust release
- Closes the existing milestone 0.1.0 scope

## Next steps once merged
1. Annotated tag: \`git tag -a 0.1.0 -m 'scitadel 0.1.0' main && git push origin 0.1.0\`
2. GitHub Release from tag with notes extracted from CHANGELOG
3. Close milestone 0.1.0 on GitHub

Binaries (#64) and crates.io publish (#65) are tracked separately under 0.2.0.

## Test plan
- [x] CHANGELOG section renders correctly
- [x] \`cargo build --workspace\` green locally
- [ ] CI: Lint + Test (ubuntu-latest) + Test (macos-latest) pass on this PR