### PR TITLE
ci(vhs): retry-once on all-identical + bump 2 flaky tapes

### DIFF
--- a/.github/workflows/vhs.yml
+++ b/.github/workflows/vhs.yml
@@ -92,8 +92,23 @@ jobs:
             fi
             unique=$(md5sum "$dir"/*.png | awk '{print $1}' | sort -u | wc -l | tr -d ' ')
             if [ "$unique" -lt 2 ]; then
-              echo "::error::$tape produced $produced byte-identical screenshots — feature did not render anything"
-              dead+=("$tape (all snapshots identical)")
+              # CI runners have variable load — a tape can flake on one
+              # render and pass on the next. Re-render this tape once
+              # before declaring failure. A real bug (feature genuinely
+              # doesn't render) will fail both times; a timing flake
+              # almost never repeats back-to-back.
+              echo "::warning::$tape all-identical on first render — retrying once"
+              rm -f "$dir"/*.png
+              if vhs "$tape"; then
+                produced2=$(find "$dir" -maxdepth 1 -name '*.png' 2>/dev/null | wc -l | tr -d ' ')
+                unique2=$(md5sum "$dir"/*.png 2>/dev/null | awk '{print $1}' | sort -u | wc -l | tr -d ' ')
+                if [ "$unique2" -ge 2 ]; then
+                  echo "ok (retry): $tape — $produced2 screenshots, $unique2 distinct"
+                  continue
+                fi
+              fi
+              echo "::error::$tape produced byte-identical screenshots on two consecutive renders — feature did not render anything"
+              dead+=("$tape (all snapshots identical, twice)")
             else
               echo "ok: $tape — $produced screenshots, $unique distinct"
             fi

--- a/tests/vhs/annotations-in-detail.tape
+++ b/tests/vhs/annotations-in-detail.tape
@@ -39,14 +39,14 @@ Show
 
 Type "scitadel tui"
 Enter
-Sleep 2500ms
+Sleep 3500ms
 
 Tab
-Sleep 1500ms
+Sleep 2500ms
 Screenshot "tests/vhs/snapshots/annotations-in-detail/01-papers-tab.png"
 
 Enter
-Sleep 2500ms
+Sleep 3500ms
 Screenshot "tests/vhs/snapshots/annotations-in-detail/02-paper-detail-with-annotations.png"
 
 Type "q"

--- a/tests/vhs/reading-queue-star.tape
+++ b/tests/vhs/reading-queue-star.tape
@@ -31,18 +31,18 @@ Show
 
 Type "scitadel tui"
 Enter
-Sleep 1500ms
+Sleep 2500ms
 
 Tab
-Sleep 600ms
+Sleep 1500ms
 Screenshot "tests/vhs/snapshots/reading-queue-star/01-papers-unstarred.png"
 
 Type "s"
-Sleep 600ms
+Sleep 1500ms
 Screenshot "tests/vhs/snapshots/reading-queue-star/02-papers-starred.png"
 
 Type "s"
-Sleep 600ms
+Sleep 1500ms
 Screenshot "tests/vhs/snapshots/reading-queue-star/03-papers-unstarred-again.png"
 
 Type "q"


### PR DESCRIPTION
## Summary

- Workflow gates: retry-once when a tape fails the all-identical check. CI timing flakes go away; #97-class real bugs still fail (twice).
- Bumped sleeps on \`annotations-in-detail.tape\` and \`reading-queue-star.tape\` — both have flaked on consecutive PRs.

## Why

Two PRs in the past hour failed CI on tape-flake-not-real-bug. Whack-a-mole on sleeps doesn't scale. Retry-once is the right level of skepticism: trust that real bugs reproduce.

[tape-exempt: CI/tape-only change]