### PR TITLE
feat(mcp): find_similar_searches FTS tool

### DIFF
--- a/crates/scitadel-db/migrations/006_search_fts.sql
+++ b/crates/scitadel-db/migrations/006_search_fts.sql
@@ -1,0 +1,26 @@
+-- Migration 006: FTS5 over search queries for `find_similar_searches`.
+--
+-- Standalone FTS5 table (not external-content) with an INSERT trigger
+-- on `searches` to keep it in sync. Standalone avoids the external-
+-- content gotchas around DELETE/UPDATE sync when we only ever insert.
+-- Porter stemming + unicode61 tokenizer covers English + diacritics.
+
+CREATE VIRTUAL TABLE IF NOT EXISTS searches_fts USING fts5(
+    search_id UNINDEXED,
+    query,
+    tokenize='porter unicode61'
+);
+
+CREATE TRIGGER IF NOT EXISTS searches_fts_ai AFTER INSERT ON searches
+BEGIN
+    INSERT INTO searches_fts(search_id, query) VALUES (new.id, new.query);
+END;
+
+-- Backfill any pre-existing rows. Safe on re-run only because migrations
+-- are version-gated — this statement fires exactly once when the 006
+-- version row is inserted below.
+INSERT INTO searches_fts(search_id, query)
+    SELECT id, query FROM searches
+    WHERE NOT EXISTS (SELECT 1 FROM searches_fts WHERE search_id = searches.id);
+
+INSERT OR IGNORE INTO schema_version (version, applied_at) VALUES (6, datetime('now'));

--- a/crates/scitadel-db/src/sqlite/migrations.rs
+++ b/crates/scitadel-db/src/sqlite/migrations.rs
@@ -7,6 +7,7 @@ const MIGRATION_002: &str = include_str!("../../migrations/002_citations.sql");
 const MIGRATION_003: &str = include_str!("../../migrations/003_full_text.sql");
 const MIGRATION_004: &str = include_str!("../../migrations/004_paper_state.sql");
 const MIGRATION_005: &str = include_str!("../../migrations/005_annotations.sql");
+const MIGRATION_006: &str = include_str!("../../migrations/006_search_fts.sql");
 
 const MIGRATIONS: &[(i64, &str)] = &[
     (1, MIGRATION_001),
@@ -14,6 +15,7 @@ const MIGRATIONS: &[(i64, &str)] = &[
     (3, MIGRATION_003),
     (4, MIGRATION_004),
     (5, MIGRATION_005),
+    (6, MIGRATION_006),
 ];
 
 /// Run all pending migrations, skipping already-applied ones.
@@ -84,6 +86,7 @@ mod tests {
         assert!(tables.contains(&"paper_state".to_string()));
         assert!(tables.contains(&"annotations".to_string()));
         assert!(tables.contains(&"annotation_reads".to_string()));
+        assert!(tables.contains(&"searches_fts".to_string()));
         assert!(tables.contains(&"schema_version".to_string()));
     }
 }

