### PR TITLE
feat(core): annotation data model + DB migration (iter 1/n)

### DIFF
--- a/crates/scitadel-core/src/models/annotation.rs
+++ b/crates/scitadel-core/src/models/annotation.rs
@@ -1,0 +1,198 @@
+//! Annotations (highlights + threaded notes) anchored to paper text.
+//!
+//! Follows the W3C Web Annotation selector pattern: a single annotation
+//! may carry multiple selectors (position, quote + context, sentence id),
+//! and the resolver tries them in order on open. Threading is self-
+//! referential via `parent_id`; replies inherit the root's anchor.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use super::{AnnotationId, PaperId, QuestionId};
+
+/// Status of the anchor after last resolve attempt.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AnchorStatus {
+    #[default]
+    /// Character-range match; the quote still lives at the same offset.
+    Ok,
+    /// The exact offsets moved but the quote (or sentence id) still matches.
+    Drifted,
+    /// None of the selectors matched — needs user re-anchoring.
+    Orphan,
+}
+
+impl AnchorStatus {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Ok => "ok",
+            Self::Drifted => "drifted",
+            Self::Orphan => "orphan",
+        }
+    }
+
+    #[must_use]
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "ok" => Some(Self::Ok),
+            "drifted" => Some(Self::Drifted),
+            "orphan" => Some(Self::Orphan),
+            _ => None,
+        }
+    }
+}
+
+/// Multi-selector anchor. Any field may be `None`; the resolver falls
+/// through: position → quote + context → sentence id → orphan.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Anchor {
+    /// TextPositionSelector: fast, fragile. `(start, end)` in chars.
+    pub char_range: Option<(usize, usize)>,
+    /// TextQuoteSelector body.
+    pub quote: Option<String>,
+    /// Context before the quote — used for disambiguation.
+    pub prefix: Option<String>,
+    /// Context after the quote.
+    pub suffix: Option<String>,
+    /// SHA1 of the normalized sentence containing the quote.
+    pub sentence_id: Option<String>,
+    /// Which paper-text extraction version this was anchored against.
+    pub source_version: Option<String>,
+    /// Last-known resolution status; updated on open.
+    pub status: AnchorStatus,
+}
+
+impl Anchor {
+    /// Is this an orphan that requires user re-anchoring?
+    #[must_use]
+    pub fn is_orphan(&self) -> bool {
+        matches!(self.status, AnchorStatus::Orphan)
+    }
+}
+
+/// One annotation. May be a root (with an anchor) or a reply (parent_id set,
+/// anchor empty; the root's anchor is the canonical one for rendering).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Annotation {
+    pub id: AnnotationId,
+    /// `None` = root (carries the anchor). `Some` = reply to that ID.
+    pub parent_id: Option<AnnotationId>,
+    pub paper_id: PaperId,
+    pub question_id: Option<QuestionId>,
+    pub anchor: Anchor,
+    pub note: String,
+    pub color: Option<String>,
+    pub tags: Vec<String>,
+    /// Identity string — `$USER` for TUI writes, required for MCP writes.
+    pub author: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    /// Soft-delete tombstone. None = live.
+    pub deleted_at: Option<DateTime<Utc>>,
+}
+
+impl Annotation {
+    /// Build a new root-level annotation with the given anchor.
+    #[must_use]
+    pub fn new_root(paper_id: PaperId, author: String, note: String, anchor: Anchor) -> Self {
+        let now = Utc::now();
+        Self {
+            id: AnnotationId::new(),
+            parent_id: None,
+            paper_id,
+            question_id: None,
+            anchor,
+            note,
+            color: None,
+            tags: Vec::new(),
+            author,
+            created_at: now,
+            updated_at: now,
+            deleted_at: None,
+        }
+    }
+
+    /// Build a new reply whose anchor is empty (inherits from root).
+    #[must_use]
+    pub fn new_reply(parent: &Annotation, author: String, note: String) -> Self {
+        let now = Utc::now();
+        Self {
+            id: AnnotationId::new(),
+            parent_id: Some(parent.id.clone()),
+            paper_id: parent.paper_id.clone(),
+            question_id: parent.question_id.clone(),
+            anchor: Anchor::default(),
+            note,
+            color: None,
+            tags: Vec::new(),
+            author,
+            created_at: now,
+            updated_at: now,
+            deleted_at: None,
+        }
+    }
+
+    /// True if this is a reply to another annotation.
+    #[must_use]
+    pub fn is_reply(&self) -> bool {
+        self.parent_id.is_some()
+    }
+
+    /// True if this annotation has been soft-deleted.
+    #[must_use]
+    pub fn is_deleted(&self) -> bool {
+        self.deleted_at.is_some()
+    }
+}
+
+/// Per-reader read receipt; composite key (annotation_id, reader).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AnnotationRead {
+    pub annotation_id: AnnotationId,
+    pub reader: String,
+    pub seen_at: DateTime<Utc>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reply_inherits_paper_and_question() {
+        let paper_id: PaperId = "p1".into();
+        let root = Annotation::new_root(
+            paper_id.clone(),
+            "lars".into(),
+            "interesting passage".into(),
+            Anchor {
+                quote: Some("neutron energy".into()),
+                ..Anchor::default()
+            },
+        );
+        let reply = Annotation::new_reply(&root, "claude".into(), "agreed; see 4.2".into());
+        assert_eq!(reply.paper_id, paper_id);
+        assert_eq!(reply.parent_id.as_ref(), Some(&root.id));
+        assert!(reply.anchor.quote.is_none(), "replies inherit anchor");
+    }
+
+    #[test]
+    fn anchor_status_round_trip() {
+        for s in [
+            AnchorStatus::Ok,
+            AnchorStatus::Drifted,
+            AnchorStatus::Orphan,
+        ] {
+            assert_eq!(AnchorStatus::parse(s.as_str()), Some(s));
+        }
+    }
+
+    #[test]
+    fn orphan_flag() {
+        let mut a = Anchor::default();
+        assert!(!a.is_orphan());
+        a.status = AnchorStatus::Orphan;
+        assert!(a.is_orphan());
+    }
+}

