### PR TITLE
feat(papers): persist download state + Papers-table column (#112)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Papers-table download-state column** (#112). Migration 007 adds
+  `local_path`, `download_status`, and `last_attempt_at` columns to
+  `papers`. The TUI Papers table renders a one-char symbol next to
+  each row: blank (never tried), `↻` (in flight), `✓` (downloaded),
+  `⊘` (paywalled / abstract-only), `✗` (failed). Both the TUI's
+  `D` keybind and the `scitadel download` CLI persist the outcome
+  back to the row so the symbol survives restarts. The in-flight
+  symbol is derived from the live task list — no DB write while
+  running.
 - **MCP progress notifications** (#58). The `search`,
   `download_paper`, and `prepare_batch_assessments` tools now emit
   `notifications/progress` frames when the caller supplies a

--- a/crates/scitadel-cli/src/commands.rs
+++ b/crates/scitadel-cli/src/commands.rs
@@ -641,10 +641,13 @@ pub async fn download(doi: &str, output_dir: Option<PathBuf>) -> Result<()> {
     println!("Downloading paper: {doi}");
     println!("  Output dir: {}", out_dir.display());
 
-    let result = downloader
-        .download(doi, &out_dir)
-        .await
-        .context("download failed")?;
+    let result = downloader.download(doi, &out_dir).await;
+
+    // Persist outcome on the matching paper row (#112) before reporting
+    // so the Papers table reflects the attempt regardless of outcome.
+    persist_cli_download_outcome(&config, doi, result.as_ref().ok());
+
+    let result = result.context("download failed")?;
 
     println!("  Format: {}", result.format);
     println!("  Source: {}", result.source);
@@ -653,6 +656,56 @@ pub async fn download(doi: &str, output_dir: Option<PathBuf>) -> Result<()> {
     println!("  Saved:  {}", result.path.display());
 
     Ok(())
+}
+
+fn persist_cli_download_outcome(
+    config: &scitadel_core::config::Config,
+    doi: &str,
+    success: Option<&scitadel_adapters::download::DownloadResult>,
+) {
+    use scitadel_adapters::download::AccessStatus;
+    use scitadel_core::models::DownloadStatus;
+    use scitadel_core::ports::PaperRepository as _;
+
+    let db = match scitadel_db::sqlite::Database::open(&config.db_path) {
+        Ok(db) => db,
+        Err(e) => {
+            tracing::warn!(error = %e, "could not open DB to persist download outcome");
+            return;
+        }
+    };
+    if let Err(e) = db.migrate() {
+        tracing::warn!(error = %e, "DB migration failed while persisting download outcome");
+        return;
+    }
+    let (paper_repo, _, _, _, _) = db.repositories();
+    let paper = match paper_repo.find_by_doi(doi) {
+        Ok(Some(p)) => p,
+        Ok(None) => {
+            tracing::debug!(doi, "no paper row for DOI; skipping download-state write");
+            return;
+        }
+        Err(e) => {
+            tracing::warn!(doi, error = %e, "DOI lookup failed");
+            return;
+        }
+    };
+
+    let (path, status) = match success {
+        Some(r) => {
+            let ds = match r.access {
+                AccessStatus::FullText => DownloadStatus::Downloaded,
+                AccessStatus::Abstract | AccessStatus::Paywall | AccessStatus::Unknown => {
+                    DownloadStatus::Paywall
+                }
+            };
+            (Some(r.path.to_string_lossy().into_owned()), ds)
+        }
+        None => (None, DownloadStatus::Failed),
+    };
+    if let Err(e) = paper_repo.update_download_state(paper.id.as_str(), path.as_deref(), status) {
+        tracing::warn!(error = %e, "failed to persist download outcome");
+    }
 }
 
 #[allow(clippy::unnecessary_wraps)]

--- a/crates/scitadel-core/src/models/mod.rs
+++ b/crates/scitadel-core/src/models/mod.rs
@@ -12,7 +12,7 @@ pub use annotation::{
 pub use assessment::Assessment;
 pub use citation::{Citation, CitationDirection, SnowballRun};
 pub use doi::{doi_to_filename, normalize_doi, validate_doi};
-pub use paper::{CandidatePaper, Paper};
+pub use paper::{CandidatePaper, DownloadStatus, Paper};
 pub use question::{ResearchQuestion, SearchTerm};
 pub use search::{Search, SearchResult, SourceOutcome, SourceStatus};
 

--- a/crates/scitadel-core/src/models/paper.rs
+++ b/crates/scitadel-core/src/models/paper.rs
@@ -29,6 +29,19 @@ pub struct Paper {
     pub source_urls: HashMap<String, String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    /// Absolute path to the locally downloaded file (PDF/HTML), if any.
+    /// Populated by the download pipeline; `None` until first successful
+    /// download attempt. See #112.
+    #[serde(default)]
+    pub local_path: Option<String>,
+    /// Outcome of the most recent download attempt. `None` = never tried.
+    #[serde(default)]
+    pub download_status: Option<DownloadStatus>,
+    /// Wall-clock time of the most recent download attempt. Together with
+    /// `download_status` lets the UI distinguish "fresh failure" from
+    /// "tried weeks ago, retry might work".
+    #[serde(default)]
+    pub last_attempt_at: Option<DateTime<Utc>>,
 }
 
 impl Paper {
@@ -53,6 +66,47 @@ impl Paper {
             source_urls: HashMap::new(),
             created_at: now,
             updated_at: now,
+            local_path: None,
+            download_status: None,
+            last_attempt_at: None,
+        }
+    }
+}
+
+/// Outcome of a paper download attempt. Persisted on `papers.download_status`.
+///
+/// `Downloaded` means the adapter classified the fetched bytes as full
+/// content. `Paywall` means we got bytes but they're an HTML stub /
+/// abstract / paywall page — file exists but doesn't contain the paper.
+/// `Failed` means the download itself errored (network, 404, etc.).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DownloadStatus {
+    Downloaded,
+    Paywall,
+    Failed,
+}
+
+impl DownloadStatus {
+    /// SQL-friendly string used in the `download_status` text column.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Downloaded => "downloaded",
+            Self::Paywall => "paywall",
+            Self::Failed => "failed",
+        }
+    }
+
+    /// Inverse of `as_str`. Returns `None` for unknown values so a
+    /// stale row from a future schema doesn't crash the loader.
+    #[must_use]
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "downloaded" => Some(Self::Downloaded),
+            "paywall" => Some(Self::Paywall),
+            "failed" => Some(Self::Failed),
+            _ => None,
         }
     }
 }