--- a/crates/scitadel-db/src/sqlite/searches.rs
+++ b/crates/scitadel-db/src/sqlite/searches.rs
@@ -14,6 +14,54 @@ impl SqliteSearchRepository {
     pub fn new(db: Database) -> Self {
         Self { db }
     }
+
+    /// Full-text search over past search queries using the `searches_fts`
+    /// FTS5 index (migration 006). Returns `(Search, rank)` tuples where
+    /// lower rank = more relevant (bm25 convention). Input is sanitized of
+    /// FTS5 operators so arbitrary user strings don't raise syntax errors.
+    pub fn find_similar(&self, query: &str, limit: i64) -> Result<Vec<(Search, f64)>, DbError> {
+        let sanitized = sanitize_fts5_query(query);
+        if sanitized.is_empty() {
+            return Ok(Vec::new());
+        }
+        let conn = self.db.conn()?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT s.*, bm25(searches_fts) AS rank
+                 FROM searches_fts f
+                 JOIN searches s ON s.id = f.search_id
+                 WHERE searches_fts MATCH ?1
+                 ORDER BY rank ASC
+                 LIMIT ?2",
+            )
+            .map_err(DbError::Sqlite)?;
+        let rows = stmt
+            .query_map(params![sanitized, limit], |row| {
+                let search = row_to_search(row)?;
+                let rank: f64 = row.get("rank")?;
+                Ok((search, rank))
+            })
+            .map_err(DbError::Sqlite)?;
+        let out: Vec<(Search, f64)> = rows.filter_map(Result::ok).collect();
+        Ok(out)
+    }
+}
+
+/// Strip FTS5 query-syntax characters so arbitrary user input doesn't
+/// trigger `fts5: syntax error near …`. We lose operator support but
+/// gain robustness; callers who want advanced syntax can submit
+/// pre-sanitized queries with the operators they know to be valid.
+fn sanitize_fts5_query(q: &str) -> String {
+    q.chars()
+        .map(|c| match c {
+            // These are FTS5 operators / quote chars.
+            '"' | '\'' | '(' | ')' | ':' | '*' | '-' => ' ',
+            other => other,
+        })
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 fn row_to_search(row: &rusqlite::Row) -> rusqlite::Result<Search> {
@@ -200,6 +248,52 @@ mod tests {
 
         let loaded = repo.get(search.id.as_str()).unwrap().unwrap();
         assert_eq!(loaded.query, "test query");
+    }
+
+    #[test]
+    fn fts_sanitizer_strips_operators() {
+        assert_eq!(sanitize_fts5_query(r#"GAN "stability""#), "GAN stability");
+        assert_eq!(sanitize_fts5_query("foo (bar) - baz"), "foo bar baz");
+        assert_eq!(sanitize_fts5_query("   "), "");
+        assert_eq!(sanitize_fts5_query("scope:field"), "scope field");
+    }
+
+    #[test]
+    fn fts_find_similar_roundtrip() {
+        let (_, repo, _) = setup();
+        let a = {
+            let mut s = Search::new("generative adversarial networks stability");
+            s.id = SearchId::from("s-a");
+            s
+        };
+        let b = {
+            let mut s = Search::new("attention is all you need transformers");
+            s.id = SearchId::from("s-b");
+            s
+        };
+        let c = {
+            let mut s = Search::new("retrieval augmented generation");
+            s.id = SearchId::from("s-c");
+            s
+        };
+        repo.save(&a).unwrap();
+        repo.save(&b).unwrap();
+        repo.save(&c).unwrap();
+
+        // Porter stemming should match "generative" against "generating".
+        let hits = repo.find_similar("generative networks", 10).unwrap();
+        assert!(
+            hits.iter().any(|(s, _)| s.id.as_str() == "s-a"),
+            "expected GAN search to be found; got {:?}",
+            hits.iter().map(|(s, _)| s.id.as_str()).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn fts_find_similar_empty_query() {
+        let (_, repo, _) = setup();
+        repo.save(&Search::new("something")).unwrap();
+        assert!(repo.find_similar("()(", 10).unwrap().is_empty());
     }
 
     #[test]

--- a/crates/scitadel-mcp/src/server.rs
+++ b/crates/scitadel-mcp/src/server.rs
@@ -87,6 +87,21 @@ impl ScitadelServer {
     }
 
     #[tool(
+        description = "Full-text search over stored past searches (FTS5 + Porter stemming). Returns JSON array of matching prior searches sorted by relevance (lower rank = more relevant). Call before running a fresh `search` to detect redundant work."
+    )]
+    fn find_similar_searches(
+        &self,
+        #[tool(param)]
+        #[schemars(description = "Free-text query — FTS5 operators are stripped automatically")]
+        query: String,
+        #[tool(param)]
+        #[schemars(description = "Max hits to return (default 10)")]
+        limit: Option<i64>,
+    ) -> Result<String, String> {
+        tools::find_similar_searches_tool(&query, limit)
+    }
+
+    #[tool(
         description = "Summarize every paper in a search as JSON in one call: title, authors, year, abstract (truncated), DOI, identifiers. Preferred over iterating `get_paper` per result when scanning a corpus."
     )]
     fn summarize_search(

--- a/crates/scitadel-mcp/src/tools.rs
+++ b/crates/scitadel-mcp/src/tools.rs
@@ -724,6 +724,34 @@ pub fn prepare_batch_assessments_tool(
     Ok(out.join("\n"))
 }
 
+/// Full-text search over stored search queries. Returns a JSON array of
+/// past searches matching `query` (lower `rank` = more relevant per
+/// BM25). Agents should call this before running a fresh search to
+/// avoid re-doing work that's already in the DB.
+pub fn find_similar_searches_tool(query: &str, limit: Option<i64>) -> Result<String, String> {
+    let limit = limit.unwrap_or(10).max(1);
+    let db = open_db()?;
+    let (_, search_repo, _, _, _) = db.repositories();
+    let hits = search_repo
+        .find_similar(query, limit)
+        .map_err(|e| e.to_string())?;
+
+    let entries: Vec<serde_json::Value> = hits
+        .into_iter()
+        .map(|(s, rank)| {
+            serde_json::json!({
+                "search_id": s.id.as_str(),
+                "query": s.query,
+                "total_papers": s.total_papers,
+                "created_at": s.created_at.to_rfc3339(),
+                "rank": rank,
+            })
+        })
+        .collect();
+
+    serde_json::to_string_pretty(&entries).map_err(|e| e.to_string())
+}
+
 /// Return the scitadel assessment rubric (scoring criteria, score scale,
 /// response format) so an agent can fetch it once and cache, rather than
 /// re-fetching via `prepare_assessment` for every paper it evaluates.


### PR DESCRIPTION
Closes #57.

- Migration 006: `searches_fts` FTS5 table + trigger + backfill
- `SqliteSearchRepository::find_similar` with BM25 ranking
- FTS5 operator sanitizer
- New MCP tool `find_similar_searches`
- 3 new DB tests (sanitizer, roundtrip, empty query)

[tape-exempt: MCP only]