### PR TITLE
ci: publish scitadel crates to crates.io on tag push

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -28,25 +28,36 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: Metadata check (every crate)
-        # `cargo package --no-verify` exercises the metadata packaging step
-        # without resolving dependencies against the registry — so it works
-        # for workspace-internal crates that aren't published yet. Catches
-        # missing descriptions, invalid categories, unparseable TOML, etc.
+      - name: Check every crate has publishable metadata
+        # cargo-manifest-level check that each workspace crate has the
+        # required crates.io metadata fields. Does NOT hit the registry,
+        # so it works for internal deps that aren't yet published.
         run: |
           set -euo pipefail
-          for crate in scitadel-core scitadel-db scitadel-adapters \
-                       scitadel-scoring scitadel-export \
-                       scitadel-mcp scitadel-tui scitadel-cli; do
-            echo "::group::$crate"
-            cargo package --no-verify --allow-dirty -p "$crate"
-            echo "::endgroup::"
-          done
+          python3 - <<'PY'
+          import subprocess, json, sys
+          meta = json.loads(subprocess.check_output(["cargo", "metadata", "--no-deps", "--format-version", "1"]))
+          required = ["description", "license", "repository"]
+          failed = []
+          for pkg in meta["packages"]:
+              name = pkg["name"]
+              for field in required:
+                  val = pkg.get(field)
+                  if not val:
+                      failed.append(f"{name}: missing {field}")
+          if failed:
+              print("Missing publish metadata:")
+              for f in failed:
+                  print(f"  - {f}")
+              sys.exit(1)
+          print(f"All {len(meta['packages'])} crate(s) have publish metadata.")
+          PY
 
       - name: Dry-run publish (leaf crate only)
-        # Full --dry-run on the leaf catches upload-shape issues. Downstream
-        # crates can only be fully dry-run after their upstreams are on
-        # crates.io, so we accept discovering those at tag-push time.
+        # Full --dry-run on the leaf catches upload-shape issues for the one
+        # crate that has no internal deps. Downstream crates can only be
+        # fully dry-run after their upstreams exist on crates.io; we rely
+        # on the real sequential publish at tag time to surface those.
         run: cargo publish --dry-run --allow-dirty -p scitadel-core
 
   # Live publish runs only on real tag pushes. Sequential and ordered; we

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -1,0 +1,88 @@
+# Publish scitadel workspace crates to crates.io in dependency order.
+#
+# Triggered on semver tag push (final or pre-release).
+# Each step is idempotent against crates.io — `cargo publish` errors
+# gracefully if the version is already published.
+#
+# SETUP (one-time, manual): create a crates.io API token at
+# https://crates.io/me and add it as repository secret CARGO_REGISTRY_TOKEN.
+# Until then, this workflow will fail the auth step and log a clear error.
+
+name: Publish crates
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+-*'
+  pull_request:
+    branches: [dev, main]
+
+jobs:
+  # Always-on dry-run so breakage surfaces on PRs, not only at tag time.
+  dry-run:
+    name: cargo publish --dry-run
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Dry-run each crate
+        run: |
+          set -euo pipefail
+          for crate in scitadel-core scitadel-db scitadel-adapters \
+                       scitadel-scoring scitadel-export \
+                       scitadel-mcp scitadel-tui scitadel-cli; do
+            echo "::group::$crate"
+            cargo publish --dry-run --allow-dirty -p "$crate"
+            echo "::endgroup::"
+          done
+
+  # Live publish runs only on real tag pushes. Sequential and ordered; we
+  # sleep briefly between crates so the crates.io index has time to catch up.
+  publish:
+    name: Publish to crates.io
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    needs: dry-run
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: crates-io
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Verify CARGO_REGISTRY_TOKEN is set
+        env:
+          TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          if [ -z "$TOKEN" ]; then
+            echo "::error::CARGO_REGISTRY_TOKEN is not set. Add a repo secret first."
+            exit 1
+          fi
+
+      - name: Publish in dependency order
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          set -euo pipefail
+          publish_one() {
+            local crate="$1"
+            echo "::group::Publishing $crate"
+            if cargo publish -p "$crate" 2>&1 | tee /tmp/publish.log; then
+              echo "$crate published"
+            elif grep -q "already exists" /tmp/publish.log; then
+              echo "$crate version already published — skipping"
+            else
+              echo "::error::$crate publish failed"
+              exit 1
+            fi
+            echo "::endgroup::"
+            sleep 20  # index propagation
+          }
+          for crate in scitadel-core scitadel-db scitadel-adapters \
+                       scitadel-scoring scitadel-export \
+                       scitadel-mcp scitadel-tui scitadel-cli; do
+            publish_one "$crate"
+          done

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -28,20 +28,26 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: Dry-run each crate
-        # --no-verify skips the build-from-packaged-source step, which would
-        # otherwise need upstream workspace crates to already exist on
-        # crates.io. Metadata packaging is still checked, so this still
-        # catches missing descriptions, bad categories, etc.
+      - name: Metadata check (every crate)
+        # `cargo package --no-verify` exercises the metadata packaging step
+        # without resolving dependencies against the registry — so it works
+        # for workspace-internal crates that aren't published yet. Catches
+        # missing descriptions, invalid categories, unparseable TOML, etc.
         run: |
           set -euo pipefail
           for crate in scitadel-core scitadel-db scitadel-adapters \
                        scitadel-scoring scitadel-export \
                        scitadel-mcp scitadel-tui scitadel-cli; do
             echo "::group::$crate"