--- a/crates/scitadel-core/src/models/mod.rs
+++ b/crates/scitadel-core/src/models/mod.rs
@@ -1,3 +1,4 @@
+mod annotation;
 mod assessment;
 mod citation;
 mod doi;
@@ -5,6 +6,7 @@ mod paper;
 mod question;
 mod search;
 
+pub use annotation::{Anchor, AnchorStatus, Annotation, AnnotationRead};
 pub use assessment::Assessment;
 pub use citation::{Citation, CitationDirection, SnowballRun};
 pub use doi::{doi_to_filename, normalize_doi, validate_doi};
@@ -82,3 +84,4 @@ newtype_id!(QuestionId);
 newtype_id!(AssessmentId);
 newtype_id!(SearchTermId);
 newtype_id!(SnowballRunId);
+newtype_id!(AnnotationId);

--- a/crates/scitadel-db/migrations/005_annotations.sql
+++ b/crates/scitadel-db/migrations/005_annotations.sql
@@ -1,0 +1,54 @@
+-- Migration 005: annotations (highlights + threaded notes) and read receipts.
+--
+-- Multi-selector anchoring follows the W3C Web Annotation model:
+-- position (char_start/end), quote + context (quote/prefix/suffix),
+-- and a sentence hash (sentence_id). Any of them may be NULL; the
+-- resolver tries them in order and marks drift or orphan status.
+--
+-- parent_id is self-referential: NULL = anchored root, non-NULL = reply.
+-- Replies inherit their anchor from the root; selector columns on
+-- replies are expected to be NULL.
+--
+-- `deleted_at` is a soft-delete tombstone so that threads are preserved
+-- even when their root is deleted.
+
+CREATE TABLE IF NOT EXISTS annotations (
+    id             TEXT PRIMARY KEY,
+    parent_id      TEXT REFERENCES annotations(id),
+    paper_id       TEXT NOT NULL REFERENCES papers(id),
+    question_id    TEXT REFERENCES research_questions(id),
+
+    -- Multi-selector anchor (roots only; replies inherit from root).
+    char_start     INTEGER,
+    char_end       INTEGER,
+    quote          TEXT,
+    prefix         TEXT,
+    suffix         TEXT,
+    sentence_id    TEXT,
+    source_version TEXT,
+    anchor_status  TEXT CHECK(anchor_status IN ('ok', 'drifted', 'orphan')),
+
+    note           TEXT NOT NULL DEFAULT '',
+    color          TEXT,
+    tags_json      TEXT NOT NULL DEFAULT '[]',
+    author         TEXT NOT NULL,
+    created_at     TEXT NOT NULL,
+    updated_at     TEXT NOT NULL,
+    deleted_at     TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_annotations_paper    ON annotations(paper_id);
+CREATE INDEX IF NOT EXISTS idx_annotations_parent   ON annotations(parent_id);
+CREATE INDEX IF NOT EXISTS idx_annotations_question ON annotations(question_id);
+CREATE INDEX IF NOT EXISTS idx_annotations_author   ON annotations(author);
+
+CREATE TABLE IF NOT EXISTS annotation_reads (
+    annotation_id TEXT NOT NULL REFERENCES annotations(id),
+    reader        TEXT NOT NULL,
+    seen_at       TEXT NOT NULL,
+    PRIMARY KEY (annotation_id, reader)
+);
+
+CREATE INDEX IF NOT EXISTS idx_annotation_reads_reader ON annotation_reads(reader);
+
+INSERT OR IGNORE INTO schema_version (version, applied_at) VALUES (5, datetime('now'));

--- a/crates/scitadel-db/src/sqlite/migrations.rs
+++ b/crates/scitadel-db/src/sqlite/migrations.rs
@@ -6,12 +6,14 @@ const MIGRATION_001: &str = include_str!("../../migrations/001_initial.sql");
 const MIGRATION_002: &str = include_str!("../../migrations/002_citations.sql");
 const MIGRATION_003: &str = include_str!("../../migrations/003_full_text.sql");
 const MIGRATION_004: &str = include_str!("../../migrations/004_paper_state.sql");
+const MIGRATION_005: &str = include_str!("../../migrations/005_annotations.sql");
 
 const MIGRATIONS: &[(i64, &str)] = &[
     (1, MIGRATION_001),
     (2, MIGRATION_002),
     (3, MIGRATION_003),
     (4, MIGRATION_004),
+    (5, MIGRATION_005),
 ];
 
 /// Run all pending migrations, skipping already-applied ones.
@@ -80,6 +82,8 @@ mod tests {
         assert!(tables.contains(&"citations".to_string()));
         assert!(tables.contains(&"snowball_runs".to_string()));
         assert!(tables.contains(&"paper_state".to_string()));
+        assert!(tables.contains(&"annotations".to_string()));
+        assert!(tables.contains(&"annotation_reads".to_string()));
         assert!(tables.contains(&"schema_version".to_string()));
     }
 }


### PR DESCRIPTION
Refs #49 (iteration 1 of many).

## Summary
First slice of the annotations feature — **data only**, no behavior:
- Migration 005 adds `annotations` and `annotation_reads` tables with W3C-style multi-selector anchor columns
- Core `Annotation`, `Anchor`, `AnchorStatus`, `AnnotationRead` types
- Self-referential `parent_id` for threaded replies; replies inherit paper/question and have an empty anchor
- Soft-delete via `deleted_at` tombstone so threads survive root deletion

Deliberately **no** TUI / MCP / resolver code. Splitting the massive issue into small, reviewable pieces.

## Out of scope for this PR (subsequent iterations)
- DB repository (iter 2)
- Anchoring resolver (iter 3)  
- TUI two-pane reader (iter 4)
- MCP CRUD tools (iter 5)

[tape-exempt: pure data model + schema; no user-visible TUI/CLI change]

## Test plan
- [x] 3 new core unit tests (reply inheritance, status round-trip, orphan flag)
- [x] Migration test confirms new tables are created
- [x] fmt / clippy / existing tests green