--- a/crates/scitadel-core/src/ports/repository.rs
+++ b/crates/scitadel-core/src/ports/repository.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 
 use crate::error::CoreError;
 use crate::models::{
-    Assessment, Citation, Paper, PaperId, ResearchQuestion, Search, SearchResult, SearchTerm,
-    SnowballRun,
+    Assessment, Citation, DownloadStatus, Paper, PaperId, ResearchQuestion, Search, SearchResult,
+    SearchTerm, SnowballRun,
 };
 
 /// Port for paper persistence.
@@ -24,6 +24,16 @@ pub trait PaperRepository: Send + Sync {
     /// re-running pdf-extract. Idempotent — overwrites the existing
     /// `full_text` column.
     fn update_full_text(&self, paper_id: &str, text: &str) -> Result<(), CoreError>;
+    /// Persist the outcome of a download attempt. `local_path` is the
+    /// absolute path to the saved file on success (any non-`Failed`
+    /// status); pass `None` for `Failed`. `last_attempt_at` is set to
+    /// `now()` automatically. See #112.
+    fn update_download_state(
+        &self,
+        paper_id: &str,
+        local_path: Option<&str>,
+        status: DownloadStatus,
+    ) -> Result<(), CoreError>;
 }
 
 /// Port for search run persistence.

