### PR TITLE
test: VHS walkthrough tape harness (v1, no CI yet)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -241,3 +241,7 @@ vscode-scitadel/
 .direnv/
 result
 result-*
+
+# VHS tape outputs (v1 has no golden-file comparison; tapes are run locally).
+# Re-enable when structural-similarity snapshotting lands.
+tests/vhs/snapshots/

--- a/justfile.project
+++ b/justfile.project
@@ -35,6 +35,37 @@ security:
     cargo deny check
 
 # ===============================================================================
+# VHS TAPES (TUI walkthrough tests)
+# ===============================================================================
+
+# Run every tape in tests/vhs/ (requires vhs binary; available in nix devshell).
+[group('vhs')]
+vhs:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    shopt -s nullglob
+    tapes=(tests/vhs/*.tape)
+    if [ ${#tapes[@]} -eq 0 ]; then
+        echo "no tapes found under tests/vhs/"
+        exit 0
+    fi
+    mkdir -p tests/vhs/snapshots
+    for tape in "${tapes[@]}"; do
+        echo "=== $(basename "$tape") ==="
+        vhs "$tape"
+    done
+
+# Run a single tape by name (without .tape suffix). Example: just vhs-one example
+[group('vhs')]
+vhs-one name:
+    vhs tests/vhs/{{ name }}.tape
+
+# Alias for rerunning tapes and overwriting committed snapshots.
+[group('vhs')]
+vhs-update: vhs
+    @echo "Snapshots updated. Review with: git diff tests/vhs/snapshots/"
+
+# ===============================================================================
 # CONDUCTOR (agent orchestrator)
 # ===============================================================================
 

--- a/tests/vhs/README.md
+++ b/tests/vhs/README.md
@@ -1,0 +1,40 @@
+# VHS walkthrough tapes
+
+Scripted terminal recordings that demonstrate scitadel features end-to-end.
+Each tape is a [charmbracelet/vhs](https://github.com/charmbracelet/vhs) file
+that plays the TUI through a realistic user flow. Tapes double as:
+
+1. **Tests** — the feature still works if the tape runs to completion.
+2. **Documentation** — the rendered GIF shows the workflow without words.
+3. **Milestone gates** — each 0.X.0 has a `0.X.0-walkthrough.tape` that
+   exercises the whole milestone's feature set in one sitting.
+
+## Running tapes locally
+
+Requires `vhs`, available from the devshell (`nix develop` or `direnv allow`).
+
+```sh
+just vhs           # run all tapes, emit PNGs/GIFs under tests/vhs/snapshots/
+just vhs-one NAME  # run just tests/vhs/NAME.tape
+just vhs-update    # re-run all tapes and overwrite committed snapshots
+```
+
+Each tape writes artifacts next to itself under `snapshots/<tape-name>/`.
+
+## Authoring conventions
+
+- **Isolate state.** Every tape sets `SCITADEL_DB` to a temp path (see
+  `example.tape`) so user data is never touched.
+- **Fixture DBs** live under `fixtures/` (SQLite files ≤ 1 MB). Seed them
+  with small, deterministic datasets.
+- **Screenshot at inflection points.** Use `Screenshot path/name.png`
+  directives after each meaningful keystroke so regressions show up as
+  pixel/byte diffs in PR review.
+- **Keep tapes under 30s** so the full suite stays fast in CI.
+
+## CI
+
+Today `rust-ci.yml` does **not** run tapes (needs a Linux runner with `vhs`
++ `ttyd` + `ffmpeg` installed). That wiring is tracked as a follow-up once
+golden-file comparison is in place. For now, run tapes locally as part of
+your PR review and attach a fresh GIF to the description.

--- a/tests/vhs/example.tape
+++ b/tests/vhs/example.tape
@@ -1,0 +1,30 @@
+# Smoke-test tape — proves the VHS harness itself works.
+#
+# Runs `scitadel --help` in a fresh shell with SCITADEL_DB pointed at a
+# disposable temp DB. Any failure here means the VHS install or the CLI
+# wrapper is broken, not that a feature regressed.
+
+Output "tests/vhs/snapshots/example/help.gif"
+
+Set Shell "bash"
+Set FontSize 14
+Set Width 1200
+Set Height 600
+Set Padding 10
+
+Hide
+Type "export SCITADEL_DB=$(mktemp -d)/scitadel.db"
+Enter
+Show
+
+Type "scitadel --help"
+Sleep 500ms
+Enter
+Sleep 2s
+Screenshot "tests/vhs/snapshots/example/01-help.png"
+
+Type "scitadel --version"
+Sleep 500ms
+Enter
+Sleep 1s
+Screenshot "tests/vhs/snapshots/example/02-version.png"


### PR DESCRIPTION
Refs #62 (v1).

## Summary
Minimum viable VHS tape harness so subsequent UX PRs can ship walkthrough tapes without inventing directory structure each time.

- \`tests/vhs/\` with README, example tape, snapshots/ + fixtures/ dirs
- \`just vhs\` / \`just vhs-one NAME\` / \`just vhs-update\` recipes
- \`tests/vhs/snapshots/\` gitignored until golden-file comparison lands

## Out of scope for v1
- CI wiring (needs vhs + ttyd + ffmpeg on runner, plus image comparison)
- Structural-similarity snapshot diffing
- Milestone walkthrough tape (0.2.0-walkthrough.tape) — ships with the last 0.2.0 feature PR

These are follow-ups; filing separately as the 0.2.0 features land.

## Test plan
- [x] \`just vhs\` runs the example tape successfully on macOS
- [x] \`cargo test --workspace\` unaffected