### PR TITLE
docs(adr): update 0.3.0 tracker; defer #58 to 0.4.0

### DIFF
--- a/docs/decisions/ADR-003-2026-04-19-0.3.0-execution.md
+++ b/docs/decisions/ADR-003-2026-04-19-0.3.0-execution.md
@@ -41,11 +41,12 @@ issue scaffolding, design-doc research.
 | #54 list_sources | S | — | ✅ merged (PR #81) |
 | #53 summarize_search | S | — | ✅ merged (PR #82) |
 | #56 get_rubric | S | — | ✅ merged (PR #83) |
-| #55 structured per-source status | M | — | ⏳ next |
-| #57 find_similar_searches (FTS) | M | — | pending |
-| #58 MCP progress notifications | M | rmcp API check | pending |
+| #55 structured per-source status | M | — | ✅ merged (PR #84) |
+| review follow-ups (byte-slice / openalex label) | S | review | ✅ merged (PR #85) |
+| #57 find_similar_searches (FTS) | M | — | ✅ merged (PR #86) |
+| #58 MCP progress notifications | M | async task mgmt | **deferred to 0.4.0** (see below) |
 | #49 iter 1 (data model + migration) | S | — | ✅ merged (PR #79) |
-| #49 iter 2 (repo + anchoring resolver) | M | iter 1 | pending |
+| #49 iter 2 (repo + anchoring resolver) | M | iter 1 | ⏳ next |
 | #49 iter 3 (TUI two-pane reader) | L | iter 2 | pending |
 | #49 iter 4 (MCP CRUD tools) | M | iter 2 | pending |
 | #49 iter 5 (read receipts + thread rendering) | M | iter 3/4 | pending |
@@ -58,6 +59,37 @@ Merge order respects dependencies but non-dependent items can interleave.
 up: #55, the first non-trivial shape change to the `search` tool. Need
 backwards compatibility since the CLI and external MCP clients rely on
 the current string response.
+
+*Tick 2026-04-19 T2*: subagent review of PRs #81-#83 flagged two real
+bugs (byte-slice panic on non-ASCII abstracts in `get_papers_tool` and
+`prepare_batch_assessments_tool`) and one clarity issue (misleading
+`email` credential label for OpenAlex). Both fixed in PR #85.
+#55 and #57 landed cleanly. #58 deferred to 0.4.0 — see rationale below.
+Up next: #49 iter 2 (SqliteAnnotationRepository + multi-selector
+anchoring resolver). This is the biggest remaining bite of 0.3.0 and
+has real design in it, not just plumbing.
+
+## #58 deferral rationale
+
+rmcp 0.1.5 **does** have a `Peer::send_notification` API that can emit
+progress frames, but the `#[tool]` macro doesn't inject a peer reference
+into tool handlers — the handler signature is `(&self, params) -> Result`.
+Wiring peer access into every tool requires either:
+
+1. A rmcp upgrade (0.17 exists; would be a separate cross-cutting PR)
+2. A custom `#[tool]` wrapper that passes `RequestContext` through
+3. Splitting long tools into `start_X` + `get_X_status` polling pairs
+   with in-memory task state
+
+Option 3 is the most self-contained and most aligned with how long
+scitadel operations (search, download, prepare_batch_assessments)
+actually fail today. But it depends on an **async task registry** that
+doesn't exist yet — annotations iteration 3 or later will likely
+introduce one (for background anchoring resolution). Revisiting #58
+after the annotations work is the cleanest sequence.
+
+**Decision**: move #58 to 0.4.0, unblock 0.3.0 on #49 work only.
+Will update milestone in this commit.
 
 ## Follow-ups worth tracking (not 0.3.0 blockers)
 


### PR DESCRIPTION
Updates the 0.3.0 ADR with status through tick T2 and records the decision to defer #58 to 0.4.0 (rmcp-0.1.5 tool handlers can't access the peer for progress notifications without a wrapper; wait for the async task registry that iter 3 of annotations will likely introduce).

#58 moved to milestone 0.4.0.

[tape-exempt: docs only]