### PR TITLE
feat(tui): annotations in paper detail (iter 3/n, view-only)

### DIFF
--- a/crates/scitadel-tui/src/data.rs
+++ b/crates/scitadel-tui/src/data.rs
@@ -3,11 +3,11 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 
-use scitadel_core::models::{Assessment, Paper, ResearchQuestion, Search, SearchTerm};
+use scitadel_core::models::{Annotation, Assessment, Paper, ResearchQuestion, Search, SearchTerm};
 use scitadel_core::ports::{
     AssessmentRepository, PaperRepository, QuestionRepository, SearchRepository,
 };
-use scitadel_db::sqlite::{Database, SqlitePaperStateRepository};
+use scitadel_db::sqlite::{Database, SqliteAnnotationRepository, SqlitePaperStateRepository};
 
 /// Wrapper around the database that loads data for each TUI view.
 pub struct DataStore {
@@ -70,6 +70,11 @@ impl DataStore {
     /// Load the set of paper IDs this reader has starred.
     pub fn load_starred_ids(&self, reader: &str) -> Result<HashSet<String>> {
         Ok(SqlitePaperStateRepository::new(self.db.clone()).starred_ids(reader)?)
+    }
+
+    /// Load live annotations for a paper (roots + replies), ordered oldest-first.
+    pub fn load_annotations_for_paper(&self, paper_id: &str) -> Result<Vec<Annotation>> {
+        Ok(SqliteAnnotationRepository::new(self.db.clone()).list_by_paper(paper_id)?)
     }
 
     /// Toggle the starred flag for a paper and return the new value.

--- a/crates/scitadel-tui/src/views/detail.rs
+++ b/crates/scitadel-tui/src/views/detail.rs
@@ -107,6 +107,48 @@ pub fn draw(frame: &mut Frame, area: Rect, data: &DataStore, paper_id: &str, scr
         }
     }
 
+    // Annotations panel — view-only in iter 3. Create/edit happen via MCP
+    // (`create_annotation` etc.) until iter 3b wires in-TUI writes.
+    let annotations = data
+        .load_annotations_for_paper(paper_id)
+        .unwrap_or_default();
+    if !annotations.is_empty() {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            format!("Annotations ({}):", annotations.len()),
+            label_style,
+        )));
+        for ann in &annotations {
+            let prefix = if ann.is_reply() { "  └ " } else { "  • " };
+            if let Some(quote) = ann.anchor.quote.as_deref() {
+                lines.push(Line::from(vec![
+                    Span::raw(prefix),
+                    Span::styled(format!("\"{quote}\" "), Style::default().fg(Color::Cyan)),
+                    Span::styled(
+                        format!("— {}", ann.anchor.status.as_str()),
+                        Style::default().fg(Color::DarkGray),
+                    ),
+                ]));
+                lines.push(Line::from(format!(
+                    "    {} ({}): {}",
+                    ann.author,
+                    ann.created_at.format("%Y-%m-%d"),
+                    ann.note
+                )));
+            } else {
+                // Reply — no anchor, just author + note, indented.
+                lines.push(Line::from(vec![
+                    Span::raw(prefix),
+                    Span::styled(
+                        format!("{}: ", ann.author),
+                        Style::default().fg(Color::Yellow),
+                    ),
+                    Span::raw(ann.note.clone()),
+                ]));
+            }
+        }
+    }
+
     let paragraph = Paragraph::new(lines)
         .block(
             Block::default()

--- a/tests/vhs/annotations-in-detail.tape
+++ b/tests/vhs/annotations-in-detail.tape
@@ -1,0 +1,55 @@
+# VHS tape: annotations visible in the paper detail view (#49 iter 3).
+#
+# Seeds a paper + one annotation directly via sqlite3, launches the
+# TUI, opens the paper, screenshots the annotation listing.
+
+Output "tests/vhs/snapshots/annotations-in-detail/run.gif"
+
+Set Shell "bash"
+Set FontSize 14
+Set Width 1400
+Set Height 900
+Set Padding 10
+Set TypingSpeed 40ms
+
+Hide
+Type `export PATH="$HOME/.cargo/bin:$PWD/target/release:$PATH"`
+Enter
+Type `export PS1="$ "`
+Enter
+Type `export SCITADEL_DB=$(mktemp -d)/scitadel.db`
+Enter
+Type "scitadel init --yes --email demo@example.org --sources arxiv --db $SCITADEL_DB"
+Enter
+Sleep 800ms
+
+# Seed a paper + a root annotation + a reply.
+Type `sqlite3 $SCITADEL_DB "INSERT INTO papers (id, title, authors, year, abstract, created_at, updated_at) VALUES ('p-demo', 'Attention Is All You Need', '[\"Vaswani, A.\"]', 2017, 'The dominant sequence transduction models are based on complex recurrent or convolutional neural networks that include an encoder and a decoder. We propose a new simple network architecture, the Transformer.', datetime('now'), datetime('now'));"`
+Enter
+Sleep 300ms
+Type `sqlite3 $SCITADEL_DB "INSERT INTO annotations (id, paper_id, quote, note, author, anchor_status, tags_json, created_at, updated_at) VALUES ('a-root', 'p-demo', 'the Transformer', 'foundational architecture choice - see fig 1', 'lars', 'ok', '[]', datetime('now'), datetime('now'));"`
+Enter
+Sleep 300ms
+Type `sqlite3 $SCITADEL_DB "INSERT INTO annotations (id, parent_id, paper_id, note, author, anchor_status, tags_json, created_at, updated_at) VALUES ('a-reply', 'a-root', 'p-demo', 'matches section 3.1 of the paper', 'claude-opus-4-7', 'ok', '[]', datetime('now'), datetime('now'));"`
+Enter
+Sleep 300ms
+Type "clear"
+Enter
+Show
+
+Type "scitadel tui"
+Enter
+Sleep 1500ms
+
+Tab
+Sleep 500ms
+Screenshot "tests/vhs/snapshots/annotations-in-detail/01-papers-tab.png"
+
+Enter
+Sleep 1500ms
+Screenshot "tests/vhs/snapshots/annotations-in-detail/02-paper-detail-with-annotations.png"
+
+Type "q"
+Sleep 300ms
+Type "q"
+Sleep 300ms


### PR DESCRIPTION
Refs #49 iter 3.

View-only rendering of annotations in the existing `PaperDetail` overlay:
- Quote + anchor status badge for roots
- Indented `author: body` for replies
- No highlight overlay, no TUI-native writes yet — defer to iter 3b

VHS tape seeds a paper + root + reply via sqlite3 and screenshots the detail view.