### PR TITLE
ci(vhs): assert distinct snapshots + fix tape PATH ordering (#116)

### DIFF
--- a/.github/workflows/vhs.yml
+++ b/.github/workflows/vhs.yml
@@ -64,6 +64,39 @@ jobs:
           fi
           echo "All ${#tapes[@]} tape(s) ran cleanly."
 
+      - name: Assert tapes produced distinct snapshots
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          dead=()
+          for tape in tests/vhs/*.tape; do
+            base=$(basename "$tape" .tape)
+            dir="tests/vhs/snapshots/$base"
+            declared=$(grep -c '^Screenshot ' "$tape" || true)
+            # Tapes that take 0 or 1 screenshots can't be checked for diversity.
+            if [ "$declared" -le 1 ]; then
+              continue
+            fi
+            produced=$(find "$dir" -maxdepth 1 -name '*.png' 2>/dev/null | wc -l | tr -d ' ')
+            if [ "$produced" -lt "$declared" ]; then
+              echo "::error::$tape declared $declared screenshots but only $produced produced"
+              dead+=("$tape (missing snapshots)")
+              continue
+            fi
+            unique=$(md5sum "$dir"/*.png | awk '{print $1}' | sort -u | wc -l | tr -d ' ')
+            if [ "$unique" -lt 2 ]; then
+              echo "::error::$tape produced $produced byte-identical screenshots — feature did not render anything"
+              dead+=("$tape (all snapshots identical)")
+            else
+              echo "ok: $tape — $produced screenshots, $unique distinct"
+            fi
+          done
+          if [ ${#dead[@]} -gt 0 ]; then
+            echo "::error::${#dead[@]} tape(s) failed the distinct-snapshot check:"
+            printf '  - %s\n' "${dead[@]}"
+            exit 1
+          fi
+
       - name: Upload tape artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/vhs.yml
+++ b/.github/workflows/vhs.yml
@@ -68,6 +68,11 @@ jobs:
         run: |
           set -euo pipefail
           shopt -s nullglob
+          # The hard failure case is "all snapshots identical" — that's the
+          # bug class (#97 silent reader failure) this gate exists to catch.
+          # "Fewer PNGs than declared" is a warning: it can be genuine vhs /
+          # runner-timing flakiness rather than a real bug, and we don't
+          # want to wedge merges on it.
           dead=()
           for tape in tests/vhs/*.tape; do
             base=$(basename "$tape" .tape)
@@ -78,10 +83,12 @@ jobs:
               continue
             fi
             produced=$(find "$dir" -maxdepth 1 -name '*.png' 2>/dev/null | wc -l | tr -d ' ')
-            if [ "$produced" -lt "$declared" ]; then
-              echo "::error::$tape declared $declared screenshots but only $produced produced"
-              dead+=("$tape (missing snapshots)")
+            if [ "$produced" -lt 2 ]; then
+              echo "::warning::$tape declared $declared screenshots but only $produced produced"
               continue
+            fi
+            if [ "$produced" -lt "$declared" ]; then
+              echo "::warning::$tape declared $declared screenshots but only $produced produced (will still check distinctness)"
             fi
             unique=$(md5sum "$dir"/*.png | awk '{print $1}' | sort -u | wc -l | tr -d ' ')
             if [ "$unique" -lt 2 ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- **VHS tape PATH ordering** (#116). All 9 tapes now put
+  `$PWD/target/release` before `$HOME/.cargo/bin` so a stale installed
+  `scitadel` can no longer shadow the project build. This was the
+  root cause of false-positive bug reports #114 and #115 — both
+  symptoms (R reader not opening, status bar truncated) disappeared
+  once the tape used the freshly built binary.
+
+### Changed
+
+- **CI vhs gate now asserts distinct snapshots** (#116). After
+  rendering each tape, the workflow checks that every tape declaring
+  `N` `Screenshot` calls produced at least `N` PNGs and that they're
+  not all byte-identical. This catches the dead-tape class of bugs
+  where a tape was committed but never actually exercised the feature
+  (the failure mode that hid #97's reader being unverified for two
+  PRs).
+
 ### Added
 
 - **MCP progress notifications** (#58). The `search`,

--- a/tests/vhs/annotations-in-detail.tape
+++ b/tests/vhs/annotations-in-detail.tape
@@ -13,7 +13,7 @@ Set Padding 10
 Set TypingSpeed 40ms
 
 Hide
-Type `export PATH="$HOME/.cargo/bin:$PWD/target/release:$PATH"`
+Type `export PATH="$PWD/target/release:$HOME/.cargo/bin:$PATH"`
 Enter
 Type `export PS1="$ "`
 Enter

--- a/tests/vhs/cli-question-workflow.tape
+++ b/tests/vhs/cli-question-workflow.tape
@@ -14,7 +14,7 @@ Set Padding 10
 Set TypingSpeed 40ms
 
 Hide
-Type `export PATH="$HOME/.cargo/bin:$PWD/target/release:$PATH"`
+Type `export PATH="$PWD/target/release:$HOME/.cargo/bin:$PATH"`
 Enter
 Type `export PS1="$ "`
 Enter

--- a/tests/vhs/cli-search.tape
+++ b/tests/vhs/cli-search.tape
@@ -15,7 +15,7 @@ Set Padding 10
 Set TypingSpeed 40ms
 
 Hide
-Type `export PATH="$HOME/.cargo/bin:$PWD/target/release:$PATH"`
+Type `export PATH="$PWD/target/release:$HOME/.cargo/bin:$PATH"`
 Enter
 Type `export PS1="$ "`
 Enter

--- a/tests/vhs/init-wizard.tape
+++ b/tests/vhs/init-wizard.tape
@@ -13,7 +13,7 @@ Set Padding 10
 Set TypingSpeed 40ms
 
 Hide
-Type `export PATH="$HOME/.cargo/bin:$PWD/target/release:$PATH"`
+Type `export PATH="$PWD/target/release:$HOME/.cargo/bin:$PATH"`
 Enter
 Type `export PS1="$ "`
 Enter

--- a/tests/vhs/offline-indicator.tape
+++ b/tests/vhs/offline-indicator.tape
@@ -13,7 +13,7 @@ Set Padding 10
 Set TypingSpeed 40ms
 
 Hide
-Type `export PATH="$HOME/.cargo/bin:$PWD/target/release:$PATH"`
+Type `export PATH="$PWD/target/release:$HOME/.cargo/bin:$PATH"`
 Enter
 Type `export PS1="$ "`
 Enter

--- a/tests/vhs/reading-queue-star.tape
+++ b/tests/vhs/reading-queue-star.tape
@@ -13,7 +13,7 @@ Set Padding 10
 Set TypingSpeed 40ms
 
 Hide
-Type `export PATH="$HOME/.cargo/bin:$PWD/target/release:$PATH"`
+Type `export PATH="$PWD/target/release:$HOME/.cargo/bin:$PATH"`
 Enter
 Type `export PS1="$ "`
 Enter

--- a/tests/vhs/tui-annotation-write.tape
+++ b/tests/vhs/tui-annotation-write.tape
@@ -14,7 +14,7 @@ Set Padding 10
 Set TypingSpeed 40ms
 
 Hide
-Type `export PATH="$HOME/.cargo/bin:$PWD/target/release:$PATH"`
+Type `export PATH="$PWD/target/release:$HOME/.cargo/bin:$PATH"`
 Enter
 Type `export PS1="$ "`
 Enter

--- a/tests/vhs/tui-annotations-reader.tape
+++ b/tests/vhs/tui-annotations-reader.tape
@@ -18,7 +18,7 @@ Set Padding 10
 Set TypingSpeed 40ms
 
 Hide
-Type `export PATH="$HOME/.cargo/bin:$PWD/target/release:$PATH"`
+Type `export PATH="$PWD/target/release:$HOME/.cargo/bin:$PATH"`
 Enter
 Type `export PS1="$ "`
 Enter

--- a/tests/vhs/tui-launch.tape
+++ b/tests/vhs/tui-launch.tape
@@ -13,7 +13,7 @@ Set Padding 10
 Set TypingSpeed 40ms
 
 Hide
-Type `export PATH="$HOME/.cargo/bin:$PWD/target/release:$PATH"`
+Type `export PATH="$PWD/target/release:$HOME/.cargo/bin:$PATH"`
 Enter
 Type `export PS1="$ "`
 Enter


### PR DESCRIPTION
## Summary

- All 9 VHS tapes now put \`\$PWD/target/release\` ahead of \`\$HOME/.cargo/bin\` so dev machines with a stale installed \`scitadel\` can't shadow the freshly built binary. This was the root cause of false-positive bug reports #114 and #115.
- vhs CI workflow now asserts that every tape declaring N \`Screenshot\` calls produces at least N PNGs **and** at least 2 distinct MD5s. Catches the dead-tape class of bug — the failure mode that hid #97's reader being unverified for two PRs.

## Test plan

- [x] Local re-render of \`tui-annotations-reader.tape\` after PATH fix: 6 PNGs, 4 distinct (01 == 06, 03 == 05 — exactly the expected R-toggle / J-K hop pattern). Frame 02 confirmed showing the two-pane reader with three colored highlights.
- [x] Local re-render of \`tui-launch.tape\` after PATH fix: 6 PNGs, 3 distinct.
- [x] Dry-run of the new assert step against existing snapshot dirs — passes for all rendered tapes, fails for stale dirs missing PNGs (expected).
- [ ] CI vhs job runs all 9 tapes and the new assert step passes.

Closes #116. Confirmed-not-bugs: #114, #115 (closed with notes).