### PR TITLE
feat(mcp): get_current_selection — TUI selection visible to agents (#122)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **MCP `get_current_selection`** (#122). The TUI publishes its
+  current selection (active tab, open paper/search/question, focused
+  annotation) to a singleton `tui_state` row on every focus change.
+  Agents in the adjacent pane can now ask "what is the user looking
+  at right now?" without the user pasting IDs. Result includes a
+  `stale: bool` flag (true when the row is >60s old) so an agent can
+  tell the TUI was closed. Migration 008. Dedup by selection key —
+  no UPDATE traffic when the user isn't moving.
 - **Papers-table download-state column** (#112). Migration 007 adds
   `local_path`, `download_status`, and `last_attempt_at` columns to
   `papers`. The TUI Papers table renders a one-char symbol next to

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2485,6 +2485,7 @@ name = "scitadel-mcp"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "pdf-extract",
  "rmcp",
  "schemars",
@@ -2523,6 +2524,7 @@ name = "scitadel-tui"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "crossterm",
  "ratatui",
  "reqwest",

--- a/crates/scitadel-db/migrations/008_tui_state.sql
+++ b/crates/scitadel-db/migrations/008_tui_state.sql
@@ -1,0 +1,16 @@
+-- Singleton row tracking the TUI's current selection (#122) so an
+-- agent in an adjacent pane (the recommended 2-pane workflow) can ask
+-- "what is the user looking at right now?" without the user having to
+-- paste IDs. Last-writer-wins if multiple TUIs run concurrently.
+
+CREATE TABLE tui_state (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    tab TEXT NOT NULL,
+    paper_id TEXT,
+    search_id TEXT,
+    question_id TEXT,
+    annotation_id TEXT,
+    updated_at TEXT NOT NULL
+);
+
+INSERT OR IGNORE INTO schema_version (version, applied_at) VALUES (8, datetime('now'));

--- a/crates/scitadel-db/src/sqlite/migrations.rs
+++ b/crates/scitadel-db/src/sqlite/migrations.rs
@@ -9,6 +9,7 @@ const MIGRATION_004: &str = include_str!("../../migrations/004_paper_state.sql")
 const MIGRATION_005: &str = include_str!("../../migrations/005_annotations.sql");
 const MIGRATION_006: &str = include_str!("../../migrations/006_search_fts.sql");
 const MIGRATION_007: &str = include_str!("../../migrations/007_paper_download_state.sql");
+const MIGRATION_008: &str = include_str!("../../migrations/008_tui_state.sql");
 
 const MIGRATIONS: &[(i64, &str)] = &[
     (1, MIGRATION_001),
@@ -18,6 +19,7 @@ const MIGRATIONS: &[(i64, &str)] = &[
     (5, MIGRATION_005),
     (6, MIGRATION_006),
     (7, MIGRATION_007),
+    (8, MIGRATION_008),
 ];
 
 /// Run all pending migrations, skipping already-applied ones.

--- a/crates/scitadel-db/src/sqlite/mod.rs
+++ b/crates/scitadel-db/src/sqlite/mod.rs
@@ -6,6 +6,7 @@ mod paper_state;
 mod papers;
 mod questions;
 mod searches;
+mod tui_state;
 
 pub use annotations::{SqliteAnnotationRepository, resolve_anchor};
 pub use assessments::SqliteAssessmentRepository;
@@ -15,6 +16,7 @@ pub use paper_state::{PaperState, SqlitePaperStateRepository};
 pub use papers::SqlitePaperRepository;
 pub use questions::SqliteQuestionRepository;
 pub use searches::SqliteSearchRepository;
+pub use tui_state::{SqliteTuiStateRepository, TuiState};
 
 use r2d2::Pool;
 use r2d2_sqlite::SqliteConnectionManager;

--- a/crates/scitadel-db/src/sqlite/tui_state.rs
+++ b/crates/scitadel-db/src/sqlite/tui_state.rs
@@ -1,0 +1,128 @@
+//! Singleton TUI-selection state (#122). Lets an MCP-side agent read
+//! "what is the open scitadel TUI looking at right now?" so it can
+//! score the current paper / draft a question from the current
+//! context without the user pasting IDs.
+//!
+//! Last-writer-wins if multiple TUIs run concurrently — acceptable for
+//! v1 since the TUI is a single-pane terminal app.
+
+use rusqlite::params;
+
+use crate::error::DbError;
+use crate::sqlite::Database;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TuiState {
+    /// Active tab name: "Searches" | "Papers" | "Questions"
+    pub tab: String,
+    pub paper_id: Option<String>,
+    pub search_id: Option<String>,
+    pub question_id: Option<String>,
+    pub annotation_id: Option<String>,
+    /// RFC3339 timestamp of the last TUI-side write.
+    pub updated_at: String,
+}
+
+#[derive(Clone)]
+pub struct SqliteTuiStateRepository {
+    db: Database,
+}
+
+impl SqliteTuiStateRepository {
+    pub fn new(db: Database) -> Self {
+        Self { db }
+    }
+
+    /// Upsert the singleton row. Called by the TUI on every focus /
+    /// overlay / tab change. Idempotent.
+    pub fn set(&self, state: &TuiState) -> Result<(), DbError> {
+        let conn = self.db.conn()?;
+        conn.execute(
+            "INSERT INTO tui_state (id, tab, paper_id, search_id, question_id, annotation_id, updated_at)
+             VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6)
+             ON CONFLICT(id) DO UPDATE SET
+                 tab           = excluded.tab,
+                 paper_id      = excluded.paper_id,
+                 search_id     = excluded.search_id,
+                 question_id   = excluded.question_id,
+                 annotation_id = excluded.annotation_id,
+                 updated_at    = excluded.updated_at",
+            params![
+                state.tab,
+                state.paper_id,
+                state.search_id,
+                state.question_id,
+                state.annotation_id,
+                state.updated_at,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Read the singleton row. Returns `None` if no TUI has ever
+    /// written (rather than synthesising an empty default).
+    pub fn get(&self) -> Result<Option<TuiState>, DbError> {
+        let conn = self.db.conn()?;
+        let mut stmt = conn.prepare(
+            "SELECT tab, paper_id, search_id, question_id, annotation_id, updated_at
+             FROM tui_state WHERE id = 1",
+        )?;
+        let mut rows = stmt.query([])?;
+        if let Some(row) = rows.next()? {
+            Ok(Some(TuiState {
+                tab: row.get(0)?,
+                paper_id: row.get(1)?,
+                search_id: row.get(2)?,
+                question_id: row.get(3)?,
+                annotation_id: row.get(4)?,
+                updated_at: row.get(5)?,
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fresh() -> SqliteTuiStateRepository {
+        let db = Database::open_in_memory().unwrap();
+        db.migrate().unwrap();
+        SqliteTuiStateRepository::new(db)
+    }
+
+    #[test]
+    fn empty_until_first_write() {
+        let repo = fresh();
+        assert!(repo.get().unwrap().is_none());
+    }
+
+    #[test]
+    fn upsert_round_trip() {
+        let repo = fresh();
+        let s = TuiState {
+            tab: "Papers".into(),
+            paper_id: Some("p-abc".into()),
+            search_id: None,
+            question_id: None,
+            annotation_id: None,
+            updated_at: "2026-04-20T00:00:00Z".into(),
+        };
+        repo.set(&s).unwrap();
+        assert_eq!(repo.get().unwrap().unwrap(), s);
+
+        // Second write replaces, doesn't append.
+        let s2 = TuiState {
+            tab: "Questions".into(),
+            paper_id: None,
+            search_id: None,
+            question_id: Some("q-xyz".into()),
+            annotation_id: None,
+            updated_at: "2026-04-20T00:01:00Z".into(),
+        };
+        repo.set(&s2).unwrap();
+        assert_eq!(repo.get().unwrap().unwrap(), s2);
+    }
+}

--- a/crates/scitadel-mcp/Cargo.toml
+++ b/crates/scitadel-mcp/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = { workspace = true }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+chrono = { workspace = true }
 pdf-extract = { workspace = true }
 scraper = { workspace = true }
 

--- a/crates/scitadel-mcp/src/server.rs
+++ b/crates/scitadel-mcp/src/server.rs
@@ -667,6 +667,13 @@ impl ScitadelServer {
         notify(&ctx.peer, token.as_ref(), 1.0, Some(1.0), done_msg).await;
         result
     }
+
+    #[tool(
+        description = "Read the open scitadel TUI's current selection. Use to answer 'what is the user looking at right now?' so you can score the open paper / draft from current context without the user pasting IDs. Returns JSON `{tab, paper_id?, search_id?, question_id?, annotation_id?, updated_at, stale}`. `stale: true` means the singleton row is >60s old — TUI may have been closed. (#122)"
+    )]
+    fn get_current_selection(&self) -> Result<String, String> {
+        tools::get_current_selection_tool()
+    }
 }
 
 #[tool_handler(router = self.tool_router)]

--- a/crates/scitadel-mcp/src/tools.rs
+++ b/crates/scitadel-mcp/src/tools.rs
@@ -1495,6 +1495,41 @@ fn is_source_configured(src: &SourceInfo, config: &scitadel_core::config::Config
     }
 }
 
+// ===== TUI selection tool (#122) =====
+
+/// Read the singleton `tui_state` row written by the open scitadel TUI.
+/// Returns JSON: `{ tab, paper_id?, search_id?, question_id?,
+/// annotation_id?, updated_at, stale }`. `stale` is true when the
+/// row is older than 60s (TUI may have been closed).
+pub fn get_current_selection_tool() -> Result<String, String> {
+    let db = open_db()?;
+    let repo = scitadel_db::sqlite::SqliteTuiStateRepository::new(db);
+    match repo.get().map_err(|e| e.to_string())? {
+        Some(row) => {
+            let stale = chrono::DateTime::parse_from_rfc3339(&row.updated_at).map_or(true, |t| {
+                chrono::Utc::now().signed_duration_since(t.with_timezone(&chrono::Utc))
+                    > chrono::Duration::seconds(60)
+            });
+            Ok(serde_json::json!({
+                "tab": row.tab,
+                "paper_id": row.paper_id,
+                "search_id": row.search_id,
+                "question_id": row.question_id,
+                "annotation_id": row.annotation_id,
+                "updated_at": row.updated_at,
+                "stale": stale,
+            })
+            .to_string())
+        }
+        None => Ok(serde_json::json!({
+            "tab": null,
+            "stale": true,
+            "note": "no TUI has written state yet — start `scitadel tui` to populate"
+        })
+        .to_string()),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{

--- a/crates/scitadel-tui/Cargo.toml
+++ b/crates/scitadel-tui/Cargo.toml
@@ -22,6 +22,7 @@ tracing = { workspace = true }
 tokio = { workspace = true }
 uuid = { workspace = true }
 reqwest = { workspace = true }
+chrono = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/scitadel-tui/src/app.rs
+++ b/crates/scitadel-tui/src/app.rs
@@ -684,13 +684,7 @@ impl App {
 /// user-visible selection so we skip the redundant DB write (#122).
 fn tui_state_key(
     s: &scitadel_db::sqlite::TuiState,
-) -> (
-    &str,
-    Option<&str>,
-    Option<&str>,
-    Option<&str>,
-    Option<&str>,
-) {
+) -> (&str, Option<&str>, Option<&str>, Option<&str>, Option<&str>) {
     (
         s.tab.as_str(),
         s.paper_id.as_deref(),

--- a/crates/scitadel-tui/src/app.rs
+++ b/crates/scitadel-tui/src/app.rs
@@ -96,6 +96,9 @@ pub struct App {
     pub question_selected: usize,
 
     pub tasks: Vec<Task>,
+    /// Last `TuiState` written to the DB, used by `publish_tui_state`
+    /// to skip redundant UPDATEs when the user hasn't moved (#122).
+    pub last_published_state: Option<scitadel_db::sqlite::TuiState>,
     pub unpaywall_email: String,
     pub papers_dir: PathBuf,
     pub show_institutional_hint: bool,
@@ -139,6 +142,7 @@ impl App {
             paper_selected: 0,
             question_selected: 0,
             tasks: Vec::new(),
+            last_published_state: None,
             unpaywall_email,
             papers_dir,
             show_institutional_hint,
@@ -172,6 +176,72 @@ impl App {
         self.drain_task_updates();
         self.drain_offline();
         self.flush_completed_tasks();
+        self.publish_tui_state();
+    }
+
+    /// Write the TUI's current selection to the singleton `tui_state`
+    /// row so an MCP-side agent can ask "what's the user looking at?"
+    /// (#122). Runs every drain pass; only writes if the *selection*
+    /// (not the timestamp) changed since last publish — otherwise the
+    /// TUI would emit ~10 UPDATEs/sec on a static screen.
+    fn publish_tui_state(&mut self) {
+        let snapshot = self.current_tui_state();
+        if let Some(prev) = &self.last_published_state
+            && tui_state_key(prev) == tui_state_key(&snapshot)
+        {
+            return;
+        }
+        if let Err(e) = self.data.publish_tui_state(&snapshot) {
+            tracing::warn!(error = %e, "failed to publish TUI state");
+            return;
+        }
+        self.last_published_state = Some(snapshot);
+    }
+
+    fn current_tui_state(&self) -> scitadel_db::sqlite::TuiState {
+        let tab = match self.tab {
+            Tab::Searches => "Searches",
+            Tab::Papers => "Papers",
+            Tab::Questions => "Questions",
+        };
+        let (paper_id, search_id, annotation_id) = match &self.overlay {
+            Some(Overlay::PaperDetail {
+                paper_id,
+                annotation_focus,
+                ..
+            }) => {
+                // Resolve the focused annotation's id only when the
+                // user is actively in focus mode — otherwise leave None
+                // so agents don't think the user is "on" an annotation
+                // they happen to be scrolling past.
+                let ann_id = annotation_focus.and_then(|i| {
+                    self.data
+                        .load_annotations_for_paper(paper_id)
+                        .ok()
+                        .and_then(|anns| anns.get(i).map(|a| a.id.as_str().to_string()))
+                });
+                (Some(paper_id.clone()), None, ann_id)
+            }
+            Some(Overlay::SearchPapers { search_id, .. }) => (None, Some(search_id.clone()), None),
+            None => (None, None, None),
+        };
+        // Question id only when the user is actually on the Questions tab.
+        let question_id = if matches!(self.tab, Tab::Questions) {
+            self.data.load_questions().ok().and_then(|qs| {
+                qs.get(self.question_selected)
+                    .map(|q| q.id.as_str().to_string())
+            })
+        } else {
+            None
+        };
+        scitadel_db::sqlite::TuiState {
+            tab: tab.to_string(),
+            paper_id,
+            search_id,
+            question_id,
+            annotation_id,
+            updated_at: chrono::Utc::now().to_rfc3339(),
+        }
     }
 
     fn drain_task_updates(&mut self) {
@@ -607,6 +677,27 @@ impl App {
             }
         }
     }
+}
+
+/// Identity of a `TuiState` for dedup purposes — everything except
+/// `updated_at`. Two snapshots with the same key represent the same
+/// user-visible selection so we skip the redundant DB write (#122).
+fn tui_state_key(
+    s: &scitadel_db::sqlite::TuiState,
+) -> (
+    &str,
+    Option<&str>,
+    Option<&str>,
+    Option<&str>,
+    Option<&str>,
+) {
+    (
+        s.tab.as_str(),
+        s.paper_id.as_deref(),
+        s.search_id.as_deref(),
+        s.question_id.as_deref(),
+        s.annotation_id.as_deref(),
+    )
 }
 
 pub fn run(

--- a/crates/scitadel-tui/src/data.rs
+++ b/crates/scitadel-tui/src/data.rs
@@ -155,4 +155,10 @@ impl DataStore {
         let (paper_repo, _, _, _, _) = self.db.repositories();
         Ok(paper_repo.update_download_state(paper_id, local_path, status)?)
     }
+
+    /// Persist the TUI's current selection so an MCP-side agent can
+    /// query it (#122).
+    pub fn publish_tui_state(&self, state: &scitadel_db::sqlite::TuiState) -> Result<()> {
+        Ok(scitadel_db::sqlite::SqliteTuiStateRepository::new(self.db.clone()).set(state)?)
+    }
 }


### PR DESCRIPTION
## Summary

- Migration 008: singleton \`tui_state\` row.
- TUI publishes its current selection on every focus change (deduped by selection key).
- New \`get_current_selection\` MCP tool exposes it with a \`stale: bool\` derived from updated_at.

## Test plan

- [x] 2 new unit tests in \`sqlite::tui_state::tests\` — empty default, upsert round-trip.
- [x] \`cargo test --workspace\` clean.
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean.

Closes #122.