### PR TITLE
feat(mcp): progress notifications for long-running tools (#58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **MCP progress notifications** (#58). The `search`,
+  `download_paper`, and `prepare_batch_assessments` tools now emit
+  `notifications/progress` frames when the caller supplies a
+  `progressToken` in the request `_meta`. Bracketing pattern: a
+  start frame at progress=0 (with a human-readable message naming
+  the operation), then a done frame at progress=total on success or
+  with the error string on failure. Per-source / per-paper
+  granularity is a follow-up that needs the orchestrator to thread a
+  callback through each adapter loop. Built on the rmcp 0.17 upgrade
+  that landed earlier in 0.4.0.
 - **TUI two-pane annotation reader** (#97, iter 1). Toggled with `R`
   on the paper detail overlay: left pane renders the paper body
   (`full_text` if cached, else the abstract) with background-color

--- a/crates/scitadel-mcp/src/server.rs
+++ b/crates/scitadel-mcp/src/server.rs
@@ -6,14 +6,41 @@
 //! in `crate::tools` so this file stays a thin façade.
 
 use rmcp::{
-    ServerHandler,
+    Peer, RoleServer, ServerHandler,
     handler::server::{router::tool::ToolRouter, wrapper::Parameters},
-    schemars, tool, tool_handler, tool_router,
+    model::{ProgressNotificationParam, ProgressToken},
+    schemars,
+    service::RequestContext,
+    tool, tool_handler, tool_router,
 };
 use schemars::JsonSchema;
 use serde::Deserialize;
 
 use crate::tools;
+
+/// Helper: emit a progress notification if the caller opted in by
+/// supplying a `progressToken` in the request `_meta`. Failures are
+/// logged but never propagated — progress is best-effort.
+async fn notify(
+    peer: &Peer<RoleServer>,
+    token: Option<&ProgressToken>,
+    progress: f64,
+    total: Option<f64>,
+    message: impl Into<String>,
+) {
+    let Some(token) = token else { return };
+    let result = peer
+        .notify_progress(ProgressNotificationParam {
+            progress_token: token.clone(),
+            progress,
+            total,
+            message: Some(message.into()),
+        })
+        .await;
+    if let Err(e) = result {
+        tracing::warn!(error = %e, "failed to send progress notification");
+    }
+}
 
 // ---------- Aggregate request structs ----------
 
@@ -276,10 +303,46 @@ impl Default for ScitadelServer {
 #[tool_router(router = tool_router)]
 impl ScitadelServer {
     #[tool(
-        description = "Search scientific literature across multiple sources. Returns: JSON with search_id, query, per-source outcomes, total counts, and a `summary` text field for human readers."
+        description = "Search scientific literature across multiple sources. Returns: JSON with search_id, query, per-source outcomes, total counts, and a `summary` text field for human readers. Emits MCP progress notifications (start + done) when the caller supplies a `progressToken` in `_meta` (#58)."
     )]
-    async fn search(&self, Parameters(req): Parameters<SearchRequest>) -> Result<String, String> {
-        tools::search_tool(req.query, req.sources, req.max_results, req.question_id).await
+    async fn search(
+        &self,
+        Parameters(req): Parameters<SearchRequest>,
+        ctx: RequestContext<RoleServer>,
+    ) -> Result<String, String> {
+        let token = ctx.meta.get_progress_token();
+        let source_count = req
+            .sources
+            .split(',')
+            .filter(|s| !s.trim().is_empty())
+            .count() as f64;
+        notify(
+            &ctx.peer,
+            token.as_ref(),
+            0.0,
+            Some(source_count.max(1.0)),
+            format!(
+                "searching {} source(s) for \"{}\"",
+                source_count.max(1.0),
+                req.query
+            ),
+        )
+        .await;
+        let result =
+            tools::search_tool(req.query, req.sources, req.max_results, req.question_id).await;
+        let done_msg = match &result {
+            Ok(_) => "search complete".to_string(),
+            Err(e) => format!("search failed: {e}"),
+        };
+        notify(
+            &ctx.peer,
+            token.as_ref(),
+            source_count.max(1.0),
+            Some(source_count.max(1.0)),
+            done_msg,
+        )
+        .await;
+        result
     }
 
     #[tool(
@@ -534,18 +597,39 @@ impl ScitadelServer {
     }
 
     #[tool(
-        description = "Download a paper (PDF or HTML). Prefer passing paper_id to leverage all stored identifiers (arxiv/openalex/doi); doi is a fallback for ad-hoc lookups. Returns: text (path + access status)."
+        description = "Download a paper (PDF or HTML). Prefer passing paper_id to leverage all stored identifiers (arxiv/openalex/doi); doi is a fallback for ad-hoc lookups. Returns: text (path + access status). Emits MCP progress notifications (start + done) when the caller supplies a `progressToken` in `_meta` (#58)."
     )]
     async fn download_paper(
         &self,
         Parameters(req): Parameters<DownloadPaperRequest>,
+        ctx: RequestContext<RoleServer>,
     ) -> Result<String, String> {
-        tools::download_paper_tool(
+        let token = ctx.meta.get_progress_token();
+        let target = req
+            .paper_id
+            .as_deref()
+            .or(req.doi.as_deref())
+            .unwrap_or("(no paper_id or doi)");
+        notify(
+            &ctx.peer,
+            token.as_ref(),
+            0.0,
+            Some(1.0),
+            format!("downloading {target}"),
+        )
+        .await;
+        let result = tools::download_paper_tool(
             req.paper_id.as_deref(),
             req.doi.as_deref(),
             req.output_dir.as_deref(),
         )
-        .await
+        .await;
+        let done_msg = match &result {
+            Ok(_) => "download complete".to_string(),
+            Err(e) => format!("download failed: {e}"),
+        };
+        notify(&ctx.peer, token.as_ref(), 1.0, Some(1.0), done_msg).await;
+        result
     }
 
     #[tool(
@@ -559,13 +643,29 @@ impl ScitadelServer {
     }
 
     #[tool(
-        description = "Prepare batch assessments for all papers in a search. Returns: text (rubric + per-paper context + instructions)."
+        description = "Prepare batch assessments for all papers in a search. Returns: text (rubric + per-paper context + instructions). Emits MCP progress notifications (start + done) when the caller supplies a `progressToken` in `_meta` (#58)."
     )]
