### PR TITLE
feat(tui): star papers — per-reader state (v1)

### DIFF
--- a/crates/scitadel-cli/src/commands.rs
+++ b/crates/scitadel-cli/src/commands.rs
@@ -47,11 +47,13 @@ pub fn tui() -> Result<()> {
     let config = load_config();
     let email = config.openalex.api_key.clone();
     let papers_dir = config.papers_dir();
+    let reader = std::env::var("USER").unwrap_or_else(|_| "unknown".into());
     scitadel_tui::run(
         &config.db_path,
         email,
         papers_dir,
         config.ui.show_institutional_hint,
+        reader,
     )?;
     Ok(())
 }

--- a/crates/scitadel-db/migrations/004_paper_state.sql
+++ b/crates/scitadel-db/migrations/004_paper_state.sql
@@ -1,0 +1,21 @@
+-- Migration 004: per-reader paper state (star / to-read / read).
+--
+-- Single row per (paper, reader). Reader defaults to $USER locally; MCP
+-- clients pass an explicit identity string. No users table in v1 — we
+-- upgrade to stable UUIDs when Dolt sync lands (Phase 5).
+
+CREATE TABLE IF NOT EXISTS paper_state (
+    paper_id   TEXT NOT NULL REFERENCES papers(id),
+    reader     TEXT NOT NULL,
+    starred    INTEGER NOT NULL DEFAULT 0,   -- SQLite bool
+    to_read    INTEGER NOT NULL DEFAULT 0,
+    read_at    TEXT,                          -- ISO-8601; NULL = unread
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (paper_id, reader)
+);
+
+CREATE INDEX IF NOT EXISTS idx_paper_state_reader ON paper_state(reader);
+CREATE INDEX IF NOT EXISTS idx_paper_state_starred ON paper_state(starred) WHERE starred = 1;
+CREATE INDEX IF NOT EXISTS idx_paper_state_to_read ON paper_state(to_read) WHERE to_read = 1;
+
+INSERT OR IGNORE INTO schema_version (version, applied_at) VALUES (4, datetime('now'));

--- a/crates/scitadel-db/src/sqlite/migrations.rs
+++ b/crates/scitadel-db/src/sqlite/migrations.rs
@@ -5,8 +5,14 @@ use crate::error::DbError;
 const MIGRATION_001: &str = include_str!("../../migrations/001_initial.sql");
 const MIGRATION_002: &str = include_str!("../../migrations/002_citations.sql");
 const MIGRATION_003: &str = include_str!("../../migrations/003_full_text.sql");
+const MIGRATION_004: &str = include_str!("../../migrations/004_paper_state.sql");
 
-const MIGRATIONS: &[(i64, &str)] = &[(1, MIGRATION_001), (2, MIGRATION_002), (3, MIGRATION_003)];
+const MIGRATIONS: &[(i64, &str)] = &[
+    (1, MIGRATION_001),
+    (2, MIGRATION_002),
+    (3, MIGRATION_003),
+    (4, MIGRATION_004),
+];
 
 /// Run all pending migrations, skipping already-applied ones.
 pub fn run_migrations(conn: &Connection) -> Result<(), DbError> {
@@ -73,6 +79,7 @@ mod tests {
         assert!(tables.contains(&"assessments".to_string()));
         assert!(tables.contains(&"citations".to_string()));
         assert!(tables.contains(&"snowball_runs".to_string()));
+        assert!(tables.contains(&"paper_state".to_string()));
         assert!(tables.contains(&"schema_version".to_string()));
     }
 }

--- a/crates/scitadel-db/src/sqlite/mod.rs
+++ b/crates/scitadel-db/src/sqlite/mod.rs
@@ -1,6 +1,7 @@
 mod assessments;
 mod citations;
 mod migrations;
+mod paper_state;
 mod papers;
 mod questions;
 mod searches;
@@ -8,6 +9,7 @@ mod searches;
 pub use assessments::SqliteAssessmentRepository;
 pub use citations::SqliteCitationRepository;
 pub use migrations::run_migrations;
+pub use paper_state::{PaperState, SqlitePaperStateRepository};
 pub use papers::SqlitePaperRepository;
 pub use questions::SqliteQuestionRepository;
 pub use searches::SqliteSearchRepository;

