### PR TITLE
feat(tui): institutional-access hint on paywalled downloads

### DIFF
--- a/crates/scitadel-adapters/src/download.rs
+++ b/crates/scitadel-adapters/src/download.rs
@@ -54,6 +54,10 @@ pub struct DownloadResult {
     pub source: String,
     pub bytes: usize,
     pub access: AccessStatus,
+    /// Canonical publisher/landing URL. Populated for publisher HTML and
+    /// last-resort URL downloads so a paywall result can point the user at
+    /// the live page (institutional IPs may grant access).
+    pub publisher_url: Option<String>,
 }
 
 /// Heuristic: classify publisher HTML as full-text / abstract / paywall.
@@ -297,6 +301,7 @@ impl PaperDownloader {
             source: "unpaywall".into(),
             bytes: bytes.len(),
             access: AccessStatus::FullText,
+            publisher_url: None,
         })
     }
 
@@ -343,6 +348,7 @@ impl PaperDownloader {
             source: "publisher".into(),
             bytes: bytes.len(),
             access,
+            publisher_url: Some(doi_url),
         })
     }
 
@@ -385,6 +391,7 @@ impl PaperDownloader {
             source: "arxiv".into(),
             bytes: bytes.len(),
             access: AccessStatus::FullText,
+            publisher_url: None,
         })
     }
 
@@ -475,6 +482,11 @@ impl PaperDownloader {
             source: "openalex".into(),
             bytes: bytes.len(),
             access,
+            publisher_url: if matches!(format, DownloadFormat::Html) {
+                Some(pdf_url)
+            } else {
+                None
+            },
         })
     }
 
@@ -519,6 +531,7 @@ impl PaperDownloader {
             source: "url".into(),
             bytes: bytes.len(),
             access,
+            publisher_url: Some(url.to_string()),
         })
     }
 }

--- a/crates/scitadel-cli/src/commands.rs
+++ b/crates/scitadel-cli/src/commands.rs
@@ -47,7 +47,12 @@ pub fn tui() -> Result<()> {
     let config = load_config();
     let email = config.openalex.api_key.clone();
     let papers_dir = config.papers_dir();
-    scitadel_tui::run(&config.db_path, email, papers_dir)?;
+    scitadel_tui::run(
+        &config.db_path,
+        email,
+        papers_dir,
+        config.ui.show_institutional_hint,
+    )?;
     Ok(())
 }
 

--- a/crates/scitadel-core/src/config.rs
+++ b/crates/scitadel-core/src/config.rs
@@ -98,6 +98,24 @@ fn default_scoring_concurrency() -> u32 {
     5
 }
 
+/// UI/UX preferences (TUI-only today; extensible for future surfaces).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UiConfig {
+    /// When a download lands on a paywalled publisher page, show the live URL
+    /// plus a note that an institutional IP range (e.g. university VPN) may
+    /// grant access. Disable for headless / CI runs.
+    #[serde(default = "default_true")]
+    pub show_institutional_hint: bool,
+}
+
+impl Default for UiConfig {
+    fn default() -> Self {
+        Self {
+            show_institutional_hint: true,
+        }
+    }
+}
+
 /// Top-level application configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
@@ -120,6 +138,8 @@ pub struct Config {
     pub epo: EpoConfig,
     #[serde(default)]
     pub chat: ChatConfig,
+    #[serde(default)]
+    pub ui: UiConfig,
 }
 
 fn default_sources() -> Vec<String> {
@@ -155,6 +175,7 @@ impl Default for Config {
             lens: SourceConfig::default(),
             epo: EpoConfig::default(),
             chat: ChatConfig::default(),
+            ui: UiConfig::default(),
         }
     }
 }