--- a/crates/scitadel-db/migrations/007_paper_download_state.sql
+++ b/crates/scitadel-db/migrations/007_paper_download_state.sql
@@ -1,0 +1,10 @@
+-- Persist the outcome of paper downloads so the TUI can show a state
+-- column ("never tried", "downloaded", "paywalled", "failed") without
+-- re-probing on every render and the user can tell at a glance which
+-- papers are openable. See #112.
+
+ALTER TABLE papers ADD COLUMN local_path TEXT;
+ALTER TABLE papers ADD COLUMN download_status TEXT;
+ALTER TABLE papers ADD COLUMN last_attempt_at TEXT;
+
+INSERT OR IGNORE INTO schema_version (version, applied_at) VALUES (7, datetime('now'));

--- a/crates/scitadel-db/src/sqlite/migrations.rs
+++ b/crates/scitadel-db/src/sqlite/migrations.rs
@@ -8,6 +8,7 @@ const MIGRATION_003: &str = include_str!("../../migrations/003_full_text.sql");
 const MIGRATION_004: &str = include_str!("../../migrations/004_paper_state.sql");
 const MIGRATION_005: &str = include_str!("../../migrations/005_annotations.sql");
 const MIGRATION_006: &str = include_str!("../../migrations/006_search_fts.sql");
+const MIGRATION_007: &str = include_str!("../../migrations/007_paper_download_state.sql");
 
 const MIGRATIONS: &[(i64, &str)] = &[
     (1, MIGRATION_001),
@@ -16,6 +17,7 @@ const MIGRATIONS: &[(i64, &str)] = &[
     (4, MIGRATION_004),
     (5, MIGRATION_005),
     (6, MIGRATION_006),
+    (7, MIGRATION_007),
 ];
 
 /// Run all pending migrations, skipping already-applied ones.

--- a/crates/scitadel-db/src/sqlite/papers.rs
+++ b/crates/scitadel-db/src/sqlite/papers.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use rusqlite::params;
 use scitadel_core::error::CoreError;
-use scitadel_core::models::{Paper, PaperId};
+use scitadel_core::models::{DownloadStatus, Paper, PaperId};
 use scitadel_core::ports::PaperRepository;
 
 use super::Database;
@@ -117,6 +117,10 @@ fn row_to_paper(row: &rusqlite::Row) -> rusqlite::Result<Paper> {
     let created_at: String = row.get("created_at")?;
     let updated_at: String = row.get("updated_at")?;
 
+    let local_path: Option<String> = row.get("local_path").ok();
+    let download_status_raw: Option<String> = row.get("download_status").ok();
+    let last_attempt_at_raw: Option<String> = row.get("last_attempt_at").ok();
+
     Ok(Paper {
         id: PaperId::from(id),
         title: row.get("title")?,
@@ -135,6 +139,14 @@ fn row_to_paper(row: &rusqlite::Row) -> rusqlite::Result<Paper> {
         source_urls: serde_json::from_str(&source_urls_json).unwrap_or_default(),
         created_at: super::parse_rfc3339_or_now(&created_at),
         updated_at: super::parse_rfc3339_or_now(&updated_at),
+        local_path,
+        download_status: download_status_raw
+            .as_deref()
+            .and_then(DownloadStatus::parse),
+        last_attempt_at: last_attempt_at_raw
+            .as_deref()
+            .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+            .map(|dt| dt.with_timezone(&chrono::Utc)),
     })
 }
 
@@ -278,6 +290,23 @@ impl PaperRepository for SqlitePaperRepository {
         conn.execute(
             "UPDATE papers SET full_text = ?1, updated_at = ?2 WHERE id = ?3",
             params![text, chrono::Utc::now().to_rfc3339(), paper_id],
+        )
+        .map_err(DbError::Sqlite)?;
+        Ok(())
+    }
+
+    fn update_download_state(
+        &self,
+        paper_id: &str,
+        local_path: Option<&str>,
+        status: DownloadStatus,
+    ) -> Result<(), CoreError> {
+        let conn = self.db.conn()?;
+        let now = chrono::Utc::now().to_rfc3339();
+        conn.execute(
+            "UPDATE papers SET local_path = ?1, download_status = ?2, last_attempt_at = ?3, \
+             updated_at = ?3 WHERE id = ?4",
+            params![local_path, status.as_str(), now, paper_id],
         )
         .map_err(DbError::Sqlite)?;
         Ok(())
@@ -484,5 +513,37 @@ mod tests {
                 "remapped paper_id should exist in DB"
             );
         }
+    }
+
+    #[test]
+    fn download_state_round_trips() {
+        let (_, repo) = setup();
+        let paper = Paper::new("DL state");
+        repo.save(&paper).unwrap();
+
+        // Pristine row: no download attempted yet.
+        let initial = repo.get(paper.id.as_str()).unwrap().unwrap();
+        assert!(initial.local_path.is_none());
+        assert!(initial.download_status.is_none());
+        assert!(initial.last_attempt_at.is_none());
+
+        // Successful download.
+        repo.update_download_state(
+            paper.id.as_str(),
+            Some("/tmp/foo.pdf"),
+            DownloadStatus::Downloaded,
+        )
+        .unwrap();
+        let after = repo.get(paper.id.as_str()).unwrap().unwrap();
+        assert_eq!(after.local_path.as_deref(), Some("/tmp/foo.pdf"));
+        assert_eq!(after.download_status, Some(DownloadStatus::Downloaded));
+        assert!(after.last_attempt_at.is_some());
+
+        // Subsequent failure overwrites cleanly (path None, status Failed).
+        repo.update_download_state(paper.id.as_str(), None, DownloadStatus::Failed)
+            .unwrap();
+        let failed = repo.get(paper.id.as_str()).unwrap().unwrap();
+        assert!(failed.local_path.is_none());
+        assert_eq!(failed.download_status, Some(DownloadStatus::Failed));
     }
 }