--- a/crates/scitadel-db/src/sqlite/paper_state.rs
+++ b/crates/scitadel-db/src/sqlite/paper_state.rs
@@ -1,0 +1,154 @@
+//! Per-reader paper state (star / to-read / read). Thin CRUD over the
+//! `paper_state` table; upserts are idempotent on (paper_id, reader).
+
+use rusqlite::params;
+
+use crate::error::DbError;
+use crate::sqlite::Database;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PaperState {
+    pub paper_id: String,
+    pub reader: String,
+    pub starred: bool,
+    pub to_read: bool,
+    /// ISO-8601 timestamp when the paper was marked read, or `None` if unread.
+    pub read_at: Option<String>,
+}
+
+#[derive(Clone)]
+pub struct SqlitePaperStateRepository {
+    db: Database,
+}
+
+impl SqlitePaperStateRepository {
+    pub fn new(db: Database) -> Self {
+        Self { db }
+    }
+
+    /// Load the state for one paper, or `None` if nothing is recorded yet.
+    pub fn get(&self, paper_id: &str, reader: &str) -> Result<Option<PaperState>, DbError> {
+        let conn = self.db.conn()?;
+        let mut stmt = conn.prepare(
+            "SELECT paper_id, reader, starred, to_read, read_at
+             FROM paper_state
+             WHERE paper_id = ?1 AND reader = ?2",
+        )?;
+        let mut rows = stmt.query(params![paper_id, reader])?;
+        if let Some(row) = rows.next()? {
+            Ok(Some(PaperState {
+                paper_id: row.get(0)?,
+                reader: row.get(1)?,
+                starred: row.get::<_, i64>(2)? != 0,
+                to_read: row.get::<_, i64>(3)? != 0,
+                read_at: row.get::<_, Option<String>>(4)?,
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Upsert full state for a (paper, reader) pair.
+    pub fn set(&self, state: &PaperState) -> Result<(), DbError> {
+        let conn = self.db.conn()?;
+        let now = chrono::Utc::now().to_rfc3339();
+        conn.execute(
+            "INSERT INTO paper_state (paper_id, reader, starred, to_read, read_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+             ON CONFLICT(paper_id, reader) DO UPDATE SET
+                 starred    = excluded.starred,
+                 to_read    = excluded.to_read,
+                 read_at    = excluded.read_at,
+                 updated_at = excluded.updated_at",
+            params![
+                state.paper_id,
+                state.reader,
+                i64::from(state.starred),
+                i64::from(state.to_read),
+                state.read_at,
+                now,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Toggle `starred` and return the new value. Creates the row if needed.
+    pub fn toggle_starred(&self, paper_id: &str, reader: &str) -> Result<bool, DbError> {
+        let existing = self.get(paper_id, reader)?;
+        let new_state = match existing {
+            Some(mut s) => {
+                s.starred = !s.starred;
+                s
+            }
+            None => PaperState {
+                paper_id: paper_id.into(),
+                reader: reader.into(),
+                starred: true,
+                to_read: false,
+                read_at: None,
+            },
+        };
+        self.set(&new_state)?;
+        Ok(new_state.starred)
+    }
+
+    /// Load starred paper IDs for one reader as a `HashSet`.
+    pub fn starred_ids(&self, reader: &str) -> Result<std::collections::HashSet<String>, DbError> {
+        let conn = self.db.conn()?;
+        let mut stmt =
+            conn.prepare("SELECT paper_id FROM paper_state WHERE reader = ?1 AND starred = 1")?;
+        let rows = stmt.query_map(params![reader], |row| row.get::<_, String>(0))?;
+        let mut out = std::collections::HashSet::new();
+        for r in rows {
+            out.insert(r?);
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fresh_db() -> Database {
+        let db = Database::open_in_memory().unwrap();
+        db.migrate().unwrap();
+        // Need a paper row to satisfy the FK.
+        let conn = db.conn().unwrap();
+        conn.execute(
+            "INSERT INTO papers (id, title, created_at, updated_at)
+             VALUES ('p1', 't', datetime('now'), datetime('now'))",
+            [],
+        )
+        .unwrap();
+        db
+    }
+
+    #[test]
+    fn toggle_starred_roundtrip() {
+        let db = fresh_db();
+        let repo = SqlitePaperStateRepository::new(db);
+        assert!(repo.toggle_starred("p1", "lars").unwrap());
+        assert!(!repo.toggle_starred("p1", "lars").unwrap());
+        assert!(repo.toggle_starred("p1", "lars").unwrap());
+        assert!(repo.get("p1", "lars").unwrap().is_some_and(|s| s.starred));
+    }
+
+    #[test]
+    fn different_readers_have_independent_state() {
+        let db = fresh_db();
+        let repo = SqlitePaperStateRepository::new(db);
+        repo.toggle_starred("p1", "lars").unwrap();
+        assert!(!repo.get("p1", "claude").unwrap().is_some_and(|s| s.starred));
+        assert!(repo.get("p1", "lars").unwrap().is_some_and(|s| s.starred));
+    }
+
+    #[test]
+    fn starred_ids_lists_only_starred() {
+        let db = fresh_db();
+        let repo = SqlitePaperStateRepository::new(db);
+        repo.toggle_starred("p1", "me").unwrap();
+        let ids = repo.starred_ids("me").unwrap();
+        assert!(ids.contains("p1"));
+    }
+}

--- a/crates/scitadel-tui/src/app.rs
+++ b/crates/scitadel-tui/src/app.rs
@@ -78,6 +78,8 @@ pub struct App {
     pub unpaywall_email: String,
     pub papers_dir: PathBuf,
     pub show_institutional_hint: bool,
+    pub reader: String,
+    pub starred: std::collections::HashSet<String>,
 
     task_tx: mpsc::UnboundedSender<TaskUpdate>,
     task_rx: mpsc::UnboundedReceiver<TaskUpdate>,
@@ -89,8 +91,10 @@ impl App {
         unpaywall_email: String,
         papers_dir: PathBuf,
         show_institutional_hint: bool,
+        reader: String,
     ) -> Self {
         let (task_tx, task_rx) = mpsc::unbounded_channel();
+        let starred = data.load_starred_ids(&reader).unwrap_or_default();
         Self {
             tab: Tab::Searches,
             running: true,
@@ -103,8 +107,21 @@ impl App {
             unpaywall_email,
             papers_dir,
             show_institutional_hint,
+            reader,
+            starred,
             task_tx,
             task_rx,
+        }
+    }
+
+    /// Toggle the starred state for a paper and refresh the cached set.
+    fn toggle_star(&mut self, paper_id: &str) {
+        if let Ok(now_starred) = self.data.toggle_starred(paper_id, &self.reader) {
+            if now_starred {
+                self.starred.insert(paper_id.to_string());
+            } else {
+                self.starred.remove(paper_id);
+            }
         }
     }
 
@@ -256,6 +273,14 @@ impl App {
                             });
                         }
                     }
+                    KeyCode::Char('s') => {
+                        if let Ok(papers) = self.data.load_papers(1000, 0)
+                            && let Some(paper) = papers.get(self.paper_selected)
+                        {
+                            let pid = paper.id.as_str().to_string();
+                            self.toggle_star(&pid);
+                        }
+                    }
                     _ => {}
                 }
             }
@@ -280,9 +305,16 @@ pub fn run(
     unpaywall_email: String,
     papers_dir: PathBuf,
     show_institutional_hint: bool,
+    reader: String,
 ) -> Result<()> {
     let data = DataStore::open(db_path)?;
-    let mut app = App::new(data, unpaywall_email, papers_dir, show_institutional_hint);
+    let mut app = App::new(
+        data,
+        unpaywall_email,
+        papers_dir,
+        show_institutional_hint,
+        reader,
+    );
 
     enable_raw_mode()?;
     let mut stdout = io::stdout();
@@ -357,11 +389,24 @@ fn draw(frame: &mut ratatui::Frame, app: &mut App) {
             search_id,
             selected,
         }) => {
-            papers::draw_for_search(frame, chunks[1], &app.data, search_id, *selected);
+            papers::draw_for_search(
+                frame,
+                chunks[1],
+                &app.data,
+                search_id,
+                *selected,
+                &app.starred,
+            );
         }
         None => match app.tab {
             Tab::Searches => searches::draw(frame, chunks[1], &app.data, app.search_selected),
-            Tab::Papers => papers::draw(frame, chunks[1], &app.data, app.paper_selected),
+            Tab::Papers => papers::draw(
+                frame,
+                chunks[1],
+                &app.data,
+                app.paper_selected,
+                &app.starred,
+            ),
             Tab::Questions => {
                 questions::draw(frame, chunks[1], &app.data, app.question_selected);
             }
@@ -372,10 +417,15 @@ fn draw(frame: &mut ratatui::Frame, app: &mut App) {
         tasks_view::draw(frame, chunks[2], &app.tasks, app.show_institutional_hint);
     }
 
-    let help_text = match &app.overlay {
-        Some(Overlay::PaperDetail { .. }) => "Esc/q: back | j/k: scroll | d/u: page | D: download",
-        Some(Overlay::SearchPapers { .. }) => "Esc/q: back | j/k: navigate | Enter: open paper",
-        None => "Tab/Shift-Tab: switch tabs | j/k: navigate | Enter: select | q: quit",
+    let help_text = match (&app.overlay, app.tab) {
+        (Some(Overlay::PaperDetail { .. }), _) => {
+            "Esc/q: back | j/k: scroll | d/u: page | D: download"
+        }
+        (Some(Overlay::SearchPapers { .. }), _) => {
+            "Esc/q: back | j/k: navigate | Enter: open paper"
+        }
+        (None, Tab::Papers) => "Tab: switch tabs | j/k: navigate | Enter: open | s: star | q: quit",
+        (None, _) => "Tab/Shift-Tab: switch tabs | j/k: navigate | Enter: select | q: quit",
     };
     status_bar::draw(frame, chunks[3], help_text);
 }

--- a/crates/scitadel-tui/src/data.rs
+++ b/crates/scitadel-tui/src/data.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::path::Path;
 
 use anyhow::{Context, Result};
@@ -6,7 +7,7 @@ use scitadel_core::models::{Assessment, Paper, ResearchQuestion, Search, SearchT
 use scitadel_core::ports::{
     AssessmentRepository, PaperRepository, QuestionRepository, SearchRepository,
 };
-use scitadel_db::sqlite::Database;
+use scitadel_db::sqlite::{Database, SqlitePaperStateRepository};
 
 /// Wrapper around the database that loads data for each TUI view.
 pub struct DataStore {
@@ -64,5 +65,15 @@ impl DataStore {
     ) -> Result<Vec<Assessment>> {
         let (_, _, _, a_repo, _) = self.db.repositories();
         Ok(a_repo.get_for_paper(paper_id, question_id)?)
+    }
+
+    /// Load the set of paper IDs this reader has starred.
+    pub fn load_starred_ids(&self, reader: &str) -> Result<HashSet<String>> {
+        Ok(SqlitePaperStateRepository::new(self.db.clone()).starred_ids(reader)?)
+    }
+
+    /// Toggle the starred flag for a paper and return the new value.
+    pub fn toggle_starred(&self, paper_id: &str, reader: &str) -> Result<bool> {
+        Ok(SqlitePaperStateRepository::new(self.db.clone()).toggle_starred(paper_id, reader)?)
     }
 }

--- a/crates/scitadel-tui/src/views/papers.rs
+++ b/crates/scitadel-tui/src/views/papers.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Rect};
 use ratatui::style::{Color, Modifier, Style};
@@ -8,9 +10,15 @@ use scitadel_core::models::Paper;
 use crate::data::DataStore;
 use crate::views::util::truncate;
 
-pub fn draw(frame: &mut Frame, area: Rect, data: &DataStore, selected: usize) {
+pub fn draw(
+    frame: &mut Frame,
+    area: Rect,
+    data: &DataStore,
+    selected: usize,
+    starred: &HashSet<String>,
+) {
     let papers = data.load_papers(1000, 0).unwrap_or_default();
-    render_paper_table(frame, area, &papers, selected, " Papers ");
+    render_paper_table(frame, area, &papers, selected, " Papers ", starred);
 }
 
 pub fn draw_for_search(
@@ -19,13 +27,14 @@ pub fn draw_for_search(
     data: &DataStore,
     search_id: &str,
     selected: usize,
+    starred: &HashSet<String>,
 ) {
     let papers = data.load_papers_for_search(search_id).unwrap_or_default();
     let title = format!(
         " Papers for search {} ",
         search_id.chars().take(8).collect::<String>()
     );
-    render_paper_table(frame, area, &papers, selected, &title);
+    render_paper_table(frame, area, &papers, selected, &title, starred);
 }
 
 fn render_paper_table(
@@ -34,6 +43,7 @@ fn render_paper_table(
     papers: &[Paper],
     selected: usize,
     title: &str,
+    starred: &HashSet<String>,
 ) {
     if papers.is_empty() {
         let block = Block::default()
@@ -46,6 +56,7 @@ fn render_paper_table(
 
     let header = Row::new(vec![
         Cell::from("#"),
+        Cell::from(""),
         Cell::from("Title"),
         Cell::from("Authors"),
         Cell::from("Year"),
@@ -62,9 +73,15 @@ fn render_paper_table(
         .map(|(i, p)| {
             let authors = format_authors(&p.authors);
             let year = p.year.map_or_else(|| "—".to_string(), |y| y.to_string());
+            let star = if starred.contains(p.id.as_str()) {
+                "★"
+            } else {
+                " "
+            };
 
             Row::new(vec![
                 Cell::from((i + 1).to_string()),
+                Cell::from(star).style(Style::default().fg(Color::Yellow)),
                 Cell::from(truncate(&p.title, 60)),
                 Cell::from(truncate(&authors, 30)),
                 Cell::from(year),
@@ -74,6 +91,7 @@ fn render_paper_table(
 
     let widths = [
         Constraint::Length(5),
+        Constraint::Length(2),
         Constraint::Min(30),
         Constraint::Length(32),
         Constraint::Length(6),

--- a/tests/vhs/reading-queue-star.tape
+++ b/tests/vhs/reading-queue-star.tape
@@ -1,0 +1,49 @@
+# VHS tape: star toggle in the Papers tab.
+#
+# Seeds one paper via sqlite3, launches the TUI, switches to Papers,
+# presses `s` to star it, captures the `★` prefix.
+
+Output "tests/vhs/snapshots/reading-queue-star/run.gif"
+
+Set Shell "bash"
+Set FontSize 14
+Set Width 1400
+Set Height 800
+Set Padding 10
+Set TypingSpeed 40ms
+
+Hide
+Type `export PATH="$HOME/.cargo/bin:$PWD/target/release:$PATH"`
+Enter
+Type `export PS1="$ "`
+Enter
+Type `export SCITADEL_DB=$(mktemp -d)/scitadel.db`
+Enter
+Type "scitadel init --yes --email demo@example.org --sources arxiv --db $SCITADEL_DB"
+Enter
+Sleep 800ms
+Type `sqlite3 $SCITADEL_DB "INSERT INTO papers (id, title, authors, year, created_at, updated_at) VALUES ('p-demo', 'Attention Is All You Need', '[\"Vaswani, A.\"]', 2017, datetime('now'), datetime('now'));"`
+Enter
+Sleep 400ms
+Type "clear"
+Enter
+Show
+
+Type "scitadel tui"
+Enter
+Sleep 1500ms
+
+Tab
+Sleep 600ms
+Screenshot "tests/vhs/snapshots/reading-queue-star/01-papers-unstarred.png"
+
+Type "s"
+Sleep 600ms
+Screenshot "tests/vhs/snapshots/reading-queue-star/02-papers-starred.png"
+
+Type "s"
+Sleep 600ms
+Screenshot "tests/vhs/snapshots/reading-queue-star/03-papers-unstarred-again.png"
+
+Type "q"
+Sleep 300ms


### PR DESCRIPTION
Refs #48 (v1 — star only; to-read/read + Queue tab + MCP tools are follow-up).

## Summary
- Migration 004: `paper_state(paper_id, reader, starred, to_read, read_at)`
- `s` in Papers tab toggles star; ★ prefix in the table; help bar updated
- Per-reader: `$USER` by default
- DB repo: get / set / toggle_starred / starred_ids, tested for roundtrip + reader-isolation
- VHS tape: `reading-queue-star.tape` shows ★ toggle on → off → on

## Out of scope for this PR
Re-scoping the large #48 to land incrementally. These are explicitly deferred:
- `r` to-read and `R` read keybindings (schema supports them)
- A separate Queue tab with filters
- MCP tools `list_queue` / `set_paper_state`

## Test plan
- [x] cargo test (3 new DB tests)
- [x] `vhs reading-queue-star.tape` green locally