--- a/crates/scitadel-tui/src/app.rs
+++ b/crates/scitadel-tui/src/app.rs
@@ -77,13 +77,19 @@ pub struct App {
     pub tasks: Vec<Task>,
     pub unpaywall_email: String,
     pub papers_dir: PathBuf,
+    pub show_institutional_hint: bool,
 
     task_tx: mpsc::UnboundedSender<TaskUpdate>,
     task_rx: mpsc::UnboundedReceiver<TaskUpdate>,
 }
 
 impl App {
-    fn new(data: DataStore, unpaywall_email: String, papers_dir: PathBuf) -> Self {
+    fn new(
+        data: DataStore,
+        unpaywall_email: String,
+        papers_dir: PathBuf,
+        show_institutional_hint: bool,
+    ) -> Self {
         let (task_tx, task_rx) = mpsc::unbounded_channel();
         Self {
             tab: Tab::Searches,
@@ -96,6 +102,7 @@ impl App {
             tasks: Vec::new(),
             unpaywall_email,
             papers_dir,
+            show_institutional_hint,
             task_tx,
             task_rx,
         }
@@ -268,9 +275,14 @@ impl App {
     }
 }
 
-pub fn run(db_path: &Path, unpaywall_email: String, papers_dir: PathBuf) -> Result<()> {
+pub fn run(
+    db_path: &Path,
+    unpaywall_email: String,
+    papers_dir: PathBuf,
+    show_institutional_hint: bool,
+) -> Result<()> {
     let data = DataStore::open(db_path)?;
-    let mut app = App::new(data, unpaywall_email, papers_dir);
+    let mut app = App::new(data, unpaywall_email, papers_dir, show_institutional_hint);
 
     enable_raw_mode()?;
     let mut stdout = io::stdout();
@@ -357,7 +369,7 @@ fn draw(frame: &mut ratatui::Frame, app: &mut App) {
     }
 
     if task_panel_height > 0 {
-        tasks_view::draw(frame, chunks[2], &app.tasks);
+        tasks_view::draw(frame, chunks[2], &app.tasks, app.show_institutional_hint);
     }
 
     let help_text = match &app.overlay {

--- a/crates/scitadel-tui/src/tasks.rs
+++ b/crates/scitadel-tui/src/tasks.rs
@@ -26,6 +26,9 @@ pub enum TaskStatus {
         path: PathBuf,
         format: DownloadFormat,
         access: AccessStatus,
+        /// Live publisher URL if the download went through one; used by the
+        /// view to show a "try publisher" hint when the result is paywalled.
+        publisher_url: Option<String>,
     },
     Failed(String),
 }
@@ -75,6 +78,7 @@ pub fn spawn_download_paper(
                 path: result.path,
                 format: result.format,
                 access: result.access,
+                publisher_url: result.publisher_url,
             },
             Err(e) => TaskStatus::Failed(e.to_string()),
         };

--- a/crates/scitadel-tui/src/views/tasks.rs
+++ b/crates/scitadel-tui/src/views/tasks.rs
@@ -3,6 +3,7 @@ use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, List, ListItem};
+use scitadel_adapters::download::AccessStatus;
 
 use crate::tasks::{Task, TaskKind, TaskStatus};
 use crate::views::util::truncate;
@@ -17,13 +18,16 @@ pub fn panel_height(tasks: &[Task]) -> u16 {
     }
 }
 
-pub fn draw(frame: &mut Frame, area: Rect, tasks: &[Task]) {
-    let items: Vec<ListItem<'_>> = tasks.iter().map(render_row).collect();
+pub fn draw(frame: &mut Frame, area: Rect, tasks: &[Task], show_institutional_hint: bool) {
+    let items: Vec<ListItem<'_>> = tasks
+        .iter()
+        .map(|t| render_row(t, show_institutional_hint))
+        .collect();
     let list = List::new(items).block(Block::default().title(" Tasks ").borders(Borders::ALL));
     frame.render_widget(list, area);
 }
 
-fn render_row(task: &Task) -> ListItem<'_> {
+fn render_row(task: &Task, show_institutional_hint: bool) -> ListItem<'_> {
     let (icon, color) = match &task.status {
         TaskStatus::Queued => ("…", Color::DarkGray),
         TaskStatus::Running => ("◐", Color::Yellow),
@@ -35,19 +39,7 @@ fn render_row(task: &Task) -> ListItem<'_> {
         TaskKind::Download { title, ref_id } => (truncate(title, 55), ref_id.as_str()),
     };
 
-    let status_tail = match &task.status {
-        TaskStatus::Queued => "queued".to_string(),
-        TaskStatus::Running => "downloading…".to_string(),
-        TaskStatus::Done {
-            format,
-            access,
-            path,
-        } => {
-            let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("saved");
-            format!("{format} · {access} · {name}")
-        }
-        TaskStatus::Failed(e) => format!("failed: {}", truncate(e, 60)),
-    };
+    let status_tail = status_tail_text(&task.status, show_institutional_hint);
 
     ListItem::new(Line::from(vec![
         Span::styled(
@@ -59,4 +51,80 @@ fn render_row(task: &Task) -> ListItem<'_> {
         Span::styled(format!("[{ref_id}] "), Style::default().fg(Color::Blue)),
         Span::styled(status_tail, Style::default().fg(Color::DarkGray)),
     ]))
+}
+
+fn status_tail_text(status: &TaskStatus, show_institutional_hint: bool) -> String {
+    match status {
+        TaskStatus::Queued => "queued".to_string(),
+        TaskStatus::Running => "downloading…".to_string(),
+        TaskStatus::Done {
+            format,
+            access,
+            path,
+            publisher_url,
+        } => {
+            let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("saved");
+            // On paywall, tell the user where to get the live page — an
+            // institutional IP range will often grant access that the
+            // headless fetcher can't.
+            if *access == AccessStatus::Paywall
+                && show_institutional_hint
+                && let Some(url) = publisher_url
+            {
+                format!(
+                    "{format} · {access} · try {url} (institutional IP may grant access) · {name}"
+                )
+            } else {
+                format!("{format} · {access} · {name}")
+            }
+        }
+        TaskStatus::Failed(e) => format!("failed: {}", truncate(e, 60)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use scitadel_adapters::download::DownloadFormat;
+
+    use super::*;
+
+    #[test]
+    fn paywall_with_hint_includes_url() {
+        let status = TaskStatus::Done {
+            path: PathBuf::from("foo.html"),
+            format: DownloadFormat::Html,
+            access: AccessStatus::Paywall,
+            publisher_url: Some("https://doi.org/10.1234/x".into()),
+        };
+        let text = status_tail_text(&status, true);
+        assert!(text.contains("https://doi.org/10.1234/x"));
+        assert!(text.contains("institutional IP may grant access"));
+    }
+
+    #[test]
+    fn paywall_without_hint_omits_url() {
+        let status = TaskStatus::Done {
+            path: PathBuf::from("foo.html"),
+            format: DownloadFormat::Html,
+            access: AccessStatus::Paywall,
+            publisher_url: Some("https://doi.org/10.1234/x".into()),
+        };
+        let text = status_tail_text(&status, false);
+        assert!(!text.contains("https://doi.org/10.1234/x"));
+        assert!(text.contains("paywall"));
+    }
+
+    #[test]
+    fn full_text_never_shows_hint() {
+        let status = TaskStatus::Done {
+            path: PathBuf::from("foo.pdf"),
+            format: DownloadFormat::Pdf,
+            access: AccessStatus::FullText,
+            publisher_url: Some("https://example.org".into()),
+        };
+        let text = status_tail_text(&status, true);
+        assert!(!text.contains("institutional IP"));
+    }
 }


### PR DESCRIPTION
Closes #50.

## Summary
- When the download chain lands on a paywalled publisher page, the TUI task panel now shows the live publisher URL + a hint that an institutional IP range may grant access.
- \`DownloadResult\` gains \`publisher_url: Option<String>\`; piped through \`TaskStatus::Done\` into the view.
- New \`UiConfig.show_institutional_hint\` (default \`true\`) under \`[ui]\` in config.
- Three unit tests cover the hint-on, hint-off, and non-paywall paths.

## Test plan
- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo test --workspace\` passes (TUI suite green)