### PR TITLE
fix(mcp): byte-slice bugs + openalex credential label (review follow-ups)

### DIFF
--- a/crates/scitadel-mcp/src/tools.rs
+++ b/crates/scitadel-mcp/src/tools.rs
@@ -215,11 +215,7 @@ pub fn get_papers_tool(search_id: &str) -> Result<String, String> {
         } else {
             String::new()
         };
-        let abstract_preview = if p.r#abstract.len() > 300 {
-            format!("{}...", &p.r#abstract[..300])
-        } else {
-            p.r#abstract.clone()
-        };
+        let (abstract_preview, _) = truncate_abstract(&p.r#abstract, 300);
 
         out.push(format!(
             "[{}] {}\n    Authors: {}{}\n    Year: {}  Journal: {}\n    DOI: {}  ID: {}\n    Abstract: {}\n",
@@ -696,11 +692,7 @@ pub fn prepare_batch_assessments_tool(
         } else {
             String::new()
         };
-        let abstract_preview = if p.r#abstract.len() > 300 {
-            format!("{}...", &p.r#abstract[..300])
-        } else {
-            p.r#abstract.clone()
-        };
+        let (abstract_preview, _) = truncate_abstract(&p.r#abstract, 300);
 
         out.push(format!(
             "[{}] {}\n\
@@ -851,9 +843,11 @@ const SOURCE_REGISTRY: &[SourceInfo] = &[
     },
     SourceInfo {
         name: "openalex",
-        description: "Open scholarly-works graph covering most disciplines. Email polite-pool recommended.",
-        credential_fields: &["email"],
-        rate_limit_hint: "10 req/s in the polite pool (with email).",
+        description: "Open scholarly-works graph covering most disciplines. The polite-pool email gets 10 req/s; without it you share the global 10 req/s pool.",
+        // Stored under `openalex.api_key` in config for historical reasons;
+        // users authenticate by putting their contact email there, not a real key.
+        credential_fields: &["polite_pool_email"],
+        rate_limit_hint: "10 req/s in the polite pool (with email), otherwise shared.",
     },
     SourceInfo {
         name: "inspire",


### PR DESCRIPTION
Addresses review findings from the automated code review of PRs #81–#83:

1. Two byte-slice panics (`&s[..300]`) on non-ASCII abstracts — replaced with existing `truncate_abstract` helper.
2. `openalex` credential-field label in SOURCE_REGISTRY was misleading; renamed to `polite_pool_email` and clarified the description.

[tape-exempt: MCP only]