--- a/crates/scitadel-tui/src/app.rs
+++ b/crates/scitadel-tui/src/app.rs
@@ -16,7 +16,7 @@ use ratatui::widgets::Tabs;
 use tokio::sync::mpsc;
 
 use crate::data::DataStore;
-use crate::tasks::{Task, TaskUpdate, spawn_download_paper};
+use crate::tasks::{Task, TaskKind, TaskStatus, TaskUpdate, spawn_download_paper};
 use crate::views::annotation_prompt::{AnnotationPrompt, PromptCommit, PromptSubmission};
 use crate::views::{annotation_prompt, detail, papers, questions, searches, tasks as tasks_view};
 use crate::widgets::status_bar;
@@ -183,10 +183,68 @@ impl App {
                     }
                 }
                 TaskUpdate::Status { id, status } => {
+                    // Persist Done/Failed back to papers.download_status
+                    // (#112) before mutating the in-memory task — borrow
+                    // the matching task once to read the paper_id.
+                    let paper_id = self
+                        .tasks
+                        .iter()
+                        .find(|t| t.id == id)
+                        .map(|t| match &t.kind {
+                            TaskKind::Download { paper_id, .. } => paper_id.clone(),
+                        });
+                    if let Some(pid) = paper_id {
+                        self.persist_download_outcome(&pid, &status);
+                    }
                     if let Some(t) = self.tasks.iter_mut().find(|t| t.id == id) {
                         t.status = status;
                     }
                 }