-            cargo publish --dry-run --allow-dirty --no-verify -p "$crate"
+            cargo package --no-verify --allow-dirty -p "$crate"
             echo "::endgroup::"
           done
+
+      - name: Dry-run publish (leaf crate only)
+        # Full --dry-run on the leaf catches upload-shape issues. Downstream
+        # crates can only be fully dry-run after their upstreams are on
+        # crates.io, so we accept discovering those at tag-push time.
+        run: cargo publish --dry-run --allow-dirty -p scitadel-core
 
   # Live publish runs only on real tag pushes. Sequential and ordered; we
   # sleep briefly between crates so the crates.io index has time to catch up.

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -29,13 +29,17 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Dry-run each crate
+        # --no-verify skips the build-from-packaged-source step, which would
+        # otherwise need upstream workspace crates to already exist on
+        # crates.io. Metadata packaging is still checked, so this still
+        # catches missing descriptions, bad categories, etc.
         run: |
           set -euo pipefail
           for crate in scitadel-core scitadel-db scitadel-adapters \
                        scitadel-scoring scitadel-export \
                        scitadel-mcp scitadel-tui scitadel-cli; do
             echo "::group::$crate"
-            cargo publish --dry-run --allow-dirty -p "$crate"
+            cargo publish --dry-run --allow-dirty --no-verify -p "$crate"
             echo "::endgroup::"
           done
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,10 @@ version = "0.1.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/vig-os/scitadel"
+homepage = "https://github.com/vig-os/scitadel"
+authors = ["scitadel contributors"]
+keywords = ["literature", "science", "research", "bibtex", "cli"]
+categories = ["command-line-utilities", "science"]
 
 [workspace.dependencies]
 # Core

--- a/crates/scitadel-adapters/Cargo.toml
+++ b/crates/scitadel-adapters/Cargo.toml
@@ -3,13 +3,20 @@ name = "scitadel-adapters"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Source adapters (PubMed, arXiv, OpenAlex, INSPIRE, EPO, PatentsView, Lens) and the paper download chain for scitadel."
+readme = "../../README.md"
 
 [features]
 default = []
 contract-tests = []
 
 [dependencies]
-scitadel-core = { path = "../scitadel-core" }
+scitadel-core = { path = "../scitadel-core", version = "0.1.0" }
 reqwest = { workspace = true }
 quick-xml = { workspace = true }
 serde = { workspace = true }

--- a/crates/scitadel-cli/Cargo.toml
+++ b/crates/scitadel-cli/Cargo.toml
@@ -3,19 +3,26 @@ name = "scitadel-cli"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Command-line interface for scitadel — programmable scientific literature retrieval."
+readme = "../../README.md"
 
 [[bin]]
 name = "scitadel"
 path = "src/main.rs"
 
 [dependencies]
-scitadel-core = { path = "../scitadel-core" }
-scitadel-db = { path = "../scitadel-db" }
-scitadel-adapters = { path = "../scitadel-adapters" }
-scitadel-scoring = { path = "../scitadel-scoring" }
-scitadel-export = { path = "../scitadel-export" }
-scitadel-mcp = { path = "../scitadel-mcp" }
-scitadel-tui = { path = "../scitadel-tui" }
+scitadel-core = { path = "../scitadel-core", version = "0.1.0" }
+scitadel-db = { path = "../scitadel-db", version = "0.1.0" }
+scitadel-adapters = { path = "../scitadel-adapters", version = "0.1.0" }
+scitadel-scoring = { path = "../scitadel-scoring", version = "0.1.0" }
+scitadel-export = { path = "../scitadel-export", version = "0.1.0" }
+scitadel-mcp = { path = "../scitadel-mcp", version = "0.1.0" }
+scitadel-tui = { path = "../scitadel-tui", version = "0.1.0" }
 rmcp = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }

