### PR TITLE
fix(db): synchronous=NORMAL + cross-process visibility test (#121)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **SQLite cross-process write visibility** (#121). Added `synchronous=NORMAL`
+  to the WAL pairing (already had `journal_mode=WAL` and `busy_timeout=5000`)
+  and a `cross_process_write_visible_within_one_redraw` integration test
+  that opens two `Database` handles on the same file and verifies a write
+  through one is visible through the other on the very next read. This is
+  the property the 2-pane workflow (TUI in one pane, `scitadel mcp` in
+  another) depends on — without it the TUI shows stale state after every
+  agent-driven edit.
 - **VHS tape PATH ordering** (#116). All 9 tapes now put
   `$PWD/target/release` before `$HOME/.cargo/bin` so a stale installed
   `scitadel` can no longer shadow the project build. This was the

--- a/crates/scitadel-db/src/sqlite/mod.rs
+++ b/crates/scitadel-db/src/sqlite/mod.rs
@@ -43,8 +43,14 @@ impl Database {
         }
 
         let manager = SqliteConnectionManager::file(path).with_init(|conn| {
+            // synchronous=NORMAL is the recommended pairing with WAL: full
+            // sync is unnecessary because WAL replay covers durability,
+            // and NORMAL roughly halves write latency. busy_timeout lets
+            // the cross-process 2-pane workflow ride through transient
+            // writer locks instead of failing reads. (#121)
             conn.execute_batch(
                 "PRAGMA journal_mode=WAL;
+                     PRAGMA synchronous=NORMAL;
                      PRAGMA foreign_keys=ON;
                      PRAGMA busy_timeout=5000;",
             )?;
@@ -100,5 +106,57 @@ impl Database {
             SqliteAssessmentRepository::new(db.clone()),
             SqliteCitationRepository::new(db),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use scitadel_core::models::Paper;
+    use scitadel_core::ports::PaperRepository;
+
+    /// Two `Database` instances pointing at the same file simulate the
+    /// 2-pane workflow: TUI process holds one, `scitadel mcp` process
+    /// holds the other. A write through one must surface through the
+    /// other — that's the contract WAL mode buys us. (#121)
+    #[test]
+    fn cross_process_write_visible_within_one_redraw() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("scitadel.db");
+
+        // Process A (e.g. the TUI) opens, migrates, holds open.
+        let db_a = Database::open(&db_path).unwrap();
+        db_a.migrate().unwrap();
+        let (paper_repo_a, _, _, _, _) = db_a.repositories();
+
+        // Process B (e.g. scitadel mcp) opens the same file independently.
+        let db_b = Database::open(&db_path).unwrap();
+        let (paper_repo_b, _, _, _, _) = db_b.repositories();
+
+        // Pre-write sanity: A sees nothing.
+        assert!(paper_repo_a.list_all(10, 0).unwrap().is_empty());
+
+        // B writes.
+        let p = Paper::new("MCP-side write");
+        paper_repo_b.save(&p).unwrap();
+
+        // A must see it on the very next read — no commit barrier, no
+        // sleep, no reconnect. This is the property the 2-pane workflow
+        // depends on.
+        let papers = paper_repo_a.list_all(10, 0).unwrap();
+        assert_eq!(papers.len(), 1, "TUI process must see MCP process's write");
+        assert_eq!(papers[0].title, "MCP-side write");
+    }
+
+    #[test]
+    fn pragma_journal_mode_is_wal_on_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("pragma.db");
+        let db = Database::open(&db_path).unwrap();
+        let conn = db.conn().unwrap();
+        let mode: String = conn
+            .query_row("PRAGMA journal_mode", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(mode.to_lowercase(), "wal");
     }
 }


### PR DESCRIPTION
## Summary

- Added \`PRAGMA synchronous=NORMAL\` (the recommended pairing with the already-enabled WAL + busy_timeout).
- New test: two \`Database\` handles on the same file → B writes → A sees it on next read. Locks in the contract the 2-pane workflow depends on.

## Test plan

- [x] \`cargo test -p scitadel-db --lib sqlite::tests\` — 2 new tests pass.
- [x] \`cargo clippy -p scitadel-db --all-targets -- -D warnings\` clean.

Closes #121.