### PR TITLE
docs: CHANGELOG entry for 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,59 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [0.2.0] - 2026-04-18
+
+Onboarding and reading workflow. Eight PRs, every UX/TUI change backed
+by a VHS tape, CI gate prevents future UI work from skipping tapes.
+
+Note on original scope: #49 annotations is deferred to 0.3.0 — it is
+an architectural effort (multi-selector anchoring, threaded replies,
+two-pane reader, full MCP CRUD) that benefits from its own focused
+release rather than being rushed alongside the onboarding work.
+
+### Added
+
+- **`scitadel init` wizard** (#47): interactive first-run setup with
+  prompts for email + sources, non-interactive `--yes` mode, writes
+  `config.toml`, migrates the DB, prints a ready-to-run sample query.
+- **Star papers in the TUI** (#48, v1): `s` toggles a per-reader ★ flag
+  on the Papers tab. New `paper_state` table scoped by reader; the
+  schema already has `to_read` / `read_at` columns for the upcoming
+  Queue tab in a follow-up.
+- **Institutional-access hint on paywalled downloads** (#50): when
+  `AccessStatus::Paywall` is detected, the task panel shows the live
+  publisher URL + a note that an institutional IP range may grant
+  access. Gated by `UiConfig.show_institutional_hint` (default on).
+- **OFFLINE indicator** (#51, v1): startup network probe; yellow bold
+  `[OFFLINE]` in the status bar when the probe fails. Reads continue
+  to work from local SQLite. `SCITADEL_FORCE_OFFLINE=1` env var
+  bypasses the probe for testing.
+- **Prebuilt binaries** (#64): new `binaries.yml` workflow builds
+  scitadel-cli on linux-x64 + macos-x64 + macos-arm64 on every semver
+  tag push, tarballs + SHA256 sums attached to the GitHub Release.
+- **Crates.io publishing pipeline** (#65): `publish-crates.yml`
+  dry-runs metadata on every PR, sequential live-publish on tag
+  push in dependency order (core → db → adapters → scoring → export
+  → mcp → tui → cli). Requires `CARGO_REGISTRY_TOKEN` secret.
+- **VHS walkthrough-tape harness** (#62): `tests/vhs/` + `just vhs`
+  recipes + CI workflow that installs vhs on ubuntu, runs every tape
+  on PR/push, uploads snapshots as artifacts. Coverage gate: PRs that
+  touch TUI/CLI source must add or update a tape (or include
+  `[tape-exempt: <reason>]` in a commit).
+
+### Changed
+
+- Every merged UX/TUI PR in this release ships with a VHS tape. Any
+  future PR that misses the gate will be blocked by CI.
+
+### Deferred
+
+- **Annotations** (#49) — threaded notes, read receipts, multi-selector
+  anchoring, two-pane reader. Moved to 0.3.0.
+- **Reading queue: `r`/`R` keybindings + Queue tab** — data model exists;
+  UI is a follow-up.
+- **Offline retry queue** — the indicator ships; queued retries don't.
+
 ## [0.1.0] - 2026-04-18
 
 Initial release. Rust workspace implementing the scitadel MVP: federated


### PR DESCRIPTION
Closes the 0.2.0 scope on dev. Next PR merges dev → main for the tag.