+            }
+        }
+    }
+
+    /// Set of paper IDs that have a Queued or Running download task.
+    /// Used by the Papers table to render the `↻` in-flight symbol.
+    fn downloading_paper_ids(&self) -> std::collections::HashSet<String> {
+        self.tasks
+            .iter()
+            .filter(|t| matches!(t.status, TaskStatus::Queued | TaskStatus::Running))
+            .map(|t| {
+                let TaskKind::Download { paper_id, .. } = &t.kind;
+                paper_id.clone()
+            })
+            .collect()
+    }
+
+    fn persist_download_outcome(&self, paper_id: &str, status: &TaskStatus) {
+        use scitadel_adapters::download::AccessStatus;
+        use scitadel_core::models::DownloadStatus;
+        let outcome = match status {
+            TaskStatus::Done { path, access, .. } => {
+                let download_status = match access {
+                    AccessStatus::FullText => DownloadStatus::Downloaded,
+                    AccessStatus::Abstract | AccessStatus::Paywall | AccessStatus::Unknown => {
+                        DownloadStatus::Paywall
+                    }
+                };
+                Some((path.to_string_lossy().into_owned(), download_status))
+            }
+            TaskStatus::Failed(_) => Some((String::new(), DownloadStatus::Failed)),
+            TaskStatus::Queued | TaskStatus::Running => None,
+        };
+        if let Some((path, ds)) = outcome {
+            let path_arg = if matches!(ds, DownloadStatus::Failed) {
+                None
+            } else {
+                Some(path.as_str())
+            };
+            if let Err(e) = self.data.record_download_outcome(paper_id, path_arg, ds) {
+                tracing::warn!(
+                    paper_id,
+                    error = %e,
+                    "failed to persist download outcome"
+                );
             }
         }
     }
