### PR TITLE
feat(mcp): get_rubric tool

### DIFF
--- a/crates/scitadel-mcp/src/server.rs
+++ b/crates/scitadel-mcp/src/server.rs
@@ -80,6 +80,13 @@ impl ScitadelServer {
     }
 
     #[tool(
+        description = "Return the scoring rubric (criteria, 0.0-1.0 scale, response format) as a string. Fetch once at the start of a scoring session and cache; use with `save_assessment` or `assess_paper` for each paper. Avoids the per-paper rubric fetch that `prepare_assessment` does."
+    )]
+    fn get_rubric(&self) -> Result<String, String> {
+        tools::get_rubric_tool()
+    }
+
+    #[tool(
         description = "Summarize every paper in a search as JSON in one call: title, authors, year, abstract (truncated), DOI, identifiers. Preferred over iterating `get_paper` per result when scanning a corpus."
     )]
     fn summarize_search(

--- a/crates/scitadel-mcp/src/tools.rs
+++ b/crates/scitadel-mcp/src/tools.rs
@@ -718,6 +718,17 @@ pub fn prepare_batch_assessments_tool(
     Ok(out.join("\n"))
 }
 
+/// Return the scitadel assessment rubric (scoring criteria, score scale,
+/// response format) so an agent can fetch it once and cache, rather than
+/// re-fetching via `prepare_assessment` for every paper it evaluates.
+///
+/// Today the rubric is a static prompt shared across all questions;
+/// if per-question rubrics ever land, this function becomes the
+/// customization point.
+pub fn get_rubric_tool() -> Result<String, String> {
+    Ok(scitadel_scoring::SCORING_SYSTEM_PROMPT.to_string())
+}
+
 /// Summarize every paper in a search as JSON — title, abstract, access
 /// status, identifiers — in a single call. Saves round-trips vs. the
 /// agent iterating `get_paper` per result.


### PR DESCRIPTION
Closes #56. Small tool that returns the static scoring rubric so clients can cache it instead of paying for it per-paper via prepare_assessment. [tape-exempt: MCP only]