### PR TITLE
feat(mcp): search returns structured per-source status

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"4406bc4d-dc2c-4161-b3ee-3e718d624139","pid":15504,"acquiredAt":1776552394825}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"4406bc4d-dc2c-4161-b3ee-3e718d624139","pid":15504,"acquiredAt":1776552394825}

--- a/.gitignore
+++ b/.gitignore
@@ -224,8 +224,10 @@ justfile.local
 .scitadel/
 results.bib
 
-# Claude Code (keep CLAUDE.md, ignore local settings)
+# Claude Code (keep CLAUDE.md, ignore local settings + loop state)
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
+.claude/scheduled_tasks.json
 
 # Conductor orchestration state
 .conductor/

--- a/crates/scitadel-mcp/src/tools.rs
+++ b/crates/scitadel-mcp/src/tools.rs
@@ -106,7 +106,7 @@ pub async fn search_tool(
         .save_results(&search_results)
         .map_err(|e| e.to_string())?;
 
-    let outcomes: Vec<String> = search_record
+    let outcome_lines: Vec<String> = search_record
         .source_outcomes
         .iter()
         .map(|o| {
@@ -117,14 +117,28 @@ pub async fn search_tool(
         })
         .collect();
 
-    Ok(format!(
+    let summary = format!(
         "Search ID: {}\nQuery: {query}\nSources: {}\nTotal candidates: {}\nUnique papers after dedup: {}\n{}",
         search_record.id,
         source_list.join(", "),
         search_record.total_candidates,
         papers.len(),
-        outcomes.join("\n")
-    ))
+        outcome_lines.join("\n")
+    );
+
+    // Structured payload: agents introspect per-source status + counts
+    // without parsing the summary string. `summary` field kept so
+    // existing string-consuming clients keep working.
+    let payload = serde_json::json!({
+        "search_id": search_record.id.as_str(),
+        "query": search_record.query,
+        "sources": search_record.source_outcomes,
+        "total_candidates": search_record.total_candidates,
+        "total_unique_papers": papers.len(),
+        "summary": summary,
+    });
+
+    serde_json::to_string_pretty(&payload).map_err(|e| e.to_string())
 }
 
 pub fn list_searches_tool(limit: i64) -> Result<String, String> {

--- a/docs/decisions/ADR-003-2026-04-19-0.3.0-execution.md
+++ b/docs/decisions/ADR-003-2026-04-19-0.3.0-execution.md
@@ -1,0 +1,72 @@
+# ADR-003 — 0.3.0 execution tracker (iterative, loop-driven)
+
+- Status: in progress
+- Date: 2026-04-19
+- Driver: /loop 15m autonomous execution across Claude sessions
+
+## Context
+
+0.3.0 was re-scoped at the tail of the 0.2.0 release to include:
+1. MCP DX polish (#53, #54, #55, #56, #57, #58)
+2. Annotations (#49) — moved from 0.2.0, architectural, iterative
+
+The user requested loop-driven autonomous execution in 15-minute ticks
+until every 0.3.0 issue is merged to `dev`. State must survive ticks.
+
+## Decision
+
+**Operate on `dev` as the integration branch.** Every unit of work is a
+`feature/<n>-<slug>` branch → PR → squash-merge to `dev`. `main` gets a
+single release merge when 0.3.0 is complete.
+
+**Tape-exempt MCP-only PRs** (via commit footer `[tape-exempt: MCP only]`)
+for issues that don't touch TUI/CLI source. Rust tests + clippy still gate.
+
+**Iterate big issues.** #49 annotations ships in 5 PRs (data model, repo,
+TUI reader, MCP CRUD, read receipts). Each PR is mergeable standalone.
+
+**External agent review between important steps.** After every 2-3
+feature merges, dispatch an `Explore`/`general-purpose` subagent to
+audit the recent changes for quality regressions, unclear naming,
+tech debt. Record findings in this ADR's "Observations" section.
+
+**Parallelize with subagents.** Use the `Agent` tool for independent
+work that can run while the main session drives a PR: code review,
+issue scaffolding, design-doc research.
+
+## Execution order (priority)
+
+| # | Size | Depends on | Status |
+|---|------|------------|--------|
+| #54 list_sources | S | — | ✅ merged (PR #81) |
+| #53 summarize_search | S | — | ✅ merged (PR #82) |
+| #56 get_rubric | S | — | ✅ merged (PR #83) |
+| #55 structured per-source status | M | — | ⏳ next |
+| #57 find_similar_searches (FTS) | M | — | pending |
+| #58 MCP progress notifications | M | rmcp API check | pending |
+| #49 iter 1 (data model + migration) | S | — | ✅ merged (PR #79) |
+| #49 iter 2 (repo + anchoring resolver) | M | iter 1 | pending |
+| #49 iter 3 (TUI two-pane reader) | L | iter 2 | pending |
+| #49 iter 4 (MCP CRUD tools) | M | iter 2 | pending |
+| #49 iter 5 (read receipts + thread rendering) | M | iter 3/4 | pending |
+
+Merge order respects dependencies but non-dependent items can interleave.
+
+## Observations (append-only, append per review)
+
+*Tick 2026-04-19 T1*: starting — three smallest MCP tools merged. Next
+up: #55, the first non-trivial shape change to the `search` tool. Need
+backwards compatibility since the CLI and external MCP clients rely on
+the current string response.
+
+## Follow-ups worth tracking (not 0.3.0 blockers)
+
+- Rotate crates.io token leaked in conversation earlier (user has the token)
+- Audit / delete `.github/workflows/renovate-changelog.yml` if it refs
+  Python-only workflow assumptions
+- `sync-main-to-dev.yml` still has Python refs — refactor or drop
+
+## When this loop ends
+
+All 11 rows above are ✅. Then: PR `dev → main`, tag `0.3.0`, GH
+Release, close milestone 0.3.0. Same pattern as 0.2.0.


### PR DESCRIPTION
Closes #55. Breaking change — `search` now returns JSON with per-source `status`/`result_count`/`latency_ms`/`error`. `summary` field preserves the original text for string-consuming clients.

[tape-exempt: MCP only]