### PR TITLE
feat(mcp): toggle_star / set_star / list_starred (#120)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **MCP star tools — `toggle_star`, `set_star`, `list_starred`** (#120).
+  Closes the only TUI-only affordance gap so an agent in an adjacent
+  pane (the recommended 2-pane workflow) can drive every state change
+  the user can drive in the TUI. Trust-on-first-use `reader` identity,
+  matching the existing annotation tools (#100). Audit logged.
 - **Papers-table download-state column** (#112). Migration 007 adds
   `local_path`, `download_status`, and `last_attempt_at` columns to
   `papers`. The TUI Papers table renders a one-char symbol next to

--- a/crates/scitadel-mcp/src/server.rs
+++ b/crates/scitadel-mcp/src/server.rs
@@ -247,6 +247,30 @@ pub struct PaperQuestionRequest {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+pub struct ToggleStarRequest {
+    /// Paper ID to toggle the star on
+    pub paper_id: String,
+    /// Reader identity (e.g. agent slug, user name)
+    pub reader: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SetStarRequest {
+    /// Paper ID
+    pub paper_id: String,
+    /// Desired starred state (true = star, false = unstar)
+    pub starred: bool,
+    /// Reader identity
+    pub reader: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ReaderRequest {
+    /// Reader identity to scope the query to
+    pub reader: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct DownloadPaperRequest {
     /// Paper ID from the scitadel DB (preferred — unlocks arxiv/openalex/Unpaywall chain)
     pub paper_id: Option<String>,
@@ -666,6 +690,27 @@ impl ScitadelServer {
         };
         notify(&ctx.peer, token.as_ref(), 1.0, Some(1.0), done_msg).await;
         result
+    }
+
+    #[tool(
+        description = "Toggle the starred flag for a paper under `reader`. Creates the per-reader state row if missing. NOTE: author/reader identity is trust-on-first-use — real auth ships with the Phase-5 Dolt sync layer. Returns: JSON `{paper_id, starred}` with the new value."
+    )]
+    fn toggle_star(&self, Parameters(req): Parameters<ToggleStarRequest>) -> Result<String, String> {
+        tools::toggle_star_tool(&req.paper_id, &req.reader)
+    }
+
+    #[tool(
+        description = "Set the starred flag for a paper under `reader` to an explicit value. Idempotent — call this when you want \"ensure starred\" semantics rather than a toggle. NOTE: trust-on-first-use identity (#100). Returns: JSON `{paper_id, starred}`."
+    )]
+    fn set_star(&self, Parameters(req): Parameters<SetStarRequest>) -> Result<String, String> {
+        tools::set_star_tool(&req.paper_id, req.starred, &req.reader)
+    }
+
+    #[tool(
+        description = "List all paper IDs `reader` has starred. Returns: JSON array of paper ID strings (no metadata — call `get_paper` for each if you need title/authors)."
+    )]
+    fn list_starred(&self, Parameters(req): Parameters<ReaderRequest>) -> Result<String, String> {
+        tools::list_starred_tool(&req.reader)
     }
 }
 

--- a/crates/scitadel-mcp/src/server.rs
+++ b/crates/scitadel-mcp/src/server.rs
@@ -695,7 +695,10 @@ impl ScitadelServer {
     #[tool(
         description = "Toggle the starred flag for a paper under `reader`. Creates the per-reader state row if missing. NOTE: author/reader identity is trust-on-first-use — real auth ships with the Phase-5 Dolt sync layer. Returns: JSON `{paper_id, starred}` with the new value."
     )]
-    fn toggle_star(&self, Parameters(req): Parameters<ToggleStarRequest>) -> Result<String, String> {
+    fn toggle_star(
+        &self,
+        Parameters(req): Parameters<ToggleStarRequest>,
+    ) -> Result<String, String> {
         tools::toggle_star_tool(&req.paper_id, &req.reader)
     }
 

--- a/crates/scitadel-mcp/src/tools.rs
+++ b/crates/scitadel-mcp/src/tools.rs
@@ -1495,6 +1495,71 @@ fn is_source_configured(src: &SourceInfo, config: &scitadel_core::config::Config
     }
 }
 
+// ===== Star / paper-state tools (#120) =====
+
+/// Toggle the starred flag for `paper_id` under `reader`. Returns the
+/// new value as JSON: `{"paper_id": "...", "starred": true|false}`.
+pub fn toggle_star_tool(paper_id: &str, reader: &str) -> Result<String, String> {
+    if reader.trim().is_empty() {
+        return Err("reader is required (pass an identity string)".into());
+    }
+    let db = open_db()?;
+    let repo = scitadel_db::sqlite::SqlitePaperStateRepository::new(db);
+    let starred = repo
+        .toggle_starred(paper_id, reader)
+        .map_err(|e| e.to_string())?;
+    tracing::info!(
+        op = "toggle_star",
+        paper_id,
+        reader,
+        starred,
+        "star write (trust-on-first-use)"
+    );
+    Ok(serde_json::json!({ "paper_id": paper_id, "starred": starred }).to_string())
+}
+
+/// Idempotent "ensure starred state" — sets `starred` to the requested
+/// value regardless of current. Returns the same JSON shape as toggle.
+pub fn set_star_tool(paper_id: &str, starred: bool, reader: &str) -> Result<String, String> {
+    if reader.trim().is_empty() {
+        return Err("reader is required".into());
+    }
+    let db = open_db()?;
+    let repo = scitadel_db::sqlite::SqlitePaperStateRepository::new(db);
+    let existing = repo.get(paper_id, reader).map_err(|e| e.to_string())?;
+    let new_state = scitadel_db::sqlite::PaperState {
+        paper_id: paper_id.into(),
+        reader: reader.into(),
+        starred,
+        to_read: existing.as_ref().is_some_and(|s| s.to_read),
+        read_at: existing.and_then(|s| s.read_at),
+    };
+    repo.set(&new_state).map_err(|e| e.to_string())?;
+    tracing::info!(
+        op = "set_star",
+        paper_id,
+        reader,
+        starred,
+        "star write (trust-on-first-use)"
+    );
+    Ok(serde_json::json!({ "paper_id": paper_id, "starred": starred }).to_string())
+}
+
+/// List all paper IDs `reader` has starred. Returns a JSON array of
+/// strings (paper IDs only — call `get_paper` for each if you need
+/// metadata).
+pub fn list_starred_tool(reader: &str) -> Result<String, String> {
+    if reader.trim().is_empty() {
+        return Err("reader is required".into());
+    }
+    let db = open_db()?;
+    let repo = scitadel_db::sqlite::SqlitePaperStateRepository::new(db);
+    let ids = repo.starred_ids(reader).map_err(|e| e.to_string())?;
+    let mut sorted: Vec<String> = ids.into_iter().collect();
+    sorted.sort();
+    serde_json::to_string(&sorted).map_err(|e| e.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::{


### PR DESCRIPTION
## Summary

- 3 new MCP tools wrapping existing \`SqlitePaperStateRepository\` methods.
- Closes the only TUI-only affordance gap — agent in adjacent pane can now drive star state.
- Trust-on-first-use \`reader\` identity, matching annotation tools (#100).

## Test plan

- [x] \`cargo build --workspace\` clean.
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean.
- [x] Underlying \`paper_state.rs\` tests cover the actual behaviour.

Closes #120.