### PR TITLE
feat(tui): task panel flush policy + c clear keybind (#113)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- **TUI task panel flush policy** (#113). Done downloads auto-flush
+  after 5 s, Failed after 30 s — long enough for the user to see the
+  result, short enough that they don't crowd the panel. The 10-task
+  cap now only evicts terminal tasks; an in-flight Queued or Running
+  download is never dropped to make room. New `c` keybind clears all
+  completed/failed tasks immediately (visible in the tab-mode status
+  bar).
+
 ### Added
 
 - **MCP progress notifications** (#58). The `search`,

--- a/crates/scitadel-tui/src/app.rs
+++ b/crates/scitadel-tui/src/app.rs
@@ -16,7 +16,7 @@ use ratatui::widgets::Tabs;
 use tokio::sync::mpsc;
 
 use crate::data::DataStore;
-use crate::tasks::{Task, TaskUpdate, spawn_download_paper};
+use crate::tasks::{Task, TaskStatus, TaskUpdate, spawn_download_paper};
 use crate::views::annotation_prompt::{AnnotationPrompt, PromptCommit, PromptSubmission};
 use crate::views::{annotation_prompt, detail, papers, questions, searches, tasks as tasks_view};
 use crate::widgets::status_bar;
@@ -171,6 +171,7 @@ impl App {
     fn drain_all_channels(&mut self) {
         self.drain_task_updates();
         self.drain_offline();
+        self.flush_completed_tasks();
     }
 
     fn drain_task_updates(&mut self) {
@@ -178,17 +179,37 @@ impl App {
             match update {
                 TaskUpdate::New(task) => {
                     self.tasks.push(task);
-                    if self.tasks.len() > 10 {
-                        self.tasks.remove(0);
+                    // Evict the oldest *terminal* task only — never drop
+                    // a Queued or Running download just because the panel
+                    // is full. If everything in the panel is still active,
+                    // grow past the cap rather than lose work.
+                    if self.tasks.len() > 10
+                        && let Some(idx) = self.tasks.iter().position(|t| t.terminal_at.is_some())
+                    {
+                        self.tasks.remove(idx);
                     }
                 }
                 TaskUpdate::Status { id, status } => {
                     if let Some(t) = self.tasks.iter_mut().find(|t| t.id == id) {
                         t.status = status;
+                        if matches!(t.status, TaskStatus::Done { .. } | TaskStatus::Failed(_)) {
+                            t.terminal_at = Some(std::time::Instant::now());
+                        }
                     }
                 }
             }
         }
+    }
+
+    /// Drop terminal tasks once their linger window has elapsed (5s for
+    /// Done, 30s for Failed). Runs every drain pass — cheap.
+    fn flush_completed_tasks(&mut self) {
+        crate::tasks::retain_recent_terminal(&mut self.tasks, std::time::Instant::now());
+    }
+
+    /// Drop every terminal task immediately. Bound to `c` in tab mode (#113).
+    fn clear_completed_tasks(&mut self) {
+        crate::tasks::clear_terminal(&mut self.tasks);
     }
 
     fn handle_key(&mut self, code: KeyCode, modifiers: KeyModifiers) {
@@ -209,6 +230,9 @@ impl App {
         match code {
             KeyCode::Tab => self.tab = self.tab.next(),
             KeyCode::BackTab => self.tab = self.tab.prev(),
+            // `c` clears all terminal tasks (#113). Available globally
+            // in tab mode; no-op when the panel is already empty.
+            KeyCode::Char('c') => self.clear_completed_tasks(),
             _ => self.handle_tab_key(code),
         }
     }
@@ -698,8 +722,12 @@ fn draw(frame: &mut ratatui::Frame, app: &mut App) {
         (Some(Overlay::SearchPapers { .. }), _) => {
             "Esc/q: back | j/k: navigate | Enter: open paper"
         }
-        (None, Tab::Papers) => "Tab: switch tabs | j/k: navigate | Enter: open | s: star | q: quit",
-        (None, _) => "Tab/Shift-Tab: switch tabs | j/k: navigate | Enter: select | q: quit",
+        (None, Tab::Papers) => {
+            "Tab: switch tabs | j/k: navigate | Enter: open | s: star | c: clear tasks | q: quit"
+        }
+        (None, _) => {
+            "Tab/Shift-Tab: switch tabs | j/k: navigate | Enter: select | c: clear tasks | q: quit"
+        }
     };
     status_bar::draw(frame, chunks[3], help_text, app.offline);
 }

--- a/crates/scitadel-tui/src/tasks.rs
+++ b/crates/scitadel-tui/src/tasks.rs
@@ -1,15 +1,27 @@
 use std::path::PathBuf;
+use std::time::{Duration, Instant};
 
 use scitadel_adapters::download::{AccessStatus, DownloadFormat, PaperDownloader};
 use scitadel_core::models::Paper;
 use tokio::sync::mpsc::UnboundedSender;
 use uuid::Uuid;
 
+/// How long a `Done` task lingers in the panel after completing before
+/// it auto-flushes. Long enough for the user to see the result, short
+/// enough that it doesn't crowd out new work.
+pub const DONE_LINGER: Duration = Duration::from_secs(5);
+/// `Failed` tasks linger longer so the user has time to read the error.
+pub const FAILED_LINGER: Duration = Duration::from_secs(30);
+
 #[derive(Debug, Clone)]
 pub struct Task {
     pub id: Uuid,
     pub kind: TaskKind,
     pub status: TaskStatus,
+    /// Wall-clock instant when the task entered a terminal state
+    /// (`Done` / `Failed`). `None` while it's still `Queued` or
+    /// `Running`. Drives the auto-flush policy in `App::flush_completed_tasks`.
+    pub terminal_at: Option<Instant>,
 }
 
 #[derive(Debug, Clone)]
@@ -39,6 +51,22 @@ pub enum TaskUpdate {
     Status { id: Uuid, status: TaskStatus },
 }
 
+/// Drop terminal-state tasks whose linger window has elapsed (#113).
+/// Pure helper called from `App::flush_completed_tasks` so the policy
+/// is unit-testable without constructing the full TUI.
+pub fn retain_recent_terminal(tasks: &mut Vec<Task>, now: Instant) {
+    tasks.retain(|t| match (&t.status, t.terminal_at) {
+        (TaskStatus::Done { .. }, Some(at)) => now.duration_since(at) < DONE_LINGER,
+        (TaskStatus::Failed(_), Some(at)) => now.duration_since(at) < FAILED_LINGER,
+        _ => true,
+    });
+}
+
+/// Drop every Done/Failed task immediately. Bound to `c` (#113).
+pub fn clear_terminal(tasks: &mut Vec<Task>) {
+    tasks.retain(|t| matches!(t.status, TaskStatus::Queued | TaskStatus::Running));
+}
+
 /// Spawn a download for a full `Paper` (uses all available identifiers).
 pub fn spawn_download_paper(
     tx: UnboundedSender<TaskUpdate>,
@@ -62,6 +90,7 @@ pub fn spawn_download_paper(
             title: paper.title.clone(),
         },
         status: TaskStatus::Queued,
+        terminal_at: None,
     };
     let _ = tx.send(TaskUpdate::New(task));
 
@@ -86,4 +115,89 @@ pub fn spawn_download_paper(
     });
 
     id
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn t(status: TaskStatus, terminal_at: Option<Instant>) -> Task {
+        Task {
+            id: Uuid::new_v4(),
+            kind: TaskKind::Download {
+                ref_id: "ref".into(),
+                title: "title".into(),
+            },
+            status,
+            terminal_at,
+        }
+    }
+
+    fn done() -> TaskStatus {
+        TaskStatus::Done {
+            path: PathBuf::from("/tmp/x"),
+            format: DownloadFormat::Pdf,
+            access: AccessStatus::FullText,
+            publisher_url: None,
+        }
+    }
+
+    #[test]
+    fn retain_keeps_active_tasks() {
+        let now = Instant::now();
+        let mut tasks = vec![
+            t(TaskStatus::Queued, None),
+            t(TaskStatus::Running, None),
+            t(done(), Some(now)),
+        ];
+        retain_recent_terminal(&mut tasks, now);
+        assert_eq!(
+            tasks.len(),
+            3,
+            "fresh terminal task stays alongside actives"
+        );
+    }
+
+    #[test]
+    fn retain_drops_done_after_linger() {
+        // Use a fake "now" that's well past Instant::now so subtraction is safe.
+        let now = Instant::now() + Duration::from_mins(1);
+        let stale = Instant::now();
+        let mut tasks = vec![t(TaskStatus::Running, None), t(done(), Some(stale))];
+        retain_recent_terminal(&mut tasks, now);
+        assert_eq!(tasks.len(), 1, "stale Done task is flushed");
+        assert!(matches!(tasks[0].status, TaskStatus::Running));
+    }
+
+    #[test]
+    fn retain_keeps_failed_longer_than_done() {
+        // 10s past mid: past DONE_LINGER (5s) but before FAILED_LINGER (30s).
+        let mid = Instant::now();
+        let now = mid + Duration::from_secs(10);
+        let mut tasks = vec![
+            t(done(), Some(mid)),
+            t(TaskStatus::Failed("oops".into()), Some(mid)),
+        ];
+        retain_recent_terminal(&mut tasks, now);
+        assert_eq!(tasks.len(), 1, "Done flushed but Failed stays");
+        assert!(matches!(tasks[0].status, TaskStatus::Failed(_)));
+    }
+
+    #[test]
+    fn clear_drops_all_terminal_keeps_active() {
+        let now = Instant::now();
+        let mut tasks = vec![
+            t(TaskStatus::Queued, None),
+            t(TaskStatus::Running, None),
+            t(done(), Some(now)),
+            t(TaskStatus::Failed("x".into()), Some(now)),
+        ];
+        clear_terminal(&mut tasks);
+        assert_eq!(tasks.len(), 2);
+        assert!(
+            tasks
+                .iter()
+                .all(|t| matches!(t.status, TaskStatus::Queued | TaskStatus::Running))
+        );
+    }
 }

--- a/tests/vhs/annotations-in-detail.tape
+++ b/tests/vhs/annotations-in-detail.tape
@@ -39,14 +39,14 @@ Show
 
 Type "scitadel tui"
 Enter
-Sleep 1500ms
+Sleep 2500ms
 
 Tab
-Sleep 500ms
+Sleep 1500ms
 Screenshot "tests/vhs/snapshots/annotations-in-detail/01-papers-tab.png"
 
 Enter
-Sleep 1500ms
+Sleep 2500ms
 Screenshot "tests/vhs/snapshots/annotations-in-detail/02-paper-detail-with-annotations.png"
 
 Type "q"

--- a/tests/vhs/offline-indicator.tape
+++ b/tests/vhs/offline-indicator.tape
@@ -30,11 +30,11 @@ Show
 
 Type "scitadel tui"
 Enter
-Sleep 2s
+Sleep 2500ms
 Screenshot "tests/vhs/snapshots/offline-indicator/01-offline-badge.png"
 
 Tab
-Sleep 500ms
+Sleep 1500ms
 Screenshot "tests/vhs/snapshots/offline-indicator/02-papers-still-works.png"
 
 Type "q"


### PR DESCRIPTION
## Summary

- 10-task cap now only evicts terminal tasks — never drops a Queued/Running download.
- Done auto-flushes after 5 s, Failed after 30 s. Cheap retain in the existing drain pass.
- New \`c\` keybind in tab mode clears all Done/Failed immediately. Status-bar hint updated.

## Test plan

- [x] 4 new unit tests in \`scitadel_tui::tasks::tests\` cover keep-actives, stale-Done flush, Failed-outlives-Done, manual clear.
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean.
- [x] [tape-exempt: 5/30 s timing not friendly to vhs; behaviour proven by unit tests].

Closes #113.