@@ -644,6 +702,7 @@ fn draw(frame: &mut ratatui::Frame, app: &mut App) {
                 search_id,
                 *selected,
                 &app.starred,
+                &app.downloading_paper_ids(),
             );
         }
         None => match app.tab {
@@ -654,6 +713,7 @@ fn draw(frame: &mut ratatui::Frame, app: &mut App) {
                 &app.data,
                 app.paper_selected,
                 &app.starred,
+                &app.downloading_paper_ids(),
             ),
             Tab::Questions => {
                 questions::draw(frame, chunks[1], &app.data, app.question_selected);

--- a/crates/scitadel-tui/src/data.rs
+++ b/crates/scitadel-tui/src/data.rs
@@ -142,4 +142,17 @@ impl DataStore {
     pub fn delete_annotation(&self, annotation_id: &str) -> Result<()> {
         Ok(SqliteAnnotationRepository::new(self.db.clone()).soft_delete(annotation_id)?)
     }
+
+    /// Persist the outcome of a download attempt for the Papers-table
+    /// state column (#112). `local_path` is the absolute path to the
+    /// saved file on success, `None` on failure.
+    pub fn record_download_outcome(
+        &self,
+        paper_id: &str,
+        local_path: Option<&str>,
+        status: scitadel_core::models::DownloadStatus,
+    ) -> Result<()> {
+        let (paper_repo, _, _, _, _) = self.db.repositories();
+        Ok(paper_repo.update_download_state(paper_id, local_path, status)?)
+    }
 }

--- a/crates/scitadel-tui/src/tasks.rs
+++ b/crates/scitadel-tui/src/tasks.rs
@@ -15,7 +15,13 @@ pub struct Task {
 #[derive(Debug, Clone)]
 pub enum TaskKind {
     /// `ref_id` is the best identifier we have to show the user (DOI, arxiv id, or paper UUID prefix).
-    Download { ref_id: String, title: String },
+    /// `paper_id` lets the drain loop persist the outcome back to the
+    /// `papers.download_status` column (#112).
+    Download {
+        paper_id: String,
+        ref_id: String,
+        title: String,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -58,6 +64,7 @@ pub fn spawn_download_paper(
     let task = Task {
         id,
         kind: TaskKind::Download {
+            paper_id: paper.id.as_str().to_string(),
             ref_id,
             title: paper.title.clone(),
         },

--- a/crates/scitadel-tui/src/views/papers.rs
+++ b/crates/scitadel-tui/src/views/papers.rs
@@ -5,7 +5,7 @@ use ratatui::layout::{Constraint, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table, TableState};
 
-use scitadel_core::models::Paper;
+use scitadel_core::models::{DownloadStatus, Paper};
 
 use crate::data::DataStore;
 use crate::views::util::truncate;
@@ -16,9 +16,18 @@ pub fn draw(
     data: &DataStore,
     selected: usize,
     starred: &HashSet<String>,
+    downloading: &HashSet<String>,
 ) {
     let papers = data.load_papers(1000, 0).unwrap_or_default();
-    render_paper_table(frame, area, &papers, selected, " Papers ", starred);
+    render_paper_table(
+        frame,
+        area,
+        &papers,
+        selected,
+        " Papers ",
+        starred,
+        downloading,
+    );
 }
 
 pub fn draw_for_search(
@@ -28,13 +37,29 @@ pub fn draw_for_search(
     search_id: &str,
     selected: usize,
     starred: &HashSet<String>,
+    downloading: &HashSet<String>,
 ) {
     let papers = data.load_papers_for_search(search_id).unwrap_or_default();
     let title = format!(
         " Papers for search {} ",
         search_id.chars().take(8).collect::<String>()
     );
-    render_paper_table(frame, area, &papers, selected, &title, starred);
+    render_paper_table(frame, area, &papers, selected, &title, starred, downloading);
+}
+
+/// Returns (symbol, color) for the Papers-table state column.
+/// `↻` if a download is currently running for this paper, otherwise
+/// derived from the persisted `download_status` (#112).
+fn download_cell(paper: &Paper, downloading: &HashSet<String>) -> (&'static str, Color) {
+    if downloading.contains(paper.id.as_str()) {
+        return ("↻", Color::Yellow);
+    }
+    match paper.download_status {
+        Some(DownloadStatus::Downloaded) => ("✓", Color::Green),
+        Some(DownloadStatus::Paywall) => ("⊘", Color::Yellow),
+        Some(DownloadStatus::Failed) => ("✗", Color::Red),
+        None => (" ", Color::DarkGray),
+    }
 }
 
 fn render_paper_table(
@@ -44,6 +69,7 @@ fn render_paper_table(
     selected: usize,
     title: &str,
     starred: &HashSet<String>,
+    downloading: &HashSet<String>,
 ) {
     if papers.is_empty() {
         let block = Block::default()
@@ -56,6 +82,7 @@ fn render_paper_table(
 
     let header = Row::new(vec![
         Cell::from("#"),
+        Cell::from(""),
         Cell::from(""),
         Cell::from("Title"),
         Cell::from("Authors"),
@@ -78,10 +105,12 @@ fn render_paper_table(
             } else {
                 " "
             };
+            let (dl_symbol, dl_color) = download_cell(p, downloading);
 
             Row::new(vec![
                 Cell::from((i + 1).to_string()),
                 Cell::from(star).style(Style::default().fg(Color::Yellow)),
+                Cell::from(dl_symbol).style(Style::default().fg(dl_color)),
                 Cell::from(truncate(&p.title, 60)),
                 Cell::from(truncate(&authors, 30)),
                 Cell::from(year),
@@ -91,6 +120,7 @@ fn render_paper_table(
 
     let widths = [
         Constraint::Length(5),
+        Constraint::Length(2),
         Constraint::Length(2),
         Constraint::Min(30),
         Constraint::Length(32),

--- a/crates/scitadel-tui/src/views/tasks.rs
+++ b/crates/scitadel-tui/src/views/tasks.rs
@@ -36,7 +36,7 @@ fn render_row(task: &Task, show_institutional_hint: bool) -> ListItem<'_> {
     };
 
     let (title, ref_id) = match &task.kind {
-        TaskKind::Download { title, ref_id } => (truncate(title, 55), ref_id.as_str()),
+        TaskKind::Download { title, ref_id, .. } => (truncate(title, 55), ref_id.as_str()),
     };
 
     let status_tail = status_tail_text(&task.status, show_institutional_hint);

--- a/tests/vhs/papers-download-state.tape
+++ b/tests/vhs/papers-download-state.tape
@@ -1,0 +1,56 @@
+# VHS tape: Papers table renders the download-state column (#112).
+#
+# Seeds 4 papers, each in a different download_status state
+# (none / downloaded / paywall / failed) so the symbol column
+# renders all four glyphs side-by-side: blank, ✓, ⊘, ✗.
+
+Output "tests/vhs/snapshots/papers-download-state/run.gif"
+
+Set Shell "bash"
+Set FontSize 14
+Set Width 1400
+Set Height 600
+Set Padding 10
+Set TypingSpeed 40ms
+
+Hide
+Type `export PATH="$PWD/target/release:$HOME/.cargo/bin:$PATH"`
+Enter
+Type `export PS1="$ "`
+Enter
+Type `export SCITADEL_DB=$(mktemp -d)/scitadel.db`
+Enter
+Type "scitadel init --yes --email demo@example.org --sources arxiv --db $SCITADEL_DB"
+Enter
+Sleep 800ms
+
+# Seed 4 papers with distinct download states.
+Type `sqlite3 $SCITADEL_DB "INSERT INTO papers (id, title, authors, abstract, created_at, updated_at) VALUES ('p-none', 'Paper Never Tried', '[\"Alice\"]', '', datetime('now', '-4 hours'), datetime('now'));"`
+Enter
+Sleep 100ms
+Type `sqlite3 $SCITADEL_DB "INSERT INTO papers (id, title, authors, abstract, local_path, download_status, last_attempt_at, created_at, updated_at) VALUES ('p-ok', 'Paper Successfully Downloaded', '[\"Bob\"]', '', '/tmp/p-ok.pdf', 'downloaded', datetime('now'), datetime('now', '-3 hours'), datetime('now'));"`
+Enter
+Sleep 100ms
+Type `sqlite3 $SCITADEL_DB "INSERT INTO papers (id, title, authors, abstract, local_path, download_status, last_attempt_at, created_at, updated_at) VALUES ('p-pay', 'Paper Behind Paywall', '[\"Carol\"]', '', '/tmp/p-pay.html', 'paywall', datetime('now'), datetime('now', '-2 hours'), datetime('now'));"`
+Enter
+Sleep 100ms
+Type `sqlite3 $SCITADEL_DB "INSERT INTO papers (id, title, authors, abstract, download_status, last_attempt_at, created_at, updated_at) VALUES ('p-fail', 'Paper Download Failed', '[\"Dave\"]', '', 'failed', datetime('now'), datetime('now', '-1 hours'), datetime('now'));"`
+Enter
+Sleep 200ms
+
+Type "clear"
+Enter
+Show
+
+Type "scitadel tui"
+Enter
+Sleep 1500ms
+
+# Tab to Papers tab — table should show 4 rows with blank/✓/⊘/✗ symbols.
+Tab
+Sleep 500ms
+Screenshot "tests/vhs/snapshots/papers-download-state/01-papers-table.png"
+
+Type "q"
+Sleep 300ms
+Screenshot "tests/vhs/snapshots/papers-download-state/02-quit.png"


### PR DESCRIPTION
## Summary

- After download — TUI \`D\` or \`scitadel download\` — the outcome lives on the paper row (migration 007: \`local_path\`, \`download_status\`, \`last_attempt_at\`).
- Papers table renders a one-char state column: blank · \`↻\` · \`✓\` · \`⊘\` · \`✗\` (in flight / downloaded / paywalled / failed).
- New \`DownloadStatus\` enum in core, \`PaperRepository::update_download_state\`, persistence wired in TUI drain loop and CLI download command.

## Test plan

- [x] \`cargo test --workspace\` — 40 papers tests including new \`download_state_round_trips\`.
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean.
- [x] Local vhs render of new \`papers-download-state.tape\` shows all 4 glyphs side-by-side.

Closes #112.