-    fn prepare_batch_assessments(
+    async fn prepare_batch_assessments(
         &self,
         Parameters(req): Parameters<SearchQuestionRequest>,
+        ctx: RequestContext<RoleServer>,
     ) -> Result<String, String> {
-        tools::prepare_batch_assessments_tool(&req.search_id, &req.question_id)
+        let token = ctx.meta.get_progress_token();
+        notify(
+            &ctx.peer,
+            token.as_ref(),
+            0.0,
+            Some(1.0),
+            format!("preparing assessments for search {}", req.search_id),
+        )
+        .await;
+        let result = tools::prepare_batch_assessments_tool(&req.search_id, &req.question_id);
+        let done_msg = match &result {
+            Ok(_) => "batch prep complete".to_string(),
+            Err(e) => format!("batch prep failed: {e}"),
+        };
+        notify(&ctx.peer, token.as_ref(), 1.0, Some(1.0), done_msg).await;
+        result
     }
 }
 


### PR DESCRIPTION
## Summary

Closes the final 0.4.0 issue. The \`search\`, \`download_paper\`, and \`prepare_batch_assessments\` tools now emit MCP \`notifications/progress\` frames when the caller opts in by supplying a \`progressToken\` in the request \`_meta\`. Frame shape per the spec:

\`\`\`
{ progressToken, progress: f64, total: Option<f64>, message }
\`\`\`

Pattern is a simple **start/done bracket**: progress=0 at entry with a descriptive message ("searching N source(s) for X"), and progress=total at exit (or progress=total + an error message on failure). Per-source / per-paper granularity would need the orchestrator to thread a callback through each adapter loop — that's a follow-up; the start/done bracket alone delivers the core value flagged in #58 (host LLM no longer sits idle without acknowledgment).

**Implementation:**
- Single \`notify(peer, token, progress, total, message)\` helper that no-ops cleanly when the caller didn't supply a progress token.
- Failure to send is logged via \`tracing::warn!\` but never propagates — progress is best-effort.
- Each affected handler gains a \`RequestContext<RoleServer>\` extractor; the rmcp 0.17 macro picks up \`ctx.peer\` and \`ctx.meta.get_progress_token()\` automatically.
- \`prepare_batch_assessments\` becomes \`async fn\` (was sync); the underlying tool function still runs synchronously, only the outer wrapper awaits.

Tool descriptions updated to document the behaviour. The #98 style test still passes.

Built on the rmcp 0.1.5 → 0.17 upgrade (PR #110) that landed earlier today.

## Test plan

- [x] \`cargo test --workspace\`
- [x] \`cargo clippy --workspace -- -D warnings\`
- [x] \`cargo fmt --check\`