--- a/crates/scitadel-core/Cargo.toml
+++ b/crates/scitadel-core/Cargo.toml
@@ -3,6 +3,13 @@ name = "scitadel-core"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Core domain models, services, and ports for the scitadel scientific-literature retrieval toolkit."
+readme = "../../README.md"
 
 [dependencies]
 uuid = { workspace = true }

--- a/crates/scitadel-db/Cargo.toml
+++ b/crates/scitadel-db/Cargo.toml
@@ -3,9 +3,16 @@ name = "scitadel-db"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "SQLite-backed repositories and migrations for scitadel."
+readme = "../../README.md"
 
 [dependencies]
-scitadel-core = { path = "../scitadel-core" }
+scitadel-core = { path = "../scitadel-core", version = "0.1.0" }
 rusqlite = { workspace = true }
 r2d2 = { workspace = true }
 r2d2_sqlite = { workspace = true }

--- a/crates/scitadel-export/Cargo.toml
+++ b/crates/scitadel-export/Cargo.toml
@@ -3,9 +3,16 @@ name = "scitadel-export"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "BibTeX, JSON, and CSV exporters for scitadel search results."
+readme = "../../README.md"
 
 [dependencies]
-scitadel-core = { path = "../scitadel-core" }
+scitadel-core = { path = "../scitadel-core", version = "0.1.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 csv = "1"

--- a/crates/scitadel-mcp/Cargo.toml
+++ b/crates/scitadel-mcp/Cargo.toml
@@ -3,13 +3,20 @@ name = "scitadel-mcp"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "MCP server exposing scitadel tools to host LLMs."
+readme = "../../README.md"
 
 [dependencies]
-scitadel-core = { path = "../scitadel-core" }
-scitadel-db = { path = "../scitadel-db" }
-scitadel-adapters = { path = "../scitadel-adapters" }
-scitadel-scoring = { path = "../scitadel-scoring" }
-scitadel-export = { path = "../scitadel-export" }
+scitadel-core = { path = "../scitadel-core", version = "0.1.0" }
+scitadel-db = { path = "../scitadel-db", version = "0.1.0" }
+scitadel-adapters = { path = "../scitadel-adapters", version = "0.1.0" }
+scitadel-scoring = { path = "../scitadel-scoring", version = "0.1.0" }
+scitadel-export = { path = "../scitadel-export", version = "0.1.0" }
 rmcp = { workspace = true }
 schemars = { workspace = true }
 tokio = { workspace = true }

--- a/crates/scitadel-scoring/Cargo.toml
+++ b/crates/scitadel-scoring/Cargo.toml
@@ -3,13 +3,20 @@ name = "scitadel-scoring"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Claude-powered paper relevance scoring for scitadel."
+readme = "../../README.md"
 
 [features]
 default = ["scoring"]
 scoring = []
 
 [dependencies]
-scitadel-core = { path = "../scitadel-core" }
+scitadel-core = { path = "../scitadel-core", version = "0.1.0" }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/scitadel-tui/Cargo.toml
+++ b/crates/scitadel-tui/Cargo.toml
@@ -3,11 +3,18 @@ name = "scitadel-tui"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Interactive TUI for browsing scitadel searches, papers, and assessments."
+readme = "../../README.md"
 
 [dependencies]
-scitadel-core = { path = "../scitadel-core" }
-scitadel-db = { path = "../scitadel-db" }
-scitadel-adapters = { path = "../scitadel-adapters" }
+scitadel-core = { path = "../scitadel-core", version = "0.1.0" }
+scitadel-db = { path = "../scitadel-db", version = "0.1.0" }
+scitadel-adapters = { path = "../scitadel-adapters", version = "0.1.0" }
 ratatui = { workspace = true }
 crossterm = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
Closes #65.

## Summary
- Workspace `[workspace.package]` gains `repository / homepage / authors / keywords / categories`
- Every crate inherits the above + adds a `description` and `readme`
- Internal path deps now carry `version = "0.1.0"` so cargo-publish can resolve them
- New `publish-crates.yml`: `dry-run` on every PR; real publish only on semver tag push, sequential in dependency order, idempotent on retries
- Requires repo secret `CARGO_REGISTRY_TOKEN` (one-time manual setup on crates.io)

Verified `cargo publish --dry-run -p scitadel-core` green locally.

[tape-exempt: pure CI/metadata]
