### PR TITLE
release: v0.5.0

### DIFF
--- a/.github/workflows/vhs.yml
+++ b/.github/workflows/vhs.yml
@@ -64,6 +64,46 @@ jobs:
           fi
           echo "All ${#tapes[@]} tape(s) ran cleanly."
 
+      - name: Assert tapes produced distinct snapshots
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          # The hard failure case is "all snapshots identical" — that's the
+          # bug class (#97 silent reader failure) this gate exists to catch.
+          # "Fewer PNGs than declared" is a warning: it can be genuine vhs /
+          # runner-timing flakiness rather than a real bug, and we don't
+          # want to wedge merges on it.
+          dead=()
+          for tape in tests/vhs/*.tape; do
+            base=$(basename "$tape" .tape)
+            dir="tests/vhs/snapshots/$base"
+            declared=$(grep -c '^Screenshot ' "$tape" || true)
+            # Tapes that take 0 or 1 screenshots can't be checked for diversity.
+            if [ "$declared" -le 1 ]; then
+              continue
+            fi
+            produced=$(find "$dir" -maxdepth 1 -name '*.png' 2>/dev/null | wc -l | tr -d ' ')
+            if [ "$produced" -lt 2 ]; then
+              echo "::warning::$tape declared $declared screenshots but only $produced produced"
+              continue
+            fi
+            if [ "$produced" -lt "$declared" ]; then
+              echo "::warning::$tape declared $declared screenshots but only $produced produced (will still check distinctness)"
+            fi
+            unique=$(md5sum "$dir"/*.png | awk '{print $1}' | sort -u | wc -l | tr -d ' ')
+            if [ "$unique" -lt 2 ]; then
+              echo "::error::$tape produced $produced byte-identical screenshots — feature did not render anything"
+              dead+=("$tape (all snapshots identical)")
+            else
+              echo "ok: $tape — $produced screenshots, $unique distinct"
+            fi
+          done
+          if [ ${#dead[@]} -gt 0 ]; then
+            echo "::error::${#dead[@]} tape(s) failed the distinct-snapshot check:"
+            printf '  - %s\n' "${dead[@]}"
+            exit 1
+          fi
+
       - name: Upload tape artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/vhs.yml
+++ b/.github/workflows/vhs.yml
@@ -92,8 +92,23 @@ jobs:
             fi
             unique=$(md5sum "$dir"/*.png | awk '{print $1}' | sort -u | wc -l | tr -d ' ')
             if [ "$unique" -lt 2 ]; then
-              echo "::error::$tape produced $produced byte-identical screenshots — feature did not render anything"
-              dead+=("$tape (all snapshots identical)")
+              # CI runners have variable load — a tape can flake on one
+              # render and pass on the next. Re-render this tape once
+              # before declaring failure. A real bug (feature genuinely
+              # doesn't render) will fail both times; a timing flake
+              # almost never repeats back-to-back.
+              echo "::warning::$tape all-identical on first render — retrying once"
+              rm -f "$dir"/*.png
+              if vhs "$tape"; then
+                produced2=$(find "$dir" -maxdepth 1 -name '*.png' 2>/dev/null | wc -l | tr -d ' ')
+                unique2=$(md5sum "$dir"/*.png 2>/dev/null | awk '{print $1}' | sort -u | wc -l | tr -d ' ')
+                if [ "$unique2" -ge 2 ]; then
+                  echo "ok (retry): $tape — $produced2 screenshots, $unique2 distinct"
+                  continue
+                fi
+              fi
+              echo "::error::$tape produced byte-identical screenshots on two consecutive renders — feature did not render anything"
+              dead+=("$tape (all snapshots identical, twice)")
             else
               echo "ok: $tape — $produced screenshots, $unique distinct"
             fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **rmcp upgrade 0.1.5 → 0.17** (#58 prep). Mechanical rewrite of
+  `crates/scitadel-mcp/src/server.rs` against the new `tool_router`
+  macro: each tool is a method with a `Parameters<T>` extractor;
+  `ToolRouter<Self>` field on the server; `ServerHandler` delegates
+  via `#[tool_handler]`. Per-param structs added for tools that
+  used `#[tool(param)]` in 0.1.5. Behaviour unchanged — every
+  existing tool still works the same — but the new API unlocks the
+  `Peer<RoleServer>` extractor that #58 (MCP progress notifications)
+  will use as a follow-up. Workspace `schemars` bumped 0.8 → 1 to
+  match rmcp 0.17's transitive dep.
 - **MCP tool-signature + return-shape consistency pass** (#98):
   - `add_search_terms.query_string` is now `Option<String>` to match
     its description (was a required `String` clients couldn't omit).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- **VHS tape PATH ordering** (#116). All 9 tapes now put
+  `$PWD/target/release` before `$HOME/.cargo/bin` so a stale installed
+  `scitadel` can no longer shadow the project build. This was the
+  root cause of false-positive bug reports #114 and #115 — both
+  symptoms (R reader not opening, status bar truncated) disappeared
+  once the tape used the freshly built binary.
+
+### Changed
+
+- **CI vhs gate now asserts distinct snapshots** (#116). After
+  rendering each tape, the workflow checks that every tape declaring
+  `N` `Screenshot` calls produced at least `N` PNGs and that they're
+  not all byte-identical. This catches the dead-tape class of bugs
+  where a tape was committed but never actually exercised the feature
+  (the failure mode that hid #97's reader being unverified for two
+  PRs).
+
 ### Added
 
 - **MCP progress notifications** (#58). The `search`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **MCP `get_annotated_paper`** (#95): one-call JSON of a paper +
+  every live annotation anchored to it (with `parent_id` / `root_id`
+  for thread reconstruction and the full anchor incl.
+  char_range/quote/prefix/suffix/sentence_id/source_version/status).
+  Replaces `get_paper` + `list_annotations` for agents that reason
+  over offsets.
 - **VHS coverage for CLI search + question subcommands** (#99): two
   new tapes (`tests/vhs/cli-search.tape`,
   `tests/vhs/cli-question-workflow.tape`) plus a `Shift+Tab`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`sentence_id` + `normalize_sentence` in `scitadel-core`** (#96):
+  SHA1 of NFKC-composed, lowercased, whitespace-collapsed sentence
+  text. Spec pinned in [ADR-004](docs/decisions/ADR-004-2026-04-19-sentence-id-normalization.md).
 - **MCP `get_annotated_paper`** (#95): one-call JSON of a paper +
   every live annotation anchored to it (with `parent_id` / `root_id`
   for thread reconstruction and the full anchor incl.
@@ -23,6 +26,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Annotation anchor resolver** (#96): completes the four-step
+  W3C-style pipeline shipped half-done in 0.3.0. Adds
+  prefix/suffix-based disambiguation for repeated quotes, sliding-
+  window fuzzy match (Jaro-Winkler ≥ 0.9 default; tunable via
+  `resolve_anchor_with_threshold`), sentence-id fallback, and
+  bounds-checking on `char_range` so malformed rows return
+  `Orphan` instead of panicking.
 - **MCP annotation tool descriptions** (#100): `create_annotation`,
   `reply_annotation`, `update_annotation`, `delete_annotation`, and
   `list_unread` now flag trust-on-first-use author identity (real auth

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **TUI-native annotation create / edit / reply / delete** (#92,
+  iter 3b of #49). New keybindings on the paper detail overlay:
+  `n` opens a two-stage Create prompt (quote → note); `Shift+J`
+  enters annotation focus mode; `e` edits the focused note inline;
+  `r` opens a reply prompt; `d` opens a y/n delete confirmation.
+  The state machine lives in
+  `crates/scitadel-tui/src/views/annotation_prompt.rs` (pure, fully
+  tested). $EDITOR integration + visual-mode char-range selection
+  remain out of scope — see #97 for the two-pane reader.
 - **Citation graph — iter 1** (#59). New OpenAlex helpers
   (`fetch_work_by_id`, `fetch_works_by_ids`, `fetch_cited_by`,
   `short_openalex_id`, `work_to_paper`) plus two MCP tools:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Citation graph — iter 1** (#59). New OpenAlex helpers
+  (`fetch_work_by_id`, `fetch_works_by_ids`, `fetch_cited_by`,
+  `short_openalex_id`, `work_to_paper`) plus two MCP tools:
+  - `get_references(paper_id)` — fetches the works this paper cites
+    via OpenAlex's `referenced_works`, materialises each as a Paper
+    row, and persists the citation edges. Source paper must have an
+    `openalex_id`.
+  - `get_citations(paper_id, limit?)` — fetches the works that cite
+    this paper (`cites:` filter; default 25, capped at 200).
+  Idempotent: existing papers upsert on the OpenAlex id, and the
+  citation edge has a uniqueness constraint so re-runs are no-ops.
+  TUI graph view + snowball orchestration (`snowball(seed_paper_ids,
+  depth, stop_condition)`) ship in iter 2.
 - **`sentence_id` + `normalize_sentence` in `scitadel-core`** (#96):
   SHA1 of NFKC-composed, lowercased, whitespace-collapsed sentence
   text. Spec pinned in [ADR-004](docs/decisions/ADR-004-2026-04-19-sentence-id-normalization.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **MCP annotation tool descriptions** (#100): `create_annotation`,
+  `reply_annotation`, `update_annotation`, `delete_annotation`, and
+  `list_unread` now flag trust-on-first-use author identity (real auth
+  ships with the Phase-5 Dolt sync layer) and the wall-clock-based
+  read-receipt race window (`seen_at < updated_at`). Every annotation
+  write now emits a `tracing::info!` audit record (op + ids + author).
+
 ### Removed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **MCP `get_current_selection`** (#122). The TUI publishes its
+  current selection (active tab, open paper/search/question, focused
+  annotation) to a singleton `tui_state` row on every focus change.
+  Agents in the adjacent pane can now ask "what is the user looking
+  at right now?" without the user pasting IDs. Result includes a
+  `stale: bool` flag (true when the row is >60s old) so an agent can
+  tell the TUI was closed. Migration 008. Dedup by selection key —
+  no UPDATE traffic when the user isn't moving.
 - **MCP star tools — `toggle_star`, `set_star`, `list_starred`** (#120).
   Closes the only TUI-only affordance gap so an agent in an adjacent
   pane (the recommended 2-pane workflow) can drive every state change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **TUI task panel flush policy** (#113). Done downloads auto-flush
+  after 5 s, Failed after 30 s — long enough for the user to see the
+  result, short enough that they don't crowd the panel. The 10-task
+  cap now only evicts terminal tasks; an in-flight Queued or Running
+  download is never dropped to make room. New `c` keybind clears all
+  completed/failed tasks immediately (visible in the tab-mode status
+  bar).
 - **CI vhs gate now asserts distinct snapshots** (#116). After
   rendering each tape, the workflow checks that every tape declaring
   `N` `Screenshot` calls produced at least `N` PNGs and that they're

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **VHS coverage for CLI search + question subcommands** (#99): two
+  new tapes (`tests/vhs/cli-search.tape`,
+  `tests/vhs/cli-question-workflow.tape`) plus a `Shift+Tab`
+  (BackTab) + `d`/`u` page-scroll addition to `tui-launch.tape` to
+  close the gaps flagged in the 0.4.0 coverage audit.
+
 ### Changed
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **SQLite cross-process write visibility** (#121). Added `synchronous=NORMAL`
+  to the WAL pairing (already had `journal_mode=WAL` and `busy_timeout=5000`)
+  and a `cross_process_write_visible_within_one_redraw` integration test
+  that opens two `Database` handles on the same file and verifies a write
+  through one is visible through the other on the very next read. This is
+  the property the 2-pane workflow (TUI in one pane, `scitadel mcp` in
+  another) depends on — without it the TUI shows stale state after every
+  agent-driven edit.
 - **VHS tape PATH ordering** (#116). All 9 tapes now put
   `$PWD/target/release` before `$HOME/.cargo/bin` so a stale installed
   `scitadel` can no longer shadow the project build. This was the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **TUI two-pane annotation reader** (#97, iter 1). Toggled with `R`
+  on the paper detail overlay: left pane renders the paper body
+  (`full_text` if cached, else the abstract) with background-color
+  highlights over annotated ranges, palette hashed by thread root_id
+  so a thread keeps the same color on every render. Right pane
+  threads root annotations + replies, focused row syncs with the
+  highlight underline. `J` / `K` hop between highlights. Single-
+  pane fallback message when no body text is available yet.
+  Multi-line gutter bars and PDF overlay are deferred.
+- **`PaperRepository::update_full_text`** + caching in
+  `read_paper_tool` (#97 prep). The MCP read tool now persists the
+  extracted text on first call so subsequent reads — including the
+  new TUI reader — hit the DB instead of re-running pdf-extract.
+  Failure to cache is non-fatal (extraction still returns).
 - **TUI-native annotation create / edit / reply / delete** (#92,
   iter 3b of #49). New keybindings on the paper detail overlay:
   `n` opens a two-stage Create prompt (quote → note); `Shift+J`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **MCP star tools — `toggle_star`, `set_star`, `list_starred`** (#120).
+  Closes the only TUI-only affordance gap so an agent in an adjacent
+  pane (the recommended 2-pane workflow) can drive every state change
+  the user can drive in the TUI. Trust-on-first-use `reader` identity,
+  matching the existing annotation tools (#100). Audit logged.
 - **Papers-table download-state column** (#112). Migration 007 adds
   `local_path`, `download_status`, and `last_attempt_at` columns to
   `papers`. The TUI Papers table renders a one-char symbol next to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.5.0] - 2026-04-21
+
+The 2-pane workflow release. Combines the agent-side affordances
+shipped under the 0.4.0 milestone (citation graph, MCP progress
+notifications, rmcp 0.17 upgrade, annotations CRUD via TUI + MCP,
+two-pane reader, get_annotated_paper, multi-selector resolver) with
+the 0.5.0 milestone's affordance-gap closures (download-state column,
+task-panel flush, star MCP tools, get_current_selection, SQLite
+cross-process visibility) and the meta-pivot away from a bundled LLM
+abstraction (#60/#61 closed as superseded) toward MCP-driven
+2-pane workflow as the primary recommendation.
+
+`Cargo.toml` workspace version is bumped 0.1.0 → 0.5.0 to align with
+the changelog narrative; this is the first release where the on-disk
+crate version actually matches the documented release. Earlier 0.2.x
+and 0.3.x sections in this file are CHANGELOG-only milestones — no
+git tags exist for them.
+
 ### Fixed
 
 - **SQLite cross-process write visibility** (#121). Added `synchronous=NORMAL`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Papers-table download-state column** (#112). Migration 007 adds
+  `local_path`, `download_status`, and `last_attempt_at` columns to
+  `papers`. The TUI Papers table renders a one-char symbol next to
+  each row: blank (never tried), `↻` (in flight), `✓` (downloaded),
+  `⊘` (paywalled / abstract-only), `✗` (failed). Both the TUI's
+  `D` keybind and the `scitadel download` CLI persist the outcome
+  back to the row so the symbol survives restarts. The in-flight
+  symbol is derived from the live task list — no DB write while
+  running.
 - **MCP progress notifications** (#58). The `search`,
   `download_paper`, and `prepare_batch_assessments` tools now emit
   `notifications/progress` frames when the caller supplies a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **MCP progress notifications** (#58). The `search`,
+  `download_paper`, and `prepare_batch_assessments` tools now emit
+  `notifications/progress` frames when the caller supplies a
+  `progressToken` in the request `_meta`. Bracketing pattern: a
+  start frame at progress=0 (with a human-readable message naming
+  the operation), then a done frame at progress=total on success or
+  with the error string on failure. Per-source / per-paper
+  granularity is a follow-up that needs the orchestrator to thread a
+  callback through each adapter loop. Built on the rmcp 0.17 upgrade
+  that landed earlier in 0.4.0.
 - **TUI two-pane annotation reader** (#97, iter 1). Toggled with `R`
   on the paper detail overlay: left pane renders the paper body
   (`full_text` if cached, else the abstract) with background-color

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **MCP tool-signature + return-shape consistency pass** (#98):
+  - `add_search_terms.query_string` is now `Option<String>` to match
+    its description (was a required `String` clients couldn't omit).
+  - Every MCP tool description now telegraphs its return shape
+    (`Returns: JSON` / `Returns: text`); enforced by a new style test
+    in `crates/scitadel-mcp/src/server.rs`.
+  - `get_assessments` description now says "at least one of paper_id
+    or question_id is required" — the handler error is unchanged.
+  - `list_annotations` description now states paper_id is required and
+    cross-paper listing is not yet implemented (matches the schema +
+    handler).
+  - `prepare_assessment` and `get_rubric` cross-reference each other
+    so an LLM doesn't redundantly fetch the rubric twice.
 - **Annotation anchor resolver** (#96): completes the four-step
   W3C-style pipeline shipped half-done in 0.3.0. Adds
   prefix/suffix-based disambiguation for repeated quotes, sliding-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,7 +267,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "rand_core 0.10.0",
 ]
 
@@ -382,6 +382,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -2406,10 +2415,12 @@ dependencies = [
  "proptest",
  "serde",
  "serde_json",
+ "sha1",
  "thiserror",
  "tokio",
  "toml",
  "tracing",
+ "unicode-normalization",
  "uuid",
 ]
 
@@ -2424,6 +2435,7 @@ dependencies = [
  "rusqlite",
  "scitadel-core",
  "serde_json",
+ "strsim",
  "tempfile",
  "thiserror",
  "tracing",
@@ -2649,6 +2661,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d036d71a959e00c77a63538b90a6c2390969f9772b096ea837205c6bd0491a44"
 dependencies = [
  "stable_deref_trait",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2485,6 +2485,7 @@ name = "scitadel-mcp"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "pdf-extract",
  "rmcp",
  "schemars",
@@ -2523,6 +2524,7 @@ name = "scitadel-tui"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "crossterm",
  "ratatui",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,12 +160,6 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -1089,7 +1083,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1667,6 +1661,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+
+[[package]]
 name = "pdf-extract"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2086,6 +2086,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2120,7 +2140,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2170,14 +2190,15 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.1.5"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33a0110d28bd076f39e14bfd5b0340216dd18effeb5d02b43215944cc3e5c751"
+checksum = "8a0ce46f9101dc911f07e1468084c057839d15b08040d110820c5513312ef56a"
 dependencies = [
- "base64 0.21.7",
+ "async-trait",
+ "base64",
  "chrono",
  "futures",
- "paste",
+ "pastey",
  "pin-project-lite",
  "rmcp-macros",
  "schemars",
@@ -2191,12 +2212,14 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.1.5"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e2b2fd7497540489fa2db285edd43b7ed14c49157157438664278da6e42a7a"
+checksum = "abad6f5f46e220e3bda2fc90fd1ad64c1c2a2bd716d52c845eb5c9c64cda7542"
 dependencies = [
+ "darling",
  "proc-macro2",
  "quote",
+ "serde_json",
  "syn",
 ]
 
@@ -2339,11 +2362,13 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.22"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
+ "chrono",
  "dyn-clone",
+ "ref-cast",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -2351,9 +2376,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.22"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3706,7 +3731,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
 dependencies = [
  "assert-json-diff",
- "base64 0.22.1",
+ "base64",
  "deadpool",
  "futures",
  "http",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2388,7 +2388,7 @@ dependencies = [
 
 [[package]]
 name = "scitadel-adapters"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "insta",
@@ -2405,7 +2405,7 @@ dependencies = [
 
 [[package]]
 name = "scitadel-cli"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2431,7 +2431,7 @@ dependencies = [
 
 [[package]]
 name = "scitadel-core"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2451,7 +2451,7 @@ dependencies = [
 
 [[package]]
 name = "scitadel-db"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "insta",
@@ -2469,7 +2469,7 @@ dependencies = [
 
 [[package]]
 name = "scitadel-export"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "csv",
@@ -2482,7 +2482,7 @@ dependencies = [
 
 [[package]]
 name = "scitadel-mcp"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2504,7 +2504,7 @@ dependencies = [
 
 [[package]]
 name = "scitadel-scoring"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2521,7 +2521,7 @@ dependencies = [
 
 [[package]]
 name = "scitadel-tui"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.5.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/vig-os/scitadel"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,8 +62,8 @@ ratatui = "0.29"
 crossterm = "0.28"
 
 # MCP
-rmcp = { version = "0.1", features = ["server", "transport-io"] }
-schemars = "0.8"
+rmcp = { version = "0.17", features = ["server", "transport-io", "macros"] }
+schemars = "1"
 
 # Content extraction (PDF / HTML → text)
 pdf-extract = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,11 @@ schemars = "0.8"
 pdf-extract = "0.7"
 scraper = "0.20"
 
+# Annotation anchor resolver (#96)
+strsim = "0.11"
+sha1 = "0.10"
+unicode-normalization = "0.1"
+
 # Testing
 insta = { version = "1", features = ["json"] }
 wiremock = "0.6"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,30 @@ Scientific literature retrieval is fragmented, manual, and non-reproducible. Res
 
 Scitadel fixes this: one query, all sources, deterministic results, full audit trail.
 
+## Recommended workflow: TUI + agent in adjacent pane
+
+Scitadel's primary workflow is **`scitadel tui` in one terminal pane, an MCP-aware agent (Claude Code, Cursor, Cline, …) in an adjacent pane**. The agent talks to scitadel through the MCP server (40+ tools); the TUI redraws live as the agent writes.
+
+```
+┌─────────────────────────────┬──────────────────────────────┐
+│ $ scitadel tui              │ $ claude                     │
+│ ┌── Papers ───────────────┐ │                              │
+│ │ ✓ Attention Is All You  │ │ > score the open paper       │
+│ │ ⊘ Recurrent Neural...   │ │   against my CRISPR question │
+│ │ ★ ✓ Transformer Survey  │ │                              │
+│ └─────────────────────────┘ │   [agent calls                │
+│   Annotations (3)           │    get_current_selection,    │
+│   • "self-attention..." ─ok │    prepare_assessment,       │
+│   • "the Transformer" ─ ok  │    save_assessment]           │
+│                             │                              │
+│   Esc: back · n: new · …    │ Done. Score: 0.87, reasoning │
+└─────────────────────────────┴──────────────────────────────┘
+```
+
+The agent owns conversational reasoning (drafting questions, summarizing papers, suggesting related terms). The TUI owns reading and quick navigation (browse, star, annotate, scroll). They share the SQLite database via WAL mode — every MCP write surfaces in the open TUI within ~100 ms.
+
+You don't need any LLM CLI installed to use scitadel — every TUI/CLI feature works standalone. But once you set up the MCP server (one line, see below), the agent + TUI combo is what scitadel was designed for.
+
 ## Install
 
 Scitadel is a Rust workspace. You need a Rust toolchain (`rustup`, stable channel).
@@ -155,72 +179,57 @@ New papers discovered via snowballing are deduplicated against the existing data
 
 ### 4. Interactive TUI
 
-Browse searches, papers, assessments, and citation trees in an interactive terminal dashboard.
+Browse searches, papers, annotations, and citation trees in an interactive terminal dashboard. Best experienced with an MCP-aware agent in an adjacent terminal pane (see [Recommended workflow](#recommended-workflow-tui--agent-in-adjacent-pane)).
 
 ```bash
-# Launch the TUI (requires textual: pip install scitadel[tui])
 scitadel tui
-
-# Or use the standalone entry point
-scitadel-tui
 ```
 
 The TUI has three tabs:
 
 - **Searches** — browse past search runs, drill into papers, view full metadata and assessments
-- **Questions** — see research questions with their linked terms and assessment statistics
-- **New Search** — run a search and watch results stream in
+- **Papers** — every paper across every search, with a state column (`✓` downloaded, `⊘` paywalled, `✗` failed, `↻` in flight) and a star toggle (`s`)
+- **Questions** — research questions with their linked search terms
 
-From any paper, press `c` to view its citation tree (references and citing papers from snowball runs).
+**Per-paper overlay** (Enter on a paper): full metadata, annotation list, and:
+- `R` — two-pane reader (left: full text with colored highlights, right: annotation threads)
+- `n / e / r / d` — create / edit / reply / delete annotation
+- `J / K` — hop between highlights in reader mode
+- `D` — download via Unpaywall / publisher
+
+The TUI re-queries the DB every redraw, so any write through the MCP server (in an adjacent pane) shows up live with no refresh keypress.
 
 ### 5. Agent-driven workflow via MCP
 
-Connect scitadel as an MCP server and let an LLM agent drive the pipeline — from question formulation through search, scoring, and snowballing.
+The MCP server is the seam between scitadel and any agent that speaks MCP. See [Recommended workflow](#recommended-workflow-tui--agent-in-adjacent-pane) above for the 2-pane setup that's the primary use case.
 
 ```bash
 # Run the server manually (stdio transport)
 scitadel mcp
 ```
 
-For Claude Code, register once (see [Install](#install) above):
+**Setup snippets:**
 
-```bash
-claude mcp add --scope user scitadel -- scitadel mcp
-```
+| Agent | Setup |
+|---|---|
+| **Claude Code** | `claude mcp add --scope user scitadel -- scitadel mcp` |
+| **Claude Desktop** | Add to `claude_desktop_config.json`: `{"mcpServers": {"scitadel": {"command": "scitadel", "args": ["mcp"]}}}` |
+| **Cursor / Cline / Continue** | Same JSON shape — point at the `scitadel mcp` subcommand |
 
-For Claude Desktop, add to `claude_desktop_config.json`:
+**40+ MCP tools** spanning the full pipeline:
 
-```json
-{
-  "mcpServers": {
-    "scitadel": {
-      "command": "scitadel",
-      "args": ["mcp"]
-    }
-  }
-}
-```
+- **Search & retrieval**: `search`, `list_searches`, `get_papers`, `get_paper`, `get_annotated_paper`, `find_similar_searches`, `summarize_search`, `download_paper`, `read_paper`, `list_sources`
+- **Research questions**: `create_question`, `list_questions`, `add_search_terms`, `get_rubric`
+- **Scoring**: `prepare_assessment`, `prepare_batch_assessments`, `assess_paper`, `save_assessment`, `get_assessments`
+- **Annotations** (#49): `create_annotation`, `reply_annotation`, `update_annotation`, `delete_annotation`, `list_annotations`, `mark_seen`, `mark_thread_seen`, `list_unread`
+- **Citation graph** (#59): `get_references`, `get_citations`
+- **Stars** (#120): `toggle_star`, `set_star`, `list_starred`
+- **TUI awareness** (#122): `get_current_selection` — "what is the user looking at right now?"
+- **Export**: `export_search`
 
-The MCP server exposes 14 tools:
+Every long-running tool (search / batch scoring / download) emits MCP `notifications/progress` frames if the caller supplies a `progressToken` (#58). Annotation writes are audit-logged. Identity is trust-on-first-use (real auth ships with the Phase-5 Dolt sync layer).
 
-| Tool | What it does |
-|------|-------------|
-| `search` | Federated search (supports `question_id` for auto-query) |
-| `list_searches` | Browse past search runs |
-| `get_papers` | List papers from a search |
-| `get_paper` | Full details of a single paper |
-| `export_search` | Export as BibTeX / JSON / CSV |
-| `create_question` | Define a research question |
-| `list_questions` | Browse research questions |
-| `add_search_terms` | Link keywords to a question |
-| `assess_paper` | Record a relevance score with reasoning |
-| `get_assessments` | Retrieve scores for a paper or question |
-| `prepare_assessment` | Build a rubric + paper payload for host-LLM scoring |
-| `prepare_batch_assessments` | Same, for every paper in a search |
-| `save_assessment` | Persist a host-LLM-scored assessment |
-| `download_paper` | Fetch PDF (Unpaywall) or publisher HTML by DOI |
-
-This enables a workflow where the agent formulates a question, generates search terms, runs a search, scores each paper, snowballs relevant citations, and writes structured assessments — all through tool calls with no manual intervention.
+The full pipeline — agent formulates a question, generates search terms, runs a search, scores each paper, snowballs relevant citations, writes structured assessments — runs through tool calls with no manual intervention. With #122, the agent can also act on whatever the user is looking at in the TUI without the user pasting IDs.
 
 ## Workflow coverage
 

--- a/crates/scitadel-adapters/Cargo.toml
+++ b/crates/scitadel-adapters/Cargo.toml
@@ -16,7 +16,7 @@ default = []
 contract-tests = []
 
 [dependencies]
-scitadel-core = { path = "../scitadel-core", version = "0.1.0" }
+scitadel-core = { path = "../scitadel-core", version = "0.5.0" }
 reqwest = { workspace = true }
 quick-xml = { workspace = true }
 serde = { workspace = true }

--- a/crates/scitadel-adapters/src/openalex.rs
+++ b/crates/scitadel-adapters/src/openalex.rs
@@ -16,6 +16,147 @@ impl OpenAlexAdapter {
     pub fn new(email: String, timeout: f64) -> Self {
         Self { email, timeout }
     }
+
+    /// Fetch the full Work JSON for a single paper by its short OpenAlex
+    /// id (e.g. `W2741809807`). Returns the raw API payload so callers
+    /// can pluck whatever fields they need (title, `referenced_works`,
+    /// authorships, etc.). Used by the citation-graph service (#59).
+    pub async fn fetch_work_by_id(
+        &self,
+        openalex_id: &str,
+    ) -> Result<serde_json::Value, CoreError> {
+        self.fetch_from(&format!("{OPENALEX_API_URL}/{openalex_id}"), &[])
+            .await
+    }
+
+    /// Fetch a batch of Works by their short OpenAlex ids (W…) in one
+    /// request. OpenAlex's `openalex_id:W1|W2|…` filter accepts up to
+    /// 50 entries per call; the caller is responsible for chunking
+    /// larger lists. Returns the deserialised `results` array.
+    pub async fn fetch_works_by_ids(
+        &self,
+        ids: &[String],
+    ) -> Result<Vec<serde_json::Value>, CoreError> {
+        if ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        if ids.len() > 50 {
+            return Err(CoreError::Adapter(
+                "openalex".into(),
+                format!(
+                    "fetch_works_by_ids requires <=50 ids per call, got {}",
+                    ids.len()
+                ),
+            ));
+        }
+        let filter = format!("openalex_id:{}", ids.join("|"));
+        let payload = self
+            .fetch_from(
+                OPENALEX_API_URL,
+                &[("filter", filter.as_str()), ("per_page", "50")],
+            )
+            .await?;
+        Ok(payload
+            .get("results")
+            .and_then(|r| r.as_array())
+            .cloned()
+            .unwrap_or_default())
+    }
+
+    /// Fetch Works that cite the given paper (the reverse-citation
+    /// direction). `limit` defaults to 25 and is capped at 200 by the
+    /// OpenAlex API.
+    pub async fn fetch_cited_by(
+        &self,
+        openalex_id: &str,
+        limit: usize,
+    ) -> Result<Vec<serde_json::Value>, CoreError> {
+        let filter = format!("cites:{openalex_id}");
+        let per_page = limit.clamp(1, 200).to_string();
+        let payload = self
+            .fetch_from(
+                OPENALEX_API_URL,
+                &[("filter", filter.as_str()), ("per_page", per_page.as_str())],
+            )
+            .await?;
+        Ok(payload
+            .get("results")
+            .and_then(|r| r.as_array())
+            .cloned()
+            .unwrap_or_default())
+    }
+
+    async fn fetch_from(
+        &self,
+        url: &str,
+        extra: &[(&str, &str)],
+    ) -> Result<serde_json::Value, CoreError> {
+        let client = Client::builder()
+            .timeout(std::time::Duration::from_secs_f64(self.timeout))
+            .build()
+            .map_err(|e| CoreError::Adapter("openalex".into(), e.to_string()))?;
+
+        let mut params: Vec<(&str, String)> =
+            extra.iter().map(|(k, v)| (*k, (*v).to_string())).collect();
+        if !self.email.is_empty() {
+            params.push(("mailto", self.email.clone()));
+        }
+
+        let resp = client
+            .get(url)
+            .query(&params)
+            .send()
+            .await
+            .map_err(|e| CoreError::Adapter("openalex".into(), e.to_string()))?;
+        if !resp.status().is_success() {
+            return Err(CoreError::Adapter(
+                "openalex".into(),
+                format!("HTTP {} for {url}", resp.status()),
+            ));
+        }
+        resp.json()
+            .await
+            .map_err(|e| CoreError::Adapter("openalex".into(), e.to_string()))
+    }
+}
+
+/// Extract the short OpenAlex id (`W2741809807`) from either a full URL
+/// (`https://openalex.org/W2741809807`) or a bare id. Returns `None` if
+/// the input doesn't end in a `W…` token.
+#[must_use]
+pub fn short_openalex_id(maybe_url: &str) -> Option<String> {
+    let last = maybe_url.rsplit('/').next().unwrap_or(maybe_url);
+    if last.starts_with('W') && last.len() > 1 {
+        Some(last.to_string())
+    } else {
+        None
+    }
+}
+
+/// Build a `Paper` (canonical record) from an OpenAlex Work JSON.
+/// Useful when materialising referenced works as DB rows.
+#[must_use]
+pub fn work_to_paper(work: &serde_json::Value) -> scitadel_core::models::Paper {
+    use scitadel_core::models::{Paper, PaperId};
+    let candidate = work_to_candidate(work, 0);
+    let mut paper = Paper::new(candidate.title);
+    if !candidate.authors.is_empty() {
+        paper.authors = candidate.authors;
+    }
+    paper.r#abstract = candidate.r#abstract;
+    paper.doi = candidate.doi;
+    paper.openalex_id.clone_from(&candidate.openalex_id);
+    paper.pubmed_id = candidate.pubmed_id;
+    paper.year = candidate.year;
+    paper.journal = candidate.journal;
+    paper.url = candidate.url;
+    if let Some(short) = candidate.openalex_id {
+        // Use the short OpenAlex id as the canonical paper id so
+        // citation rows have a stable target_paper_id even when the
+        // metadata gets re-fetched later.
+        paper.id = PaperId::from(short);
+    }
+    paper
 }
 
 #[async_trait]
@@ -251,5 +392,34 @@ mod tests {
         assert_eq!(c.year, Some(2024));
         assert_eq!(c.authors, vec!["Alice Smith", "Bob Jones"]);
         assert_eq!(c.journal, Some("Nature".to_string()));
+    }
+
+    #[test]
+    fn short_openalex_id_extracts_from_url_or_bare_id() {
+        assert_eq!(
+            short_openalex_id("https://openalex.org/W2741809807"),
+            Some("W2741809807".into())
+        );
+        assert_eq!(short_openalex_id("W2741809807"), Some("W2741809807".into()));
+        assert_eq!(short_openalex_id("not-a-work"), None);
+        assert_eq!(short_openalex_id("https://openalex.org/A12345"), None);
+        // Edge: just "W" alone is not a valid id.
+        assert_eq!(short_openalex_id("W"), None);
+    }
+
+    #[test]
+    fn work_to_paper_uses_openalex_id_as_canonical_paper_id() {
+        let work = serde_json::json!({
+            "id": "https://openalex.org/W2741809807",
+            "title": "Foundational paper",
+            "publication_year": 2017,
+            "doi": "https://doi.org/10.5555/foo",
+        });
+        let paper = work_to_paper(&work);
+        assert_eq!(paper.id.as_str(), "W2741809807");
+        assert_eq!(paper.openalex_id.as_deref(), Some("W2741809807"));
+        assert_eq!(paper.title, "Foundational paper");
+        assert_eq!(paper.year, Some(2017));
+        assert_eq!(paper.doi.as_deref(), Some("10.5555/foo"));
     }
 }

--- a/crates/scitadel-cli/Cargo.toml
+++ b/crates/scitadel-cli/Cargo.toml
@@ -16,13 +16,13 @@ name = "scitadel"
 path = "src/main.rs"
 
 [dependencies]
-scitadel-core = { path = "../scitadel-core", version = "0.1.0" }
-scitadel-db = { path = "../scitadel-db", version = "0.1.0" }
-scitadel-adapters = { path = "../scitadel-adapters", version = "0.1.0" }
-scitadel-scoring = { path = "../scitadel-scoring", version = "0.1.0" }
-scitadel-export = { path = "../scitadel-export", version = "0.1.0" }
-scitadel-mcp = { path = "../scitadel-mcp", version = "0.1.0" }
-scitadel-tui = { path = "../scitadel-tui", version = "0.1.0" }
+scitadel-core = { path = "../scitadel-core", version = "0.5.0" }
+scitadel-db = { path = "../scitadel-db", version = "0.5.0" }
+scitadel-adapters = { path = "../scitadel-adapters", version = "0.5.0" }
+scitadel-scoring = { path = "../scitadel-scoring", version = "0.5.0" }
+scitadel-export = { path = "../scitadel-export", version = "0.5.0" }
+scitadel-mcp = { path = "../scitadel-mcp", version = "0.5.0" }
+scitadel-tui = { path = "../scitadel-tui", version = "0.5.0" }
 rmcp = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }

--- a/crates/scitadel-cli/src/commands.rs
+++ b/crates/scitadel-cli/src/commands.rs
@@ -641,10 +641,13 @@ pub async fn download(doi: &str, output_dir: Option<PathBuf>) -> Result<()> {
     println!("Downloading paper: {doi}");
     println!("  Output dir: {}", out_dir.display());
 
-    let result = downloader
-        .download(doi, &out_dir)
-        .await
-        .context("download failed")?;
+    let result = downloader.download(doi, &out_dir).await;
+
+    // Persist outcome on the matching paper row (#112) before reporting
+    // so the Papers table reflects the attempt regardless of outcome.
+    persist_cli_download_outcome(&config, doi, result.as_ref().ok());
+
+    let result = result.context("download failed")?;
 
     println!("  Format: {}", result.format);
     println!("  Source: {}", result.source);
@@ -653,6 +656,56 @@ pub async fn download(doi: &str, output_dir: Option<PathBuf>) -> Result<()> {
     println!("  Saved:  {}", result.path.display());
 
     Ok(())
+}
+
+fn persist_cli_download_outcome(
+    config: &scitadel_core::config::Config,
+    doi: &str,
+    success: Option<&scitadel_adapters::download::DownloadResult>,
+) {
+    use scitadel_adapters::download::AccessStatus;
+    use scitadel_core::models::DownloadStatus;
+    use scitadel_core::ports::PaperRepository as _;
+
+    let db = match scitadel_db::sqlite::Database::open(&config.db_path) {
+        Ok(db) => db,
+        Err(e) => {
+            tracing::warn!(error = %e, "could not open DB to persist download outcome");
+            return;
+        }
+    };
+    if let Err(e) = db.migrate() {
+        tracing::warn!(error = %e, "DB migration failed while persisting download outcome");
+        return;
+    }
+    let (paper_repo, _, _, _, _) = db.repositories();
+    let paper = match paper_repo.find_by_doi(doi) {
+        Ok(Some(p)) => p,
+        Ok(None) => {
+            tracing::debug!(doi, "no paper row for DOI; skipping download-state write");
+            return;
+        }
+        Err(e) => {
+            tracing::warn!(doi, error = %e, "DOI lookup failed");
+            return;
+        }
+    };
+
+    let (path, status) = match success {
+        Some(r) => {
+            let ds = match r.access {
+                AccessStatus::FullText => DownloadStatus::Downloaded,
+                AccessStatus::Abstract | AccessStatus::Paywall | AccessStatus::Unknown => {
+                    DownloadStatus::Paywall
+                }
+            };
+            (Some(r.path.to_string_lossy().into_owned()), ds)
+        }
+        None => (None, DownloadStatus::Failed),
+    };
+    if let Err(e) = paper_repo.update_download_state(paper.id.as_str(), path.as_deref(), status) {
+        tracing::warn!(error = %e, "failed to persist download outcome");
+    }
 }
 
 #[allow(clippy::unnecessary_wraps)]

--- a/crates/scitadel-cli/src/commands.rs
+++ b/crates/scitadel-cli/src/commands.rs
@@ -37,7 +37,7 @@ where
 pub async fn mcp() -> Result<()> {
     use rmcp::ServiceExt;
     let transport = rmcp::transport::io::stdio();
-    let server = scitadel_mcp::server::ScitadelServer;
+    let server = scitadel_mcp::server::ScitadelServer::new();
     let service = server.serve(transport).await?;
     service.waiting().await?;
     Ok(())

--- a/crates/scitadel-core/Cargo.toml
+++ b/crates/scitadel-core/Cargo.toml
@@ -22,6 +22,8 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 toml = "0.8"
 futures = { workspace = true }
+sha1 = { workspace = true }
+unicode-normalization = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/scitadel-core/src/models/annotation.rs
+++ b/crates/scitadel-core/src/models/annotation.rs
@@ -155,6 +155,56 @@ pub struct AnnotationRead {
     pub seen_at: DateTime<Utc>,
 }
 
+/// Normalize a sentence for sentence-id hashing.
+///
+/// Per ADR-004: NFKC compose (folds ligatures: ﬁ → fi, ﬂ → fl), Unicode
+/// lowercase, then collapse all Unicode whitespace runs to a single
+/// ASCII space and trim. Two sentences that differ only in case,
+/// whitespace, or ligature presentation hash to the same value.
+#[must_use]
+pub fn normalize_sentence(s: &str) -> String {
+    use unicode_normalization::UnicodeNormalization;
+    // NFKC: compatibility decomposition + canonical composition.
+    let composed: String = s.nfkc().collect();
+    let lowered: String = composed.chars().flat_map(char::to_lowercase).collect();
+    let mut out = String::with_capacity(lowered.len());
+    let mut prev_was_space = true; // collapses leading whitespace
+    for ch in lowered.chars() {
+        if ch.is_whitespace() {
+            if !prev_was_space {
+                out.push(' ');
+                prev_was_space = true;
+            }
+        } else {
+            out.push(ch);
+            prev_was_space = false;
+        }
+    }
+    if out.ends_with(' ') {
+        out.pop();
+    }
+    out
+}
+
+/// SHA1 hex of the normalized sentence — stable identifier the
+/// resolver can compare against sentences extracted from current
+/// paper text. See `normalize_sentence` and ADR-004 for the
+/// normalization spec.
+#[must_use]
+pub fn sentence_id(s: &str) -> String {
+    use sha1::{Digest, Sha1};
+    let normalized = normalize_sentence(s);
+    let mut hasher = Sha1::new();
+    hasher.update(normalized.as_bytes());
+    let digest = hasher.finalize();
+    let mut hex = String::with_capacity(40);
+    for byte in digest {
+        use std::fmt::Write as _;
+        let _ = write!(hex, "{byte:02x}");
+    }
+    hex
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -194,5 +244,32 @@ mod tests {
         assert!(!a.is_orphan());
         a.status = AnchorStatus::Orphan;
         assert!(a.is_orphan());
+    }
+
+    #[test]
+    fn normalize_collapses_whitespace_and_lowercases() {
+        assert_eq!(normalize_sentence("  Hello   WORLD\n"), "hello world");
+    }
+
+    #[test]
+    fn normalize_folds_ligatures_via_nfkc() {
+        // U+FB01 (ﬁ) → "fi" under NFKC, so "ef + ﬁ + cient" → "efficient".
+        assert_eq!(normalize_sentence("ef\u{FB01}cient"), "efficient");
+    }
+
+    #[test]
+    fn sentence_id_is_stable_under_whitespace_and_case() {
+        let a = sentence_id("Hello   World");
+        let b = sentence_id("hello world");
+        let c = sentence_id("HELLO\tWORLD");
+        assert_eq!(a, b);
+        assert_eq!(b, c);
+        // Length of SHA1 hex.
+        assert_eq!(a.len(), 40);
+    }
+
+    #[test]
+    fn sentence_id_changes_when_content_does() {
+        assert_ne!(sentence_id("hello world"), sentence_id("hello mars"));
     }
 }

--- a/crates/scitadel-core/src/models/mod.rs
+++ b/crates/scitadel-core/src/models/mod.rs
@@ -12,7 +12,7 @@ pub use annotation::{
 pub use assessment::Assessment;
 pub use citation::{Citation, CitationDirection, SnowballRun};
 pub use doi::{doi_to_filename, normalize_doi, validate_doi};
-pub use paper::{CandidatePaper, Paper};
+pub use paper::{CandidatePaper, DownloadStatus, Paper};
 pub use question::{ResearchQuestion, SearchTerm};
 pub use search::{Search, SearchResult, SourceOutcome, SourceStatus};
 

--- a/crates/scitadel-core/src/models/mod.rs
+++ b/crates/scitadel-core/src/models/mod.rs
@@ -6,7 +6,9 @@ mod paper;
 mod question;
 mod search;
 
-pub use annotation::{Anchor, AnchorStatus, Annotation, AnnotationRead};
+pub use annotation::{
+    Anchor, AnchorStatus, Annotation, AnnotationRead, normalize_sentence, sentence_id,
+};
 pub use assessment::Assessment;
 pub use citation::{Citation, CitationDirection, SnowballRun};
 pub use doi::{doi_to_filename, normalize_doi, validate_doi};

--- a/crates/scitadel-core/src/models/paper.rs
+++ b/crates/scitadel-core/src/models/paper.rs
@@ -29,6 +29,19 @@ pub struct Paper {
     pub source_urls: HashMap<String, String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    /// Absolute path to the locally downloaded file (PDF/HTML), if any.
+    /// Populated by the download pipeline; `None` until first successful
+    /// download attempt. See #112.
+    #[serde(default)]
+    pub local_path: Option<String>,
+    /// Outcome of the most recent download attempt. `None` = never tried.
+    #[serde(default)]
+    pub download_status: Option<DownloadStatus>,
+    /// Wall-clock time of the most recent download attempt. Together with
+    /// `download_status` lets the UI distinguish "fresh failure" from
+    /// "tried weeks ago, retry might work".
+    #[serde(default)]
+    pub last_attempt_at: Option<DateTime<Utc>>,
 }
 
 impl Paper {
@@ -53,6 +66,47 @@ impl Paper {
             source_urls: HashMap::new(),
             created_at: now,
             updated_at: now,
+            local_path: None,
+            download_status: None,
+            last_attempt_at: None,
+        }
+    }
+}
+
+/// Outcome of a paper download attempt. Persisted on `papers.download_status`.
+///
+/// `Downloaded` means the adapter classified the fetched bytes as full
+/// content. `Paywall` means we got bytes but they're an HTML stub /
+/// abstract / paywall page — file exists but doesn't contain the paper.
+/// `Failed` means the download itself errored (network, 404, etc.).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DownloadStatus {
+    Downloaded,
+    Paywall,
+    Failed,
+}
+
+impl DownloadStatus {
+    /// SQL-friendly string used in the `download_status` text column.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Downloaded => "downloaded",
+            Self::Paywall => "paywall",
+            Self::Failed => "failed",
+        }
+    }
+
+    /// Inverse of `as_str`. Returns `None` for unknown values so a
+    /// stale row from a future schema doesn't crash the loader.
+    #[must_use]
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "downloaded" => Some(Self::Downloaded),
+            "paywall" => Some(Self::Paywall),
+            "failed" => Some(Self::Failed),
+            _ => None,
         }
     }
 }

--- a/crates/scitadel-core/src/ports/repository.rs
+++ b/crates/scitadel-core/src/ports/repository.rs
@@ -18,6 +18,12 @@ pub trait PaperRepository: Send + Sync {
     fn find_by_doi(&self, doi: &str) -> Result<Option<Paper>, CoreError>;
     fn find_by_title(&self, title: &str) -> Result<Option<Paper>, CoreError>;
     fn list_all(&self, limit: i64, offset: i64) -> Result<Vec<Paper>, CoreError>;
+    /// Persist extracted full text for a paper. Used by `read_paper_tool`
+    /// after the first PDF/HTML extraction so subsequent reads (TUI
+    /// reader, MCP `get_annotated_paper`) hit the DB instead of
+    /// re-running pdf-extract. Idempotent — overwrites the existing
+    /// `full_text` column.
+    fn update_full_text(&self, paper_id: &str, text: &str) -> Result<(), CoreError>;
 }
 
 /// Port for search run persistence.

--- a/crates/scitadel-core/src/ports/repository.rs
+++ b/crates/scitadel-core/src/ports/repository.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 
 use crate::error::CoreError;
 use crate::models::{
-    Assessment, Citation, Paper, PaperId, ResearchQuestion, Search, SearchResult, SearchTerm,
-    SnowballRun,
+    Assessment, Citation, DownloadStatus, Paper, PaperId, ResearchQuestion, Search, SearchResult,
+    SearchTerm, SnowballRun,
 };
 
 /// Port for paper persistence.
@@ -24,6 +24,16 @@ pub trait PaperRepository: Send + Sync {
     /// re-running pdf-extract. Idempotent — overwrites the existing
     /// `full_text` column.
     fn update_full_text(&self, paper_id: &str, text: &str) -> Result<(), CoreError>;
+    /// Persist the outcome of a download attempt. `local_path` is the
+    /// absolute path to the saved file on success (any non-`Failed`
+    /// status); pass `None` for `Failed`. `last_attempt_at` is set to
+    /// `now()` automatically. See #112.
+    fn update_download_state(
+        &self,
+        paper_id: &str,
+        local_path: Option<&str>,
+        status: DownloadStatus,
+    ) -> Result<(), CoreError>;
 }
 
 /// Port for search run persistence.

--- a/crates/scitadel-db/Cargo.toml
+++ b/crates/scitadel-db/Cargo.toml
@@ -12,7 +12,7 @@ description = "SQLite-backed repositories and migrations for scitadel."
 readme = "../../README.md"
 
 [dependencies]
-scitadel-core = { path = "../scitadel-core", version = "0.1.0" }
+scitadel-core = { path = "../scitadel-core", version = "0.5.0" }
 rusqlite = { workspace = true }
 r2d2 = { workspace = true }
 r2d2_sqlite = { workspace = true }

--- a/crates/scitadel-db/Cargo.toml
+++ b/crates/scitadel-db/Cargo.toml
@@ -20,6 +20,7 @@ serde_json = { workspace = true }
 chrono = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+strsim = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/scitadel-db/migrations/007_paper_download_state.sql
+++ b/crates/scitadel-db/migrations/007_paper_download_state.sql
@@ -1,0 +1,10 @@
+-- Persist the outcome of paper downloads so the TUI can show a state
+-- column ("never tried", "downloaded", "paywalled", "failed") without
+-- re-probing on every render and the user can tell at a glance which
+-- papers are openable. See #112.
+
+ALTER TABLE papers ADD COLUMN local_path TEXT;
+ALTER TABLE papers ADD COLUMN download_status TEXT;
+ALTER TABLE papers ADD COLUMN last_attempt_at TEXT;
+
+INSERT OR IGNORE INTO schema_version (version, applied_at) VALUES (7, datetime('now'));

--- a/crates/scitadel-db/migrations/008_tui_state.sql
+++ b/crates/scitadel-db/migrations/008_tui_state.sql
@@ -1,0 +1,16 @@
+-- Singleton row tracking the TUI's current selection (#122) so an
+-- agent in an adjacent pane (the recommended 2-pane workflow) can ask
+-- "what is the user looking at right now?" without the user having to
+-- paste IDs. Last-writer-wins if multiple TUIs run concurrently.
+
+CREATE TABLE tui_state (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    tab TEXT NOT NULL,
+    paper_id TEXT,
+    search_id TEXT,
+    question_id TEXT,
+    annotation_id TEXT,
+    updated_at TEXT NOT NULL
+);
+
+INSERT OR IGNORE INTO schema_version (version, applied_at) VALUES (8, datetime('now'));

--- a/crates/scitadel-db/src/sqlite/annotations.rs
+++ b/crates/scitadel-db/src/sqlite/annotations.rs
@@ -1,10 +1,14 @@
-//! SQLite-backed repository for annotations (#49 iter 2).
+//! SQLite-backed repository for annotations (#49 iter 2, #96 resolver).
 //!
-//! Covers CRUD, threaded reply loading, and a minimal anchoring resolver.
-//! The resolver currently tries two selectors — exact char range and
-//! quote-substring match — and marks orphans for anything else. Fuzzy
-//! quote matching and sentence-id lookup are deferred to iter 3 once we
-//! have a TUI surfacing orphans to trigger re-anchoring.
+//! Covers CRUD, threaded reply loading, and the four-step W3C-style
+//! anchor resolver:
+//!
+//! 1. position (`char_range` + bounds-check)
+//! 2. quote with prefix/suffix context disambiguation
+//! 3. fuzzy quote match (Jaro-Winkler over a sliding window)
+//! 4. sentence-id (SHA1 of normalized sentence; see ADR-004)
+//!
+//! Failure of all four selectors yields `AnchorStatus::Orphan`.
 
 use chrono::{DateTime, Utc};
 use rusqlite::{OptionalExtension, params};
@@ -279,39 +283,239 @@ fn parse_dt(s: &str) -> DateTime<Utc> {
     DateTime::parse_from_rfc3339(s).map_or_else(|_| Utc::now(), |dt| dt.with_timezone(&Utc))
 }
 
+/// Default fuzzy-match threshold (Jaro-Winkler similarity in [0,1]).
+/// Anchors at or above this score are accepted as `Drifted`. See
+/// `resolve_anchor_with_threshold` for tuning.
+pub const FUZZY_THRESHOLD: f64 = 0.9;
+
 /// Resolve an anchor against current paper text, updating `status` and
-/// (if the quote shifted) `char_range` in place. The resolver tries two
-/// selectors today:
+/// (if the quote shifted) `char_range` in place. Four-step W3C-style
+/// pipeline (#96):
 ///
 /// 1. **Position**: `char_range` still hits the same `quote` → `Ok`.
-/// 2. **Quote substring**: `text.find(quote)` succeeds → `Drifted`,
-///    offsets auto-updated.
+///    Bounds-checked; out-of-range offsets fall through, never panic.
+/// 2. **Quote + prefix/suffix context**: every occurrence of `quote`
+///    in `text` is scored by how well its surroundings match the
+///    stored `prefix` / `suffix`; the best-scoring occurrence wins.
+///    With a single occurrence and no context, behaves like a plain
+///    substring search → `Drifted`.
+/// 3. **Fuzzy quote match**: sliding window the size of `quote` over
+///    `text`; Jaro-Winkler ≥ `FUZZY_THRESHOLD` → `Drifted`. Catches
+///    one-word publisher edits that would otherwise orphan.
+/// 4. **Sentence-id**: split text into sentences, hash each via
+///    `sentence_id()`, and re-anchor on a match. Survives quote
+///    rewrites that preserve the surrounding sentence.
 ///
-/// Fuzzy match + sentence-id lookup are deferred to iter 3 (introduces
-/// normalization + SHA1 hashing pipeline).
+/// Returns `Orphan` only when all four selectors fail.
 pub fn resolve_anchor(anchor: &mut Anchor, text: &str) -> AnchorStatus {
-    // Attempt 1: current offsets still match the quote exactly.
-    if let (Some((start, end)), Some(quote)) = (anchor.char_range, anchor.quote.as_ref()) {
-        let candidate: String = text.chars().skip(start).take(end - start).collect();
-        if &candidate == quote {
-            anchor.status = AnchorStatus::Ok;
-            return AnchorStatus::Ok;
-        }
+    resolve_anchor_with_threshold(anchor, text, FUZZY_THRESHOLD)
+}
+
+pub fn resolve_anchor_with_threshold(
+    anchor: &mut Anchor,
+    text: &str,
+    fuzzy_threshold: f64,
+) -> AnchorStatus {
+    // Step 1: position selector — bounds-checked.
+    if let (Some((start, end)), Some(quote)) = (anchor.char_range, anchor.quote.as_ref())
+        && let Some(slice) = char_slice(text, start, end)
+        && &slice == quote
+    {
+        anchor.status = AnchorStatus::Ok;
+        return AnchorStatus::Ok;
     }
 
-    // Attempt 2: find the quote anywhere in the text.
+    // Step 2: quote with prefix/suffix disambiguation.
     if let Some(quote) = anchor.quote.as_ref()
-        && let Some(byte_pos) = text.find(quote.as_str())
+        && let Some((sc, ec)) = find_with_context(
+            text,
+            quote,
+            anchor.prefix.as_deref(),
+            anchor.suffix.as_deref(),
+        )
     {
-        let start_char = text[..byte_pos].chars().count();
-        let end_char = start_char + quote.chars().count();
-        anchor.char_range = Some((start_char, end_char));
+        anchor.char_range = Some((sc, ec));
+        anchor.status = AnchorStatus::Drifted;
+        return AnchorStatus::Drifted;
+    }
+
+    // Step 3: fuzzy quote match (sliding window).
+    if let Some(quote) = anchor.quote.as_ref()
+        && let Some((sc, ec)) = fuzzy_find(text, quote, fuzzy_threshold)
+    {
+        anchor.char_range = Some((sc, ec));
+        anchor.status = AnchorStatus::Drifted;
+        return AnchorStatus::Drifted;
+    }
+
+    // Step 4: sentence-id fallback.
+    if let Some(sid) = anchor.sentence_id.as_ref()
+        && let Some((sc, ec)) = find_sentence_by_id(text, sid)
+    {
+        anchor.char_range = Some((sc, ec));
         anchor.status = AnchorStatus::Drifted;
         return AnchorStatus::Drifted;
     }
 
     anchor.status = AnchorStatus::Orphan;
     AnchorStatus::Orphan
+}
+
+/// Slice `text` by char positions, returning `None` if the requested
+/// range is malformed (start > end) or beyond the text. Avoids the
+/// panic the old resolver hit on out-of-bounds rows (#96 gap 4).
+fn char_slice(text: &str, start: usize, end: usize) -> Option<String> {
+    if end < start {
+        return None;
+    }
+    let want = end - start;
+    let collected: String = text.chars().skip(start).take(want).collect();
+    if collected.chars().count() == want {
+        Some(collected)
+    } else {
+        None
+    }
+}
+
+/// Find every (start_char, end_char) where `quote` occurs in `text`.
+/// Char-position aware — matches step over multibyte boundaries cleanly.
+fn find_all(text: &str, quote: &str) -> Vec<(usize, usize)> {
+    if quote.is_empty() {
+        return Vec::new();
+    }
+    let mut out = Vec::new();
+    let qlen_chars = quote.chars().count();
+    let mut search_byte = 0;
+    while let Some(rel) = text[search_byte..].find(quote) {
+        let abs = search_byte + rel;
+        let start_char = text[..abs].chars().count();
+        out.push((start_char, start_char + qlen_chars));
+        search_byte = abs + quote.len(); // non-overlapping; quote is non-empty
+    }
+    out
+}
+
+/// Pick the occurrence whose surrounding context best matches the
+/// stored `prefix` / `suffix`. With a single hit and no context, it's
+/// a plain substring lookup; with multiple hits, the prefix-suffix
+/// score breaks the tie.
+fn find_with_context(
+    text: &str,
+    quote: &str,
+    prefix: Option<&str>,
+    suffix: Option<&str>,
+) -> Option<(usize, usize)> {
+    let occurrences = find_all(text, quote);
+    if occurrences.is_empty() {
+        return None;
+    }
+    if occurrences.len() == 1 || (prefix.is_none() && suffix.is_none()) {
+        return Some(occurrences[0]);
+    }
+
+    let chars: Vec<char> = text.chars().collect();
+    occurrences
+        .into_iter()
+        .max_by_key(|&(sc, ec)| context_score(&chars, sc, ec, prefix, suffix))
+}
+
+/// Score a candidate's surroundings against the stored prefix/suffix.
+/// Counts characters that match starting from the inside out (the
+/// chars adjacent to the match are most load-bearing).
+fn context_score(
+    chars: &[char],
+    start: usize,
+    end: usize,
+    prefix: Option<&str>,
+    suffix: Option<&str>,
+) -> i64 {
+    let mut score = 0i64;
+    if let Some(p) = prefix {
+        let want: Vec<char> = p.chars().collect();
+        let max = want.len().min(start);
+        for i in 0..max {
+            // chars[start - 1 - i] vs want[want.len() - 1 - i]
+            if chars[start - 1 - i] == want[want.len() - 1 - i] {
+                score += 1;
+            } else {
+                break;
+            }
+        }
+    }
+    if let Some(s) = suffix {
+        let want: Vec<char> = s.chars().collect();
+        let max = want.len().min(chars.len().saturating_sub(end));
+        for i in 0..max {
+            if chars[end + i] == want[i] {
+                score += 1;
+            } else {
+                break;
+            }
+        }
+    }
+    score
+}
+
+/// Sliding-window fuzzy match. Walks character-aligned windows the
+/// size of `quote` and returns the highest-scoring window that meets
+/// `threshold` (Jaro-Winkler in [0,1]).
+fn fuzzy_find(text: &str, quote: &str, threshold: f64) -> Option<(usize, usize)> {
+    if quote.is_empty() {
+        return None;
+    }
+    let chars: Vec<char> = text.chars().collect();
+    let qlen = quote.chars().count();
+    if chars.len() < qlen {
+        return None;
+    }
+
+    let mut best: Option<(usize, f64)> = None;
+    for start in 0..=chars.len() - qlen {
+        let window: String = chars[start..start + qlen].iter().collect();
+        let score = strsim::jaro_winkler(&window, quote);
+        if score >= threshold && best.is_none_or(|(_, b)| score > b) {
+            best = Some((start, score));
+        }
+    }
+    best.map(|(start, _)| (start, start + qlen))
+}
+
+/// Find the sentence in `text` whose `sentence_id` matches `sid`.
+/// Sentence boundaries are simple terminator-based (`. ! ?`) — good
+/// enough for paper bodies and abstracts; ADR-004 calls out that
+/// proper ICU sentence segmentation is a follow-up.
+fn find_sentence_by_id(text: &str, sid: &str) -> Option<(usize, usize)> {
+    let chars: Vec<char> = text.chars().collect();
+    let mut sentence_start_char = 0;
+    let mut i = 0;
+    while i < chars.len() {
+        let ch = chars[i];
+        let is_terminator = matches!(ch, '.' | '!' | '?');
+        let is_end = i + 1 == chars.len();
+        if is_terminator || is_end {
+            let end = if is_end { chars.len() } else { i + 1 };
+            let sentence: String = chars[sentence_start_char..end].iter().collect();
+            let trimmed = sentence.trim();
+            if !trimmed.is_empty() && scitadel_core::models::sentence_id(trimmed) == sid {
+                // Map back to the trimmed sentence's char range inside `text`.
+                let leading_ws = sentence.chars().take_while(|c| c.is_whitespace()).count();
+                let trailing_ws = sentence
+                    .chars()
+                    .rev()
+                    .take_while(|c| c.is_whitespace())
+                    .count();
+                let trimmed_start = sentence_start_char + leading_ws;
+                let trimmed_end = end - trailing_ws;
+                if trimmed_end > trimmed_start {
+                    return Some((trimmed_start, trimmed_end));
+                }
+            }
+            // Advance past the terminator into the next sentence.
+            sentence_start_char = end;
+        }
+        i += 1;
+    }
+    None
 }
 
 #[cfg(test)]
@@ -531,5 +735,89 @@ mod tests {
             ..Anchor::default()
         };
         assert_eq!(resolve_anchor(&mut a, text), AnchorStatus::Ok);
+    }
+
+    // ---- #96 multi-selector resolver tests ----
+
+    #[test]
+    fn resolver_uses_prefix_to_disambiguate_collision() {
+        // "the model" appears twice; suffix " was trained" picks the second.
+        let text = "Initially the model failed. Then the model was trained on more data.";
+        let mut a = Anchor {
+            char_range: None,
+            quote: Some("the model".into()),
+            prefix: None,
+            suffix: Some(" was trained".into()),
+            ..Anchor::default()
+        };
+        assert_eq!(resolve_anchor(&mut a, text), AnchorStatus::Drifted);
+        let (s, e) = a.char_range.unwrap();
+        assert_eq!(&text[s..e], "the model");
+        // Specifically the *second* occurrence.
+        assert!(s > 20, "expected the second occurrence at s>20, got s={s}");
+    }
+
+    #[test]
+    fn resolver_falls_back_to_fuzzy_on_minor_edit() {
+        // Quote was "the network was deep"; publisher edited to "the
+        // network was very deep" — substring fails, fuzzy still hits.
+        let text = "We argued the network was very deep enough to overfit.";
+        let mut a = Anchor {
+            char_range: None,
+            quote: Some("the network was deep".into()),
+            ..Anchor::default()
+        };
+        // Use a permissive threshold so the test isn't sensitive to
+        // strsim version drift.
+        let s = resolve_anchor_with_threshold(&mut a, text, 0.85);
+        assert_eq!(
+            s,
+            AnchorStatus::Drifted,
+            "fuzzy match should drift, got {s:?}"
+        );
+    }
+
+    #[test]
+    fn resolver_returns_orphan_when_offsets_oob_and_quote_absent() {
+        // char_range out of bounds, quote not present in text — must
+        // return Orphan instead of panicking. (#96 gap 4)
+        let mut a = Anchor {
+            char_range: Some((9000, 9100)),
+            quote: Some("vanished".into()),
+            ..Anchor::default()
+        };
+        assert_eq!(
+            resolve_anchor(&mut a, "the small text"),
+            AnchorStatus::Orphan
+        );
+    }
+
+    #[test]
+    fn resolver_uses_sentence_id_when_quote_unfindable() {
+        use scitadel_core::models::sentence_id;
+        // Sentence content preserved (same words, different
+        // case/whitespace). Quote string is wholly absent from the
+        // new text so substring + fuzzy fail; sentence-id rescues.
+        let original_sentence = "The Transformer Architecture relies on self-attention.";
+        let new_text = "Intro. the   transformer architecture relies on self-attention. Outro.";
+        let mut a = Anchor {
+            char_range: None,
+            // Bypasses substring + fuzzy.
+            quote: Some("ZZZ-not-in-new-text-ZZZ".into()),
+            sentence_id: Some(sentence_id(original_sentence)),
+            ..Anchor::default()
+        };
+        let s = resolve_anchor(&mut a, new_text);
+        assert_eq!(
+            s,
+            AnchorStatus::Drifted,
+            "sentence-id rescue should mark Drifted, got {s:?}"
+        );
+        let (start, end) = a.char_range.unwrap();
+        let resolved: String = new_text.chars().skip(start).take(end - start).collect();
+        assert!(
+            resolved.contains("transformer architecture"),
+            "expected re-anchor to the matching sentence; got {resolved:?}"
+        );
     }
 }

--- a/crates/scitadel-db/src/sqlite/migrations.rs
+++ b/crates/scitadel-db/src/sqlite/migrations.rs
@@ -8,6 +8,7 @@ const MIGRATION_003: &str = include_str!("../../migrations/003_full_text.sql");
 const MIGRATION_004: &str = include_str!("../../migrations/004_paper_state.sql");
 const MIGRATION_005: &str = include_str!("../../migrations/005_annotations.sql");
 const MIGRATION_006: &str = include_str!("../../migrations/006_search_fts.sql");
+const MIGRATION_007: &str = include_str!("../../migrations/007_paper_download_state.sql");
 
 const MIGRATIONS: &[(i64, &str)] = &[
     (1, MIGRATION_001),
@@ -16,6 +17,7 @@ const MIGRATIONS: &[(i64, &str)] = &[
     (4, MIGRATION_004),
     (5, MIGRATION_005),
     (6, MIGRATION_006),
+    (7, MIGRATION_007),
 ];
 
 /// Run all pending migrations, skipping already-applied ones.

--- a/crates/scitadel-db/src/sqlite/migrations.rs
+++ b/crates/scitadel-db/src/sqlite/migrations.rs
@@ -9,6 +9,7 @@ const MIGRATION_004: &str = include_str!("../../migrations/004_paper_state.sql")
 const MIGRATION_005: &str = include_str!("../../migrations/005_annotations.sql");
 const MIGRATION_006: &str = include_str!("../../migrations/006_search_fts.sql");
 const MIGRATION_007: &str = include_str!("../../migrations/007_paper_download_state.sql");
+const MIGRATION_008: &str = include_str!("../../migrations/008_tui_state.sql");
 
 const MIGRATIONS: &[(i64, &str)] = &[
     (1, MIGRATION_001),
@@ -18,6 +19,7 @@ const MIGRATIONS: &[(i64, &str)] = &[
     (5, MIGRATION_005),
     (6, MIGRATION_006),
     (7, MIGRATION_007),
+    (8, MIGRATION_008),
 ];
 
 /// Run all pending migrations, skipping already-applied ones.

--- a/crates/scitadel-db/src/sqlite/mod.rs
+++ b/crates/scitadel-db/src/sqlite/mod.rs
@@ -6,6 +6,7 @@ mod paper_state;
 mod papers;
 mod questions;
 mod searches;
+mod tui_state;
 
 pub use annotations::{SqliteAnnotationRepository, resolve_anchor};
 pub use assessments::SqliteAssessmentRepository;
@@ -15,6 +16,7 @@ pub use paper_state::{PaperState, SqlitePaperStateRepository};
 pub use papers::SqlitePaperRepository;
 pub use questions::SqliteQuestionRepository;
 pub use searches::SqliteSearchRepository;
+pub use tui_state::{SqliteTuiStateRepository, TuiState};
 
 use r2d2::Pool;
 use r2d2_sqlite::SqliteConnectionManager;

--- a/crates/scitadel-db/src/sqlite/mod.rs
+++ b/crates/scitadel-db/src/sqlite/mod.rs
@@ -43,8 +43,14 @@ impl Database {
         }
 
         let manager = SqliteConnectionManager::file(path).with_init(|conn| {
+            // synchronous=NORMAL is the recommended pairing with WAL: full
+            // sync is unnecessary because WAL replay covers durability,
+            // and NORMAL roughly halves write latency. busy_timeout lets
+            // the cross-process 2-pane workflow ride through transient
+            // writer locks instead of failing reads. (#121)
             conn.execute_batch(
                 "PRAGMA journal_mode=WAL;
+                     PRAGMA synchronous=NORMAL;
                      PRAGMA foreign_keys=ON;
                      PRAGMA busy_timeout=5000;",
             )?;
@@ -100,5 +106,57 @@ impl Database {
             SqliteAssessmentRepository::new(db.clone()),
             SqliteCitationRepository::new(db),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use scitadel_core::models::Paper;
+    use scitadel_core::ports::PaperRepository;
+
+    /// Two `Database` instances pointing at the same file simulate the
+    /// 2-pane workflow: TUI process holds one, `scitadel mcp` process
+    /// holds the other. A write through one must surface through the
+    /// other — that's the contract WAL mode buys us. (#121)
+    #[test]
+    fn cross_process_write_visible_within_one_redraw() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("scitadel.db");
+
+        // Process A (e.g. the TUI) opens, migrates, holds open.
+        let db_a = Database::open(&db_path).unwrap();
+        db_a.migrate().unwrap();
+        let (paper_repo_a, _, _, _, _) = db_a.repositories();
+
+        // Process B (e.g. scitadel mcp) opens the same file independently.
+        let db_b = Database::open(&db_path).unwrap();
+        let (paper_repo_b, _, _, _, _) = db_b.repositories();
+
+        // Pre-write sanity: A sees nothing.
+        assert!(paper_repo_a.list_all(10, 0).unwrap().is_empty());
+
+        // B writes.
+        let p = Paper::new("MCP-side write");
+        paper_repo_b.save(&p).unwrap();
+
+        // A must see it on the very next read — no commit barrier, no
+        // sleep, no reconnect. This is the property the 2-pane workflow
+        // depends on.
+        let papers = paper_repo_a.list_all(10, 0).unwrap();
+        assert_eq!(papers.len(), 1, "TUI process must see MCP process's write");
+        assert_eq!(papers[0].title, "MCP-side write");
+    }
+
+    #[test]
+    fn pragma_journal_mode_is_wal_on_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("pragma.db");
+        let db = Database::open(&db_path).unwrap();
+        let conn = db.conn().unwrap();
+        let mode: String = conn
+            .query_row("PRAGMA journal_mode", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(mode.to_lowercase(), "wal");
     }
 }

--- a/crates/scitadel-db/src/sqlite/papers.rs
+++ b/crates/scitadel-db/src/sqlite/papers.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use rusqlite::params;
 use scitadel_core::error::CoreError;
-use scitadel_core::models::{Paper, PaperId};
+use scitadel_core::models::{DownloadStatus, Paper, PaperId};
 use scitadel_core::ports::PaperRepository;
 
 use super::Database;
@@ -117,6 +117,10 @@ fn row_to_paper(row: &rusqlite::Row) -> rusqlite::Result<Paper> {
     let created_at: String = row.get("created_at")?;
     let updated_at: String = row.get("updated_at")?;
 
+    let local_path: Option<String> = row.get("local_path").ok();
+    let download_status_raw: Option<String> = row.get("download_status").ok();
+    let last_attempt_at_raw: Option<String> = row.get("last_attempt_at").ok();
+
     Ok(Paper {
         id: PaperId::from(id),
         title: row.get("title")?,
@@ -135,6 +139,14 @@ fn row_to_paper(row: &rusqlite::Row) -> rusqlite::Result<Paper> {
         source_urls: serde_json::from_str(&source_urls_json).unwrap_or_default(),
         created_at: super::parse_rfc3339_or_now(&created_at),
         updated_at: super::parse_rfc3339_or_now(&updated_at),
+        local_path,
+        download_status: download_status_raw
+            .as_deref()
+            .and_then(DownloadStatus::parse),
+        last_attempt_at: last_attempt_at_raw
+            .as_deref()
+            .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+            .map(|dt| dt.with_timezone(&chrono::Utc)),
     })
 }
 
@@ -278,6 +290,23 @@ impl PaperRepository for SqlitePaperRepository {
         conn.execute(
             "UPDATE papers SET full_text = ?1, updated_at = ?2 WHERE id = ?3",
             params![text, chrono::Utc::now().to_rfc3339(), paper_id],
+        )
+        .map_err(DbError::Sqlite)?;
+        Ok(())
+    }
+
+    fn update_download_state(
+        &self,
+        paper_id: &str,
+        local_path: Option<&str>,
+        status: DownloadStatus,
+    ) -> Result<(), CoreError> {
+        let conn = self.db.conn()?;
+        let now = chrono::Utc::now().to_rfc3339();
+        conn.execute(
+            "UPDATE papers SET local_path = ?1, download_status = ?2, last_attempt_at = ?3, \
+             updated_at = ?3 WHERE id = ?4",
+            params![local_path, status.as_str(), now, paper_id],
         )
         .map_err(DbError::Sqlite)?;
         Ok(())
@@ -484,5 +513,37 @@ mod tests {
                 "remapped paper_id should exist in DB"
             );
         }
+    }
+
+    #[test]
+    fn download_state_round_trips() {
+        let (_, repo) = setup();
+        let paper = Paper::new("DL state");
+        repo.save(&paper).unwrap();
+
+        // Pristine row: no download attempted yet.
+        let initial = repo.get(paper.id.as_str()).unwrap().unwrap();
+        assert!(initial.local_path.is_none());
+        assert!(initial.download_status.is_none());
+        assert!(initial.last_attempt_at.is_none());
+
+        // Successful download.
+        repo.update_download_state(
+            paper.id.as_str(),
+            Some("/tmp/foo.pdf"),
+            DownloadStatus::Downloaded,
+        )
+        .unwrap();
+        let after = repo.get(paper.id.as_str()).unwrap().unwrap();
+        assert_eq!(after.local_path.as_deref(), Some("/tmp/foo.pdf"));
+        assert_eq!(after.download_status, Some(DownloadStatus::Downloaded));
+        assert!(after.last_attempt_at.is_some());
+
+        // Subsequent failure overwrites cleanly (path None, status Failed).
+        repo.update_download_state(paper.id.as_str(), None, DownloadStatus::Failed)
+            .unwrap();
+        let failed = repo.get(paper.id.as_str()).unwrap().unwrap();
+        assert!(failed.local_path.is_none());
+        assert_eq!(failed.download_status, Some(DownloadStatus::Failed));
     }
 }

--- a/crates/scitadel-db/src/sqlite/papers.rs
+++ b/crates/scitadel-db/src/sqlite/papers.rs
@@ -272,6 +272,16 @@ impl PaperRepository for SqlitePaperRepository {
             .collect();
         Ok(papers)
     }
+
+    fn update_full_text(&self, paper_id: &str, text: &str) -> Result<(), CoreError> {
+        let conn = self.db.conn()?;
+        conn.execute(
+            "UPDATE papers SET full_text = ?1, updated_at = ?2 WHERE id = ?3",
+            params![text, chrono::Utc::now().to_rfc3339(), paper_id],
+        )
+        .map_err(DbError::Sqlite)?;
+        Ok(())
+    }
 }
 
 // Need this import for .optional()

--- a/crates/scitadel-db/src/sqlite/tui_state.rs
+++ b/crates/scitadel-db/src/sqlite/tui_state.rs
@@ -1,0 +1,128 @@
+//! Singleton TUI-selection state (#122). Lets an MCP-side agent read
+//! "what is the open scitadel TUI looking at right now?" so it can
+//! score the current paper / draft a question from the current
+//! context without the user pasting IDs.
+//!
+//! Last-writer-wins if multiple TUIs run concurrently — acceptable for
+//! v1 since the TUI is a single-pane terminal app.
+
+use rusqlite::params;
+
+use crate::error::DbError;
+use crate::sqlite::Database;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TuiState {
+    /// Active tab name: "Searches" | "Papers" | "Questions"
+    pub tab: String,
+    pub paper_id: Option<String>,
+    pub search_id: Option<String>,
+    pub question_id: Option<String>,
+    pub annotation_id: Option<String>,
+    /// RFC3339 timestamp of the last TUI-side write.
+    pub updated_at: String,
+}
+
+#[derive(Clone)]
+pub struct SqliteTuiStateRepository {
+    db: Database,
+}
+
+impl SqliteTuiStateRepository {
+    pub fn new(db: Database) -> Self {
+        Self { db }
+    }
+
+    /// Upsert the singleton row. Called by the TUI on every focus /
+    /// overlay / tab change. Idempotent.
+    pub fn set(&self, state: &TuiState) -> Result<(), DbError> {
+        let conn = self.db.conn()?;
+        conn.execute(
+            "INSERT INTO tui_state (id, tab, paper_id, search_id, question_id, annotation_id, updated_at)
+             VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6)
+             ON CONFLICT(id) DO UPDATE SET
+                 tab           = excluded.tab,
+                 paper_id      = excluded.paper_id,
+                 search_id     = excluded.search_id,
+                 question_id   = excluded.question_id,
+                 annotation_id = excluded.annotation_id,
+                 updated_at    = excluded.updated_at",
+            params![
+                state.tab,
+                state.paper_id,
+                state.search_id,
+                state.question_id,
+                state.annotation_id,
+                state.updated_at,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Read the singleton row. Returns `None` if no TUI has ever
+    /// written (rather than synthesising an empty default).
+    pub fn get(&self) -> Result<Option<TuiState>, DbError> {
+        let conn = self.db.conn()?;
+        let mut stmt = conn.prepare(
+            "SELECT tab, paper_id, search_id, question_id, annotation_id, updated_at
+             FROM tui_state WHERE id = 1",
+        )?;
+        let mut rows = stmt.query([])?;
+        if let Some(row) = rows.next()? {
+            Ok(Some(TuiState {
+                tab: row.get(0)?,
+                paper_id: row.get(1)?,
+                search_id: row.get(2)?,
+                question_id: row.get(3)?,
+                annotation_id: row.get(4)?,
+                updated_at: row.get(5)?,
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fresh() -> SqliteTuiStateRepository {
+        let db = Database::open_in_memory().unwrap();
+        db.migrate().unwrap();
+        SqliteTuiStateRepository::new(db)
+    }
+
+    #[test]
+    fn empty_until_first_write() {
+        let repo = fresh();
+        assert!(repo.get().unwrap().is_none());
+    }
+
+    #[test]
+    fn upsert_round_trip() {
+        let repo = fresh();
+        let s = TuiState {
+            tab: "Papers".into(),
+            paper_id: Some("p-abc".into()),
+            search_id: None,
+            question_id: None,
+            annotation_id: None,
+            updated_at: "2026-04-20T00:00:00Z".into(),
+        };
+        repo.set(&s).unwrap();
+        assert_eq!(repo.get().unwrap().unwrap(), s);
+
+        // Second write replaces, doesn't append.
+        let s2 = TuiState {
+            tab: "Questions".into(),
+            paper_id: None,
+            search_id: None,
+            question_id: Some("q-xyz".into()),
+            annotation_id: None,
+            updated_at: "2026-04-20T00:01:00Z".into(),
+        };
+        repo.set(&s2).unwrap();
+        assert_eq!(repo.get().unwrap().unwrap(), s2);
+    }
+}

--- a/crates/scitadel-export/Cargo.toml
+++ b/crates/scitadel-export/Cargo.toml
@@ -12,7 +12,7 @@ description = "BibTeX, JSON, and CSV exporters for scitadel search results."
 readme = "../../README.md"
 
 [dependencies]
-scitadel-core = { path = "../scitadel-core", version = "0.1.0" }
+scitadel-core = { path = "../scitadel-core", version = "0.5.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 csv = "1"

--- a/crates/scitadel-mcp/Cargo.toml
+++ b/crates/scitadel-mcp/Cargo.toml
@@ -12,11 +12,11 @@ description = "MCP server exposing scitadel tools to host LLMs."
 readme = "../../README.md"
 
 [dependencies]
-scitadel-core = { path = "../scitadel-core", version = "0.1.0" }
-scitadel-db = { path = "../scitadel-db", version = "0.1.0" }
-scitadel-adapters = { path = "../scitadel-adapters", version = "0.1.0" }
-scitadel-scoring = { path = "../scitadel-scoring", version = "0.1.0" }
-scitadel-export = { path = "../scitadel-export", version = "0.1.0" }
+scitadel-core = { path = "../scitadel-core", version = "0.5.0" }
+scitadel-db = { path = "../scitadel-db", version = "0.5.0" }
+scitadel-adapters = { path = "../scitadel-adapters", version = "0.5.0" }
+scitadel-scoring = { path = "../scitadel-scoring", version = "0.5.0" }
+scitadel-export = { path = "../scitadel-export", version = "0.5.0" }
 rmcp = { workspace = true }
 schemars = { workspace = true }
 tokio = { workspace = true }

--- a/crates/scitadel-mcp/Cargo.toml
+++ b/crates/scitadel-mcp/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = { workspace = true }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+chrono = { workspace = true }
 pdf-extract = { workspace = true }
 scraper = { workspace = true }
 

--- a/crates/scitadel-mcp/src/server.rs
+++ b/crates/scitadel-mcp/src/server.rs
@@ -693,6 +693,13 @@ impl ScitadelServer {
     }
 
     #[tool(
+        description = "Read the open scitadel TUI's current selection. Use to answer 'what is the user looking at right now?' so you can score the open paper / draft from current context without the user pasting IDs. Returns JSON `{tab, paper_id?, search_id?, question_id?, annotation_id?, updated_at, stale}`. `stale: true` means the singleton row is >60s old — TUI may have been closed. (#122)"
+    )]
+    fn get_current_selection(&self) -> Result<String, String> {
+        tools::get_current_selection_tool()
+    }
+
+    #[tool(
         description = "Toggle the starred flag for a paper under `reader`. Creates the per-reader state row if missing. NOTE: author/reader identity is trust-on-first-use — real auth ships with the Phase-5 Dolt sync layer. Returns: JSON `{paper_id, starred}` with the new value."
     )]
     fn toggle_star(

--- a/crates/scitadel-mcp/src/server.rs
+++ b/crates/scitadel-mcp/src/server.rs
@@ -6,14 +6,41 @@
 //! in `crate::tools` so this file stays a thin façade.
 
 use rmcp::{
-    ServerHandler,
+    Peer, RoleServer, ServerHandler,
     handler::server::{router::tool::ToolRouter, wrapper::Parameters},
-    schemars, tool, tool_handler, tool_router,
+    model::{ProgressNotificationParam, ProgressToken},
+    schemars,
+    service::RequestContext,
+    tool, tool_handler, tool_router,
 };
 use schemars::JsonSchema;
 use serde::Deserialize;
 
 use crate::tools;
+
+/// Helper: emit a progress notification if the caller opted in by
+/// supplying a `progressToken` in the request `_meta`. Failures are
+/// logged but never propagated — progress is best-effort.
+async fn notify(
+    peer: &Peer<RoleServer>,
+    token: Option<&ProgressToken>,
+    progress: f64,
+    total: Option<f64>,
+    message: impl Into<String>,
+) {
+    let Some(token) = token else { return };
+    let result = peer
+        .notify_progress(ProgressNotificationParam {
+            progress_token: token.clone(),
+            progress,
+            total,
+            message: Some(message.into()),
+        })
+        .await;
+    if let Err(e) = result {
+        tracing::warn!(error = %e, "failed to send progress notification");
+    }
+}
 
 // ---------- Aggregate request structs ----------
 
@@ -276,10 +303,46 @@ impl Default for ScitadelServer {
 #[tool_router(router = tool_router)]
 impl ScitadelServer {
     #[tool(
-        description = "Search scientific literature across multiple sources. Returns: JSON with search_id, query, per-source outcomes, total counts, and a `summary` text field for human readers."
+        description = "Search scientific literature across multiple sources. Returns: JSON with search_id, query, per-source outcomes, total counts, and a `summary` text field for human readers. Emits MCP progress notifications (start + done) when the caller supplies a `progressToken` in `_meta` (#58)."
     )]
-    async fn search(&self, Parameters(req): Parameters<SearchRequest>) -> Result<String, String> {
-        tools::search_tool(req.query, req.sources, req.max_results, req.question_id).await
+    async fn search(
+        &self,
+        Parameters(req): Parameters<SearchRequest>,
+        ctx: RequestContext<RoleServer>,
+    ) -> Result<String, String> {
+        let token = ctx.meta.get_progress_token();
+        let source_count = req
+            .sources
+            .split(',')
+            .filter(|s| !s.trim().is_empty())
+            .count() as f64;
+        notify(
+            &ctx.peer,
+            token.as_ref(),
+            0.0,
+            Some(source_count.max(1.0)),
+            format!(
+                "searching {} source(s) for \"{}\"",
+                source_count.max(1.0),
+                req.query
+            ),
+        )
+        .await;
+        let result =
+            tools::search_tool(req.query, req.sources, req.max_results, req.question_id).await;
+        let done_msg = match &result {
+            Ok(_) => "search complete".to_string(),
+            Err(e) => format!("search failed: {e}"),
+        };
+        notify(
+            &ctx.peer,
+            token.as_ref(),
+            source_count.max(1.0),
+            Some(source_count.max(1.0)),
+            done_msg,
+        )
+        .await;
+        result
     }
 
     #[tool(
@@ -534,18 +597,39 @@ impl ScitadelServer {
     }
 
     #[tool(
-        description = "Download a paper (PDF or HTML). Prefer passing paper_id to leverage all stored identifiers (arxiv/openalex/doi); doi is a fallback for ad-hoc lookups. Returns: text (path + access status)."
+        description = "Download a paper (PDF or HTML). Prefer passing paper_id to leverage all stored identifiers (arxiv/openalex/doi); doi is a fallback for ad-hoc lookups. Returns: text (path + access status). Emits MCP progress notifications (start + done) when the caller supplies a `progressToken` in `_meta` (#58)."
     )]
     async fn download_paper(
         &self,
         Parameters(req): Parameters<DownloadPaperRequest>,
+        ctx: RequestContext<RoleServer>,
     ) -> Result<String, String> {
-        tools::download_paper_tool(
+        let token = ctx.meta.get_progress_token();
+        let target = req
+            .paper_id
+            .as_deref()
+            .or(req.doi.as_deref())
+            .unwrap_or("(no paper_id or doi)");
+        notify(
+            &ctx.peer,
+            token.as_ref(),
+            0.0,
+            Some(1.0),
+            format!("downloading {target}"),
+        )
+        .await;
+        let result = tools::download_paper_tool(
             req.paper_id.as_deref(),
             req.doi.as_deref(),
             req.output_dir.as_deref(),
         )
-        .await
+        .await;
+        let done_msg = match &result {
+            Ok(_) => "download complete".to_string(),
+            Err(e) => format!("download failed: {e}"),
+        };
+        notify(&ctx.peer, token.as_ref(), 1.0, Some(1.0), done_msg).await;
+        result
     }
 
     #[tool(
@@ -559,13 +643,29 @@ impl ScitadelServer {
     }
 
     #[tool(
-        description = "Prepare batch assessments for all papers in a search. Returns: text (rubric + per-paper context + instructions)."
+        description = "Prepare batch assessments for all papers in a search. Returns: text (rubric + per-paper context + instructions). Emits MCP progress notifications (start + done) when the caller supplies a `progressToken` in `_meta` (#58)."
     )]
-    fn prepare_batch_assessments(
+    async fn prepare_batch_assessments(
         &self,
         Parameters(req): Parameters<SearchQuestionRequest>,
+        ctx: RequestContext<RoleServer>,
     ) -> Result<String, String> {
-        tools::prepare_batch_assessments_tool(&req.search_id, &req.question_id)
+        let token = ctx.meta.get_progress_token();
+        notify(
+            &ctx.peer,
+            token.as_ref(),
+            0.0,
+            Some(1.0),
+            format!("preparing assessments for search {}", req.search_id),
+        )
+        .await;
+        let result = tools::prepare_batch_assessments_tool(&req.search_id, &req.question_id);
+        let done_msg = match &result {
+            Ok(_) => "batch prep complete".to_string(),
+            Err(e) => format!("batch prep failed: {e}"),
+        };
+        notify(&ctx.peer, token.as_ref(), 1.0, Some(1.0), done_msg).await;
+        result
     }
 }
 

--- a/crates/scitadel-mcp/src/server.rs
+++ b/crates/scitadel-mcp/src/server.rs
@@ -29,7 +29,7 @@ pub struct AddSearchTermsRequest {
     #[schemars(description = "List of search terms")]
     pub terms: Vec<String>,
     #[schemars(description = "Custom query string (optional, defaults to terms joined by space)")]
-    pub query_string: String,
+    pub query_string: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
@@ -101,27 +101,29 @@ pub struct ScitadelServer;
 
 #[tool(tool_box)]
 impl ScitadelServer {
-    #[tool(description = "Search scientific literature across multiple sources")]
+    #[tool(
+        description = "Search scientific literature across multiple sources. Returns: JSON with search_id, query, per-source outcomes, total counts, and a `summary` text field for human readers."
+    )]
     async fn search(&self, #[tool(aggr)] req: SearchRequest) -> Result<String, String> {
         tools::search_tool(req.query, req.sources, req.max_results, req.question_id).await
     }
 
     #[tool(
-        description = "List every source scitadel knows about (pubmed, arxiv, openalex, inspire, patentsview, lens, epo) with per-source description, required credential fields, whether credentials are configured in this environment, and rate-limit hints. Read-only; call first to decide which sources to pass to `search`."
+        description = "List every source scitadel knows about (pubmed, arxiv, openalex, inspire, patentsview, lens, epo) with per-source description, required credential fields, whether credentials are configured in this environment, and rate-limit hints. Read-only; call first to decide which sources to pass to `search`. Returns: JSON array."
     )]
     fn list_sources(&self) -> Result<String, String> {
         tools::list_sources_tool()
     }
 
     #[tool(
-        description = "Return the scoring rubric (criteria, 0.0-1.0 scale, response format) as a string. Fetch once at the start of a scoring session and cache; use with `save_assessment` or `assess_paper` for each paper. Avoids the per-paper rubric fetch that `prepare_assessment` does."
+        description = "Return the scoring rubric (criteria, 0.0-1.0 scale, response format). Fetch once at the start of a scoring session and cache; use with `save_assessment` or `assess_paper` for each paper. Avoids the per-paper rubric fetch that `prepare_assessment` does — if you only need the rubric (no paper context), prefer this. Returns: text."
     )]
     fn get_rubric(&self) -> Result<String, String> {
         tools::get_rubric_tool()
     }
 
     #[tool(
-        description = "Create an annotation anchored to a passage in a paper. Root-level; use `reply_annotation` for replies. `author` is required — pass your identity string (e.g. agent slug). NOTE: author identity is trust-on-first-use until the Dolt sync / auth layer lands (Phase 5); any client may impersonate any author. Every write is logged via tracing for audit. Returns plain text (the new annotation ID)."
+        description = "Create an annotation anchored to a passage in a paper. Root-level; use `reply_annotation` for replies. `author` is required — pass your identity string (e.g. agent slug). NOTE: author identity is trust-on-first-use until the Dolt sync / auth layer lands (Phase 5); any client may impersonate any author. Every write is logged via tracing for audit. Returns: text (the new annotation ID)."
     )]
     fn create_annotation(
         &self,
@@ -141,7 +143,7 @@ impl ScitadelServer {
     }
 
     #[tool(
-        description = "Reply to an existing annotation. Inherits paper_id + question_id from the parent; the reply has no anchor of its own. NOTE: author identity is trust-on-first-use (see create_annotation); writes are tracing-logged."
+        description = "Reply to an existing annotation. Inherits paper_id + question_id from the parent; the reply has no anchor of its own. NOTE: author identity is trust-on-first-use (see create_annotation); writes are tracing-logged. Returns: text (the new reply ID)."
     )]
     fn reply_annotation(
         &self,
@@ -159,7 +161,7 @@ impl ScitadelServer {
     }
 
     #[tool(
-        description = "Update note / color / tags on an existing annotation. NOTE: no author check — trust-on-first-use (see create_annotation). Writes are tracing-logged."
+        description = "Update note / color / tags on an existing annotation. NOTE: no author check — trust-on-first-use (see create_annotation). Writes are tracing-logged. Returns: text confirmation."
     )]
     fn update_annotation(
         &self,
@@ -169,7 +171,7 @@ impl ScitadelServer {
     }
 
     #[tool(
-        description = "Soft-delete an annotation (tombstone). Threads stay intact; list_annotations hides the row. NOTE: no author check — trust-on-first-use (see create_annotation). Writes are tracing-logged."
+        description = "Soft-delete an annotation (tombstone). Threads stay intact; list_annotations hides the row. NOTE: no author check — trust-on-first-use (see create_annotation). Writes are tracing-logged. Returns: text confirmation."
     )]
     fn delete_annotation(
         &self,
@@ -181,7 +183,7 @@ impl ScitadelServer {
     }
 
     #[tool(
-        description = "List annotations for a paper (required). Optional author filter. Returns JSON array with id, parent_id, anchor, note, tags, author, timestamps, and anchor_status."
+        description = "List annotations for a paper. `paper_id` is required (cross-paper listing is not yet implemented). Optional `author` filter. Returns: JSON array of {id, parent_id, anchor, note, tags, author, timestamps, anchor_status}."
     )]
     fn list_annotations(
         &self,
@@ -196,7 +198,7 @@ impl ScitadelServer {
     }
 
     #[tool(
-        description = "Mark one or more annotations as seen by `reader`. Repeat calls just update seen_at. Used so an agent can stop re-processing notes it already handled."
+        description = "Mark one or more annotations as seen by `reader`. Repeat calls just update seen_at. Used so an agent can stop re-processing notes it already handled. Returns: text count."
     )]
     fn mark_seen(
         &self,
@@ -211,7 +213,7 @@ impl ScitadelServer {
     }
 
     #[tool(
-        description = "Mark a whole annotation thread (root + replies) as seen by `reader` in one call."
+        description = "Mark a whole annotation thread (root + replies) as seen by `reader` in one call. Returns: text confirmation."
     )]
     fn mark_thread_seen(
         &self,
@@ -226,7 +228,7 @@ impl ScitadelServer {
     }
 
     #[tool(
-        description = "List annotations `reader` has not yet seen (or that were edited since last seen). Optional paper_id scopes the query. Use at session start to pick up human replies from the previous turn. NOTE: comparison is wall-clock-based (`seen_at < updated_at`), so a concurrent edit between mark_seen and list_unread can race on microsecond ordering and a non-monotonic clock rewind breaks the comparison entirely. Single-reader use is unaffected; multi-reader clients should treat unread as a hint, not a guarantee. (#100)"
+        description = "List annotations `reader` has not yet seen (or that were edited since last seen). Optional paper_id scopes the query. Use at session start to pick up human replies from the previous turn. NOTE: comparison is wall-clock-based (`seen_at < updated_at`), so a concurrent edit between mark_seen and list_unread can race on microsecond ordering and a non-monotonic clock rewind breaks the comparison entirely. Single-reader use is unaffected; multi-reader clients should treat unread as a hint, not a guarantee. (#100) Returns: JSON array."
     )]
     fn list_unread(
         &self,
@@ -241,7 +243,7 @@ impl ScitadelServer {
     }
 
     #[tool(
-        description = "Full-text search over stored past searches (FTS5 + Porter stemming). Returns JSON array of matching prior searches sorted by relevance (lower rank = more relevant). Call before running a fresh `search` to detect redundant work."
+        description = "Full-text search over stored past searches (FTS5 + Porter stemming). Sorted by relevance (lower rank = more relevant). Call before running a fresh `search` to detect redundant work. Returns: JSON array."
     )]
     fn find_similar_searches(
         &self,
@@ -256,7 +258,7 @@ impl ScitadelServer {
     }
 
     #[tool(
-        description = "Summarize every paper in a search as JSON in one call: title, authors, year, abstract (truncated), DOI, identifiers. Preferred over iterating `get_paper` per result when scanning a corpus."
+        description = "Summarize every paper in a search in one call: title, authors, year, abstract (truncated), DOI, identifiers. Preferred over iterating `get_paper` per result when scanning a corpus. Returns: JSON array."
     )]
     fn summarize_search(
         &self,
@@ -273,7 +275,7 @@ impl ScitadelServer {
         tools::summarize_search_tool(&search_id, max_papers, abstract_char_limit)
     }
 
-    #[tool(description = "List recent search runs")]
+    #[tool(description = "List recent search runs. Returns: text table.")]
     fn list_searches(
         &self,
         #[tool(param)]
@@ -283,7 +285,9 @@ impl ScitadelServer {
         tools::list_searches_tool(limit.unwrap_or(20))
     }
 
-    #[tool(description = "Get papers from a search result")]
+    #[tool(
+        description = "Get papers from a search result. Returns: text listing (title, authors, year, journal, IDs, abstract preview)."
+    )]
     fn get_papers(
         &self,
         #[tool(param)]
@@ -293,7 +297,7 @@ impl ScitadelServer {
         tools::get_papers_tool(&search_id)
     }
 
-    #[tool(description = "Get full details of a single paper")]
+    #[tool(description = "Get full details of a single paper. Returns: JSON.")]
     fn get_paper(
         &self,
         #[tool(param)]
@@ -304,7 +308,7 @@ impl ScitadelServer {
     }
 
     #[tool(
-        description = "Return JSON: paper {id,title,abstract,full_text}, annotations[] (live only, with parent_id/root_id and full anchor incl. char_range/quote/prefix/suffix/sentence_id/source_version/status), and source_version. One call replaces get_paper + list_annotations when an agent needs to reason over offsets."
+        description = "Returns: JSON {paper {id,title,abstract,full_text}, annotations[] (live only, with parent_id/root_id and full anchor incl. char_range/quote/prefix/suffix/sentence_id/source_version/status), source_version}. One call replaces get_paper + list_annotations when an agent needs to reason over offsets."
     )]
     fn get_annotated_paper(
         &self,
@@ -315,7 +319,9 @@ impl ScitadelServer {
         tools::get_annotated_paper_tool(&paper_id)
     }
 
-    #[tool(description = "Export search results in a given format (json, csv, bibtex)")]
+    #[tool(
+        description = "Export search results in a given format. Returns: text in the requested format (JSON / CSV / BibTeX)."
+    )]
     fn export_search(
         &self,
         #[tool(param)]
@@ -328,7 +334,7 @@ impl ScitadelServer {
         tools::export_search_tool(&search_id, &format)
     }
 
-    #[tool(description = "Create a new research question")]
+    #[tool(description = "Create a new research question. Returns: text confirmation with ID.")]
     fn create_question(
         &self,
         #[tool(param)]
@@ -341,17 +347,21 @@ impl ScitadelServer {
         tools::create_question_tool(&text, &description)
     }
 
-    #[tool(description = "List all research questions")]
+    #[tool(description = "List all research questions. Returns: text table.")]
     fn list_questions(&self) -> Result<String, String> {
         tools::list_questions_tool()
     }
 
-    #[tool(description = "Add search terms linked to a research question")]
+    #[tool(
+        description = "Add search terms linked to a research question. If `query_string` is omitted, the terms are joined by spaces. Returns: text confirmation."
+    )]
     fn add_search_terms(&self, #[tool(aggr)] req: AddSearchTermsRequest) -> Result<String, String> {
-        tools::add_search_terms_tool(&req.question_id, &req.terms, &req.query_string)
+        tools::add_search_terms_tool(&req.question_id, &req.terms, req.query_string.as_deref())
     }
 
-    #[tool(description = "Record a paper assessment with score and reasoning")]
+    #[tool(
+        description = "Record a paper assessment with score and reasoning. Returns: text summary."
+    )]
     fn assess_paper(&self, #[tool(aggr)] req: AssessPaperRequest) -> Result<String, String> {
         tools::assess_paper_tool(
             &req.paper_id,
@@ -363,7 +373,9 @@ impl ScitadelServer {
         )
     }
 
-    #[tool(description = "Get assessments for a paper and/or question")]
+    #[tool(
+        description = "Get assessments for a paper and/or question. At least one of `paper_id` or `question_id` is required (the call errors if both are omitted). Returns: text listing."
+    )]
     fn get_assessments(
         &self,
         #[tool(param)]
@@ -376,7 +388,9 @@ impl ScitadelServer {
         tools::get_assessments_tool(paper_id.as_deref(), question_id.as_deref())
     }
 
-    #[tool(description = "Prepare assessment rubric and paper data for LLM evaluation")]
+    #[tool(
+        description = "Prepare assessment rubric and paper data for LLM evaluation. Bundles `get_rubric` + the paper context for a single-call setup; if you only need the static rubric (no paper) prefer `get_rubric` to skip the paper fetch. Returns: text (rubric + paper block + instructions)."
+    )]
     fn prepare_assessment(
         &self,
         #[tool(param)]
@@ -389,13 +403,15 @@ impl ScitadelServer {
         tools::prepare_assessment_tool(&paper_id, &question_id)
     }
 
-    #[tool(description = "Save an MCP-native assessment scored by the host LLM")]
+    #[tool(
+        description = "Save an MCP-native assessment scored by the host LLM. Returns: text confirmation."
+    )]
     fn save_assessment(&self, #[tool(aggr)] req: SaveAssessmentRequest) -> Result<String, String> {
         tools::save_assessment_tool(&req.paper_id, &req.question_id, req.score, &req.reasoning)
     }
 
     #[tool(
-        description = "Download a paper (PDF or HTML). Prefer passing paper_id to leverage all stored identifiers (arxiv/openalex/doi); doi is a fallback for ad-hoc lookups."
+        description = "Download a paper (PDF or HTML). Prefer passing paper_id to leverage all stored identifiers (arxiv/openalex/doi); doi is a fallback for ad-hoc lookups. Returns: text (path + access status)."
     )]
     async fn download_paper(
         &self,
@@ -415,7 +431,7 @@ impl ScitadelServer {
     }
 
     #[tool(
-        description = "Extract the text from an already-downloaded paper's PDF or HTML. Call download_paper first."
+        description = "Extract the text from an already-downloaded paper's PDF or HTML. Call download_paper first. Returns: text (paper title, path, extracted body, possibly truncated)."
     )]
     async fn read_paper(
         &self,
@@ -429,7 +445,9 @@ impl ScitadelServer {
         tools::read_paper_tool(&paper_id, max_chars).await
     }
 
-    #[tool(description = "Prepare batch assessments for all papers in a search")]
+    #[tool(
+        description = "Prepare batch assessments for all papers in a search. Returns: text (rubric + per-paper context + instructions)."
+    )]
     fn prepare_batch_assessments(
         &self,
         #[tool(param)]
@@ -451,5 +469,69 @@ impl ServerHandler for ScitadelServer {
             capabilities: ServerCapabilities::builder().enable_tools().build(),
             ..Default::default()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    /// Style gate (#98): every `#[tool(description = "...")]` must
+    /// telegraph its return shape so an LLM client can parse the
+    /// response without trial and error. Accepts any of:
+    /// `Returns: JSON`, `Returns: text`, `Returns JSON`, `Returns text`.
+    #[test]
+    fn every_tool_description_states_return_shape() {
+        let full = include_str!("server.rs");
+        // Stop at the test module so the assertion's example string
+        // (which itself contains `#[tool(...)]`) doesn't trigger the
+        // gate on itself.
+        let cutoff = full
+            .find("#[cfg(test)]")
+            .expect("test module marker present");
+        let src = &full[..cutoff];
+        let mut offset = 0;
+        let mut tool_count = 0;
+        while let Some(start) = src[offset..].find("#[tool(") {
+            let abs_start = offset + start;
+            // Find matching close-paren by simple depth tracking.
+            let mut depth = 0;
+            let mut end = abs_start;
+            for (i, c) in src[abs_start..].char_indices() {
+                match c {
+                    '(' => depth += 1,
+                    ')' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            end = abs_start + i;
+                            break;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            let attr = &src[abs_start..=end];
+            offset = end + 1;
+
+            // Skip the macro-level `#[tool(tool_box)]` markers.
+            if !attr.contains("description") {
+                continue;
+            }
+            tool_count += 1;
+            let ok = [
+                "Returns: JSON",
+                "Returns: text",
+                "Returns JSON",
+                "Returns text",
+            ]
+            .iter()
+            .any(|needle| attr.contains(needle));
+            assert!(
+                ok,
+                "tool description missing return-shape marker (one of `Returns: JSON` / `Returns: text` / `Returns JSON` / `Returns text`):\n{attr}"
+            );
+        }
+        assert!(
+            tool_count >= 25,
+            "expected to scan all MCP tools (~26+); only saw {tool_count} — has the macro shape changed?"
+        );
     }
 }

--- a/crates/scitadel-mcp/src/server.rs
+++ b/crates/scitadel-mcp/src/server.rs
@@ -247,6 +247,30 @@ pub struct PaperQuestionRequest {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+pub struct ToggleStarRequest {
+    /// Paper ID to toggle the star on
+    pub paper_id: String,
+    /// Reader identity (e.g. agent slug, user name)
+    pub reader: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SetStarRequest {
+    /// Paper ID
+    pub paper_id: String,
+    /// Desired starred state (true = star, false = unstar)
+    pub starred: bool,
+    /// Reader identity
+    pub reader: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ReaderRequest {
+    /// Reader identity to scope the query to
+    pub reader: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct DownloadPaperRequest {
     /// Paper ID from the scitadel DB (preferred — unlocks arxiv/openalex/Unpaywall chain)
     pub paper_id: Option<String>,
@@ -666,6 +690,30 @@ impl ScitadelServer {
         };
         notify(&ctx.peer, token.as_ref(), 1.0, Some(1.0), done_msg).await;
         result
+    }
+
+    #[tool(
+        description = "Toggle the starred flag for a paper under `reader`. Creates the per-reader state row if missing. NOTE: author/reader identity is trust-on-first-use — real auth ships with the Phase-5 Dolt sync layer. Returns: JSON `{paper_id, starred}` with the new value."
+    )]
+    fn toggle_star(
+        &self,
+        Parameters(req): Parameters<ToggleStarRequest>,
+    ) -> Result<String, String> {
+        tools::toggle_star_tool(&req.paper_id, &req.reader)
+    }
+
+    #[tool(
+        description = "Set the starred flag for a paper under `reader` to an explicit value. Idempotent — call this when you want \"ensure starred\" semantics rather than a toggle. NOTE: trust-on-first-use identity (#100). Returns: JSON `{paper_id, starred}`."
+    )]
+    fn set_star(&self, Parameters(req): Parameters<SetStarRequest>) -> Result<String, String> {
+        tools::set_star_tool(&req.paper_id, req.starred, &req.reader)
+    }
+
+    #[tool(
+        description = "List all paper IDs `reader` has starred. Returns: JSON array of paper ID strings (no metadata — call `get_paper` for each if you need title/authors)."
+    )]
+    fn list_starred(&self, Parameters(req): Parameters<ReaderRequest>) -> Result<String, String> {
+        tools::list_starred_tool(&req.reader)
     }
 }
 

--- a/crates/scitadel-mcp/src/server.rs
+++ b/crates/scitadel-mcp/src/server.rs
@@ -121,7 +121,7 @@ impl ScitadelServer {
     }
 
     #[tool(
-        description = "Create an annotation anchored to a passage in a paper. Root-level; use `reply_annotation` for replies. `author` is required — pass your identity string (e.g. agent slug)."
+        description = "Create an annotation anchored to a passage in a paper. Root-level; use `reply_annotation` for replies. `author` is required — pass your identity string (e.g. agent slug). NOTE: author identity is trust-on-first-use until the Dolt sync / auth layer lands (Phase 5); any client may impersonate any author. Every write is logged via tracing for audit. Returns plain text (the new annotation ID)."
     )]
     fn create_annotation(
         &self,
@@ -141,7 +141,7 @@ impl ScitadelServer {
     }
 
     #[tool(
-        description = "Reply to an existing annotation. Inherits paper_id + question_id from the parent; the reply has no anchor of its own."
+        description = "Reply to an existing annotation. Inherits paper_id + question_id from the parent; the reply has no anchor of its own. NOTE: author identity is trust-on-first-use (see create_annotation); writes are tracing-logged."
     )]
     fn reply_annotation(
         &self,
@@ -158,7 +158,9 @@ impl ScitadelServer {
         tools::reply_annotation_tool(&parent_id, &note, &author)
     }
 
-    #[tool(description = "Update note / color / tags on an existing annotation.")]
+    #[tool(
+        description = "Update note / color / tags on an existing annotation. NOTE: no author check — trust-on-first-use (see create_annotation). Writes are tracing-logged."
+    )]
     fn update_annotation(
         &self,
         #[tool(aggr)] req: UpdateAnnotationRequest,
@@ -167,7 +169,7 @@ impl ScitadelServer {
     }
 
     #[tool(
-        description = "Soft-delete an annotation (tombstone). Threads stay intact; list_annotations hides the row."
+        description = "Soft-delete an annotation (tombstone). Threads stay intact; list_annotations hides the row. NOTE: no author check — trust-on-first-use (see create_annotation). Writes are tracing-logged."
     )]
     fn delete_annotation(
         &self,
@@ -224,7 +226,7 @@ impl ScitadelServer {
     }
 
     #[tool(
-        description = "List annotations `reader` has not yet seen (or that were edited since last seen). Optional paper_id scopes the query. Use at session start to pick up human replies from the previous turn."
+        description = "List annotations `reader` has not yet seen (or that were edited since last seen). Optional paper_id scopes the query. Use at session start to pick up human replies from the previous turn. NOTE: comparison is wall-clock-based (`seen_at < updated_at`), so a concurrent edit between mark_seen and list_unread can race on microsecond ordering and a non-monotonic clock rewind breaks the comparison entirely. Single-reader use is unaffected; multi-reader clients should treat unread as a hint, not a guarantee. (#100)"
     )]
     fn list_unread(
         &self,

--- a/crates/scitadel-mcp/src/server.rs
+++ b/crates/scitadel-mcp/src/server.rs
@@ -320,6 +320,33 @@ impl ScitadelServer {
     }
 
     #[tool(
+        description = "Fetch the works this paper cites (forward references) via OpenAlex's `referenced_works`. Materialises each cited work as a Paper row + persists the citation edges so subsequent queries hit the local DB. Requires the source paper to have an openalex_id. Returns: JSON {source_paper_id, count, references[]}."
+    )]
+    async fn get_references(
+        &self,
+        #[tool(param)]
+        #[schemars(description = "Source paper ID (must have openalex_id)")]
+        paper_id: String,
+    ) -> Result<String, String> {
+        tools::get_references_tool(&paper_id).await
+    }
+
+    #[tool(
+        description = "Fetch the works that cite this paper (reverse direction) via OpenAlex's `cites:` filter. Materialises citing works + persists edges. `limit` defaults to 25, capped at 200 by the OpenAlex API. Returns: JSON {source_paper_id, count, citations[]}."
+    )]
+    async fn get_citations(
+        &self,
+        #[tool(param)]
+        #[schemars(description = "Source paper ID (must have openalex_id)")]
+        paper_id: String,
+        #[tool(param)]
+        #[schemars(description = "Max citing works to return (default 25, max 200)")]
+        limit: Option<usize>,
+    ) -> Result<String, String> {
+        tools::get_citations_tool(&paper_id, limit).await
+    }
+
+    #[tool(
         description = "Export search results in a given format. Returns: text in the requested format (JSON / CSV / BibTeX)."
     )]
     fn export_search(

--- a/crates/scitadel-mcp/src/server.rs
+++ b/crates/scitadel-mcp/src/server.rs
@@ -1,110 +1,284 @@
+//! MCP server using rmcp 0.17's `tool_router` macro.
+//!
+//! Each tool is a method on `ScitadelServer` annotated with `#[tool]`.
+//! Aggregate request structs implement `Deserialize + JsonSchema` and
+//! are extracted via `Parameters<T>`. The tool handler functions live
+//! in `crate::tools` so this file stays a thin façade.
+
 use rmcp::{
     ServerHandler,
-    model::{ServerCapabilities, ServerInfo},
-    schemars, tool,
+    handler::server::{router::tool::ToolRouter, wrapper::Parameters},
+    schemars, tool, tool_handler, tool_router,
 };
+use schemars::JsonSchema;
+use serde::Deserialize;
 
 use crate::tools;
 
 // ---------- Aggregate request structs ----------
 
-#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct SearchRequest {
-    #[schemars(description = "Search query string")]
+    /// Search query string
     pub query: String,
-    #[schemars(
-        description = "Comma-separated list of sources (e.g. pubmed,arxiv,openalex,inspire)"
-    )]
+    /// Comma-separated list of sources (e.g. pubmed,arxiv,openalex,inspire)
     pub sources: String,
-    #[schemars(description = "Maximum results per source")]
+    /// Maximum results per source
     pub max_results: usize,
-    #[schemars(description = "Optional research question ID to link the search")]
+    /// Optional research question ID to link the search
     pub question_id: Option<String>,
 }
 
-#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct AddSearchTermsRequest {
-    #[schemars(description = "Research question ID")]
+    /// Research question ID
     pub question_id: String,
-    #[schemars(description = "List of search terms")]
+    /// List of search terms
     pub terms: Vec<String>,
-    #[schemars(description = "Custom query string (optional, defaults to terms joined by space)")]
+    /// Custom query string (optional, defaults to terms joined by space)
     pub query_string: Option<String>,
 }
 
-#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct AssessPaperRequest {
-    #[schemars(description = "Paper ID")]
+    /// Paper ID
     pub paper_id: String,
-    #[schemars(description = "Research question ID")]
+    /// Research question ID
     pub question_id: String,
-    #[schemars(description = "Relevance score (0.0-1.0)")]
+    /// Relevance score (0.0-1.0)
     pub score: f64,
-    #[schemars(description = "Reasoning for the score")]
+    /// Reasoning for the score
     pub reasoning: String,
-    #[schemars(description = "Assessor identifier")]
+    /// Assessor identifier
     pub assessor: String,
-    #[schemars(description = "Model used for assessment (optional)")]
+    /// Model used for assessment (optional)
     pub model: Option<String>,
 }
 
-#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct CreateAnnotationRequest {
-    #[schemars(description = "Paper ID the annotation anchors to")]
+    /// Paper ID the annotation anchors to
     pub paper_id: String,
-    #[schemars(description = "Exact quoted passage (TextQuoteSelector body)")]
+    /// Exact quoted passage (TextQuoteSelector body)
     pub quote: String,
-    #[schemars(description = "Note body — markdown allowed")]
+    /// Note body — markdown allowed
     pub note: String,
-    #[schemars(description = "Identity of the author (e.g. lars, claude-opus-4-7)")]
+    /// Identity of the author (e.g. lars, claude-opus-4-7)
     pub author: String,
-    #[schemars(description = "Text immediately before the quote, for anchor disambiguation")]
+    /// Text immediately before the quote, for anchor disambiguation
     pub prefix: Option<String>,
-    #[schemars(description = "Text immediately after the quote")]
+    /// Text immediately after the quote
     pub suffix: Option<String>,
-    #[schemars(description = "Optional research-question ID to link the annotation")]
+    /// Optional research-question ID to link the annotation
     pub question_id: Option<String>,
-    #[schemars(description = "Optional color label (hex or name)")]
+    /// Optional color label (hex or name)
     pub color: Option<String>,
-    #[schemars(description = "Optional tag list")]
+    /// Optional tag list
     pub tags: Option<Vec<String>>,
 }
 
-#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct UpdateAnnotationRequest {
-    #[schemars(description = "Annotation ID")]
+    /// Annotation ID
     pub id: String,
-    #[schemars(description = "New note body")]
+    /// New note body
     pub note: Option<String>,
-    #[schemars(description = "New color")]
+    /// New color
     pub color: Option<String>,
-    #[schemars(description = "Replace tag list wholesale")]
+    /// Replace tag list wholesale
     pub tags: Option<Vec<String>>,
 }
 
-#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct SaveAssessmentRequest {
-    #[schemars(description = "Paper ID")]
+    /// Paper ID
     pub paper_id: String,
-    #[schemars(description = "Research question ID")]
+    /// Research question ID
     pub question_id: String,
-    #[schemars(description = "Relevance score (0.0-1.0)")]
+    /// Relevance score (0.0-1.0)
     pub score: f64,
-    #[schemars(description = "Reasoning for the score")]
+    /// Reasoning for the score
     pub reasoning: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ReplyAnnotationRequest {
+    /// Parent annotation ID
+    pub parent_id: String,
+    /// Reply body
+    pub note: String,
+    /// Author identity
+    pub author: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct DeleteAnnotationRequest {
+    /// Annotation ID
+    pub id: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ListAnnotationsRequest {
+    /// Paper ID to list annotations for
+    pub paper_id: String,
+    /// Optional — only annotations by this author
+    pub author: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct MarkSeenRequest {
+    /// Annotation IDs to mark seen
+    pub annotation_ids: Vec<String>,
+    /// Reader identity (e.g. agent slug)
+    pub reader: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct MarkThreadSeenRequest {
+    /// Root annotation ID
+    pub root_id: String,
+    /// Reader identity
+    pub reader: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ListUnreadRequest {
+    /// Reader identity
+    pub reader: String,
+    /// Optional paper ID filter
+    pub paper_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct FindSimilarSearchesRequest {
+    /// Free-text query — FTS5 operators are stripped automatically
+    pub query: String,
+    /// Max hits to return (default 10)
+    pub limit: Option<i64>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SummarizeSearchRequest {
+    /// Search ID
+    pub search_id: String,
+    /// Max papers to return (default 50)
+    pub max_papers: Option<usize>,
+    /// Max chars per abstract before truncation (default 500)
+    pub abstract_char_limit: Option<usize>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ListSearchesRequest {
+    /// Maximum number of searches to return
+    pub limit: Option<i64>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct PaperIdRequest {
+    /// Paper ID
+    pub paper_id: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct GetCitationsRequest {
+    /// Source paper ID (must have openalex_id)
+    pub paper_id: String,
+    /// Max citing works to return (default 25, max 200)
+    pub limit: Option<usize>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ExportSearchRequest {
+    /// Search ID
+    pub search_id: String,
+    /// Export format: json, csv, or bibtex
+    pub format: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CreateQuestionRequest {
+    /// Question text
+    pub text: String,
+    /// Additional context or description
+    pub description: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct GetAssessmentsRequest {
+    /// Paper ID (optional)
+    pub paper_id: Option<String>,
+    /// Research question ID (optional)
+    pub question_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct PaperQuestionRequest {
+    /// Paper ID
+    pub paper_id: String,
+    /// Research question ID
+    pub question_id: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct DownloadPaperRequest {
+    /// Paper ID from the scitadel DB (preferred — unlocks arxiv/openalex/Unpaywall chain)
+    pub paper_id: Option<String>,
+    /// DOI (used only if paper_id is not provided)
+    pub doi: Option<String>,
+    /// Output directory (optional, defaults to .scitadel/papers/)
+    pub output_dir: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ReadPaperRequest {
+    /// Paper ID
+    pub paper_id: String,
+    /// Max characters to return (default 20000)
+    pub max_chars: Option<usize>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SearchIdRequest {
+    /// Search ID
+    pub search_id: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SearchQuestionRequest {
+    /// Search ID
+    pub search_id: String,
+    /// Research question ID
+    pub question_id: String,
 }
 
 // ---------- Server ----------
 
-#[derive(Debug, Clone, Default)]
-pub struct ScitadelServer;
+#[derive(Debug, Clone)]
+pub struct ScitadelServer {
+    tool_router: ToolRouter<Self>,
+}
 
-#[tool(tool_box)]
+impl ScitadelServer {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            tool_router: Self::tool_router(),
+        }
+    }
+}
+
+impl Default for ScitadelServer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[tool_router(router = tool_router)]
 impl ScitadelServer {
     #[tool(
         description = "Search scientific literature across multiple sources. Returns: JSON with search_id, query, per-source outcomes, total counts, and a `summary` text field for human readers."
     )]
-    async fn search(&self, #[tool(aggr)] req: SearchRequest) -> Result<String, String> {
+    async fn search(&self, Parameters(req): Parameters<SearchRequest>) -> Result<String, String> {
         tools::search_tool(req.query, req.sources, req.max_results, req.question_id).await
     }
 
@@ -127,7 +301,7 @@ impl ScitadelServer {
     )]
     fn create_annotation(
         &self,
-        #[tool(aggr)] req: CreateAnnotationRequest,
+        Parameters(req): Parameters<CreateAnnotationRequest>,
     ) -> Result<String, String> {
         tools::create_annotation_tool(
             &req.paper_id,
@@ -147,17 +321,9 @@ impl ScitadelServer {
     )]
     fn reply_annotation(
         &self,
-        #[tool(param)]
-        #[schemars(description = "Parent annotation ID")]
-        parent_id: String,
-        #[tool(param)]
-        #[schemars(description = "Reply body")]
-        note: String,
-        #[tool(param)]
-        #[schemars(description = "Author identity")]
-        author: String,
+        Parameters(req): Parameters<ReplyAnnotationRequest>,
     ) -> Result<String, String> {
-        tools::reply_annotation_tool(&parent_id, &note, &author)
+        tools::reply_annotation_tool(&req.parent_id, &req.note, &req.author)
     }
 
     #[tool(
@@ -165,7 +331,7 @@ impl ScitadelServer {
     )]
     fn update_annotation(
         &self,
-        #[tool(aggr)] req: UpdateAnnotationRequest,
+        Parameters(req): Parameters<UpdateAnnotationRequest>,
     ) -> Result<String, String> {
         tools::update_annotation_tool(&req.id, req.note.as_deref(), req.color.as_deref(), req.tags)
     }
@@ -175,11 +341,9 @@ impl ScitadelServer {
     )]
     fn delete_annotation(
         &self,
-        #[tool(param)]
-        #[schemars(description = "Annotation ID")]
-        id: String,
+        Parameters(req): Parameters<DeleteAnnotationRequest>,
     ) -> Result<String, String> {
-        tools::delete_annotation_tool(&id)
+        tools::delete_annotation_tool(&req.id)
     }
 
     #[tool(
@@ -187,29 +351,16 @@ impl ScitadelServer {
     )]
     fn list_annotations(
         &self,
-        #[tool(param)]
-        #[schemars(description = "Paper ID to list annotations for")]
-        paper_id: String,
-        #[tool(param)]
-        #[schemars(description = "Optional — only annotations by this author")]
-        author: Option<String>,
+        Parameters(req): Parameters<ListAnnotationsRequest>,
     ) -> Result<String, String> {
-        tools::list_annotations_tool(Some(&paper_id), author.as_deref())
+        tools::list_annotations_tool(Some(&req.paper_id), req.author.as_deref())
     }
 
     #[tool(
         description = "Mark one or more annotations as seen by `reader`. Repeat calls just update seen_at. Used so an agent can stop re-processing notes it already handled. Returns: text count."
     )]
-    fn mark_seen(
-        &self,
-        #[tool(param)]
-        #[schemars(description = "Annotation IDs to mark seen")]
-        annotation_ids: Vec<String>,
-        #[tool(param)]
-        #[schemars(description = "Reader identity (e.g. agent slug)")]
-        reader: String,
-    ) -> Result<String, String> {
-        tools::mark_seen_tool(annotation_ids, &reader)
+    fn mark_seen(&self, Parameters(req): Parameters<MarkSeenRequest>) -> Result<String, String> {
+        tools::mark_seen_tool(req.annotation_ids, &req.reader)
     }
 
     #[tool(
@@ -217,14 +368,9 @@ impl ScitadelServer {
     )]
     fn mark_thread_seen(
         &self,
-        #[tool(param)]
-        #[schemars(description = "Root annotation ID")]
-        root_id: String,
-        #[tool(param)]
-        #[schemars(description = "Reader identity")]
-        reader: String,
+        Parameters(req): Parameters<MarkThreadSeenRequest>,
     ) -> Result<String, String> {
-        tools::mark_thread_seen_tool(&root_id, &reader)
+        tools::mark_thread_seen_tool(&req.root_id, &req.reader)
     }
 
     #[tool(
@@ -232,14 +378,9 @@ impl ScitadelServer {
     )]
     fn list_unread(
         &self,
-        #[tool(param)]
-        #[schemars(description = "Reader identity")]
-        reader: String,
-        #[tool(param)]
-        #[schemars(description = "Optional paper ID filter")]
-        paper_id: Option<String>,
+        Parameters(req): Parameters<ListUnreadRequest>,
     ) -> Result<String, String> {
-        tools::list_unread_tool(&reader, paper_id.as_deref())
+        tools::list_unread_tool(&req.reader, req.paper_id.as_deref())
     }
 
     #[tool(
@@ -247,14 +388,9 @@ impl ScitadelServer {
     )]
     fn find_similar_searches(
         &self,
-        #[tool(param)]
-        #[schemars(description = "Free-text query — FTS5 operators are stripped automatically")]
-        query: String,
-        #[tool(param)]
-        #[schemars(description = "Max hits to return (default 10)")]
-        limit: Option<i64>,
+        Parameters(req): Parameters<FindSimilarSearchesRequest>,
     ) -> Result<String, String> {
-        tools::find_similar_searches_tool(&query, limit)
+        tools::find_similar_searches_tool(&req.query, req.limit)
     }
 
     #[tool(
@@ -262,49 +398,29 @@ impl ScitadelServer {
     )]
     fn summarize_search(
         &self,
-        #[tool(param)]
-        #[schemars(description = "Search ID")]
-        search_id: String,
-        #[tool(param)]
-        #[schemars(description = "Max papers to return (default 50)")]
-        max_papers: Option<usize>,
-        #[tool(param)]
-        #[schemars(description = "Max chars per abstract before truncation (default 500)")]
-        abstract_char_limit: Option<usize>,
+        Parameters(req): Parameters<SummarizeSearchRequest>,
     ) -> Result<String, String> {
-        tools::summarize_search_tool(&search_id, max_papers, abstract_char_limit)
+        tools::summarize_search_tool(&req.search_id, req.max_papers, req.abstract_char_limit)
     }
 
     #[tool(description = "List recent search runs. Returns: text table.")]
     fn list_searches(
         &self,
-        #[tool(param)]
-        #[schemars(description = "Maximum number of searches to return")]
-        limit: Option<i64>,
+        Parameters(req): Parameters<ListSearchesRequest>,
     ) -> Result<String, String> {
-        tools::list_searches_tool(limit.unwrap_or(20))
+        tools::list_searches_tool(req.limit.unwrap_or(20))
     }
 
     #[tool(
         description = "Get papers from a search result. Returns: text listing (title, authors, year, journal, IDs, abstract preview)."
     )]
-    fn get_papers(
-        &self,
-        #[tool(param)]
-        #[schemars(description = "Search ID")]
-        search_id: String,
-    ) -> Result<String, String> {
-        tools::get_papers_tool(&search_id)
+    fn get_papers(&self, Parameters(req): Parameters<SearchIdRequest>) -> Result<String, String> {
+        tools::get_papers_tool(&req.search_id)
     }
 
     #[tool(description = "Get full details of a single paper. Returns: JSON.")]
-    fn get_paper(
-        &self,
-        #[tool(param)]
-        #[schemars(description = "Paper ID")]
-        paper_id: String,
-    ) -> Result<String, String> {
-        tools::get_paper_tool(&paper_id)
+    fn get_paper(&self, Parameters(req): Parameters<PaperIdRequest>) -> Result<String, String> {
+        tools::get_paper_tool(&req.paper_id)
     }
 
     #[tool(
@@ -312,11 +428,9 @@ impl ScitadelServer {
     )]
     fn get_annotated_paper(
         &self,
-        #[tool(param)]
-        #[schemars(description = "Paper ID")]
-        paper_id: String,
+        Parameters(req): Parameters<PaperIdRequest>,
     ) -> Result<String, String> {
-        tools::get_annotated_paper_tool(&paper_id)
+        tools::get_annotated_paper_tool(&req.paper_id)
     }
 
     #[tool(
@@ -324,11 +438,9 @@ impl ScitadelServer {
     )]
     async fn get_references(
         &self,
-        #[tool(param)]
-        #[schemars(description = "Source paper ID (must have openalex_id)")]
-        paper_id: String,
+        Parameters(req): Parameters<PaperIdRequest>,
     ) -> Result<String, String> {
-        tools::get_references_tool(&paper_id).await
+        tools::get_references_tool(&req.paper_id).await
     }
 
     #[tool(
@@ -336,14 +448,9 @@ impl ScitadelServer {
     )]
     async fn get_citations(
         &self,
-        #[tool(param)]
-        #[schemars(description = "Source paper ID (must have openalex_id)")]
-        paper_id: String,
-        #[tool(param)]
-        #[schemars(description = "Max citing works to return (default 25, max 200)")]
-        limit: Option<usize>,
+        Parameters(req): Parameters<GetCitationsRequest>,
     ) -> Result<String, String> {
-        tools::get_citations_tool(&paper_id, limit).await
+        tools::get_citations_tool(&req.paper_id, req.limit).await
     }
 
     #[tool(
@@ -351,27 +458,17 @@ impl ScitadelServer {
     )]
     fn export_search(
         &self,
-        #[tool(param)]
-        #[schemars(description = "Search ID")]
-        search_id: String,
-        #[tool(param)]
-        #[schemars(description = "Export format: json, csv, or bibtex")]
-        format: String,
+        Parameters(req): Parameters<ExportSearchRequest>,
     ) -> Result<String, String> {
-        tools::export_search_tool(&search_id, &format)
+        tools::export_search_tool(&req.search_id, &req.format)
     }
 
     #[tool(description = "Create a new research question. Returns: text confirmation with ID.")]
     fn create_question(
         &self,
-        #[tool(param)]
-        #[schemars(description = "Question text")]
-        text: String,
-        #[tool(param)]
-        #[schemars(description = "Additional context or description")]
-        description: String,
+        Parameters(req): Parameters<CreateQuestionRequest>,
     ) -> Result<String, String> {
-        tools::create_question_tool(&text, &description)
+        tools::create_question_tool(&req.text, &req.description)
     }
 
     #[tool(description = "List all research questions. Returns: text table.")]
@@ -382,14 +479,20 @@ impl ScitadelServer {
     #[tool(
         description = "Add search terms linked to a research question. If `query_string` is omitted, the terms are joined by spaces. Returns: text confirmation."
     )]
-    fn add_search_terms(&self, #[tool(aggr)] req: AddSearchTermsRequest) -> Result<String, String> {
+    fn add_search_terms(
+        &self,
+        Parameters(req): Parameters<AddSearchTermsRequest>,
+    ) -> Result<String, String> {
         tools::add_search_terms_tool(&req.question_id, &req.terms, req.query_string.as_deref())
     }
 
     #[tool(
         description = "Record a paper assessment with score and reasoning. Returns: text summary."
     )]
-    fn assess_paper(&self, #[tool(aggr)] req: AssessPaperRequest) -> Result<String, String> {
+    fn assess_paper(
+        &self,
+        Parameters(req): Parameters<AssessPaperRequest>,
+    ) -> Result<String, String> {
         tools::assess_paper_tool(
             &req.paper_id,
             &req.question_id,
@@ -405,14 +508,9 @@ impl ScitadelServer {
     )]
     fn get_assessments(
         &self,
-        #[tool(param)]
-        #[schemars(description = "Paper ID (optional)")]
-        paper_id: Option<String>,
-        #[tool(param)]
-        #[schemars(description = "Research question ID (optional)")]
-        question_id: Option<String>,
+        Parameters(req): Parameters<GetAssessmentsRequest>,
     ) -> Result<String, String> {
-        tools::get_assessments_tool(paper_id.as_deref(), question_id.as_deref())
+        tools::get_assessments_tool(req.paper_id.as_deref(), req.question_id.as_deref())
     }
 
     #[tool(
@@ -420,20 +518,18 @@ impl ScitadelServer {
     )]
     fn prepare_assessment(
         &self,
-        #[tool(param)]
-        #[schemars(description = "Paper ID")]
-        paper_id: String,
-        #[tool(param)]
-        #[schemars(description = "Research question ID")]
-        question_id: String,
+        Parameters(req): Parameters<PaperQuestionRequest>,
     ) -> Result<String, String> {
-        tools::prepare_assessment_tool(&paper_id, &question_id)
+        tools::prepare_assessment_tool(&req.paper_id, &req.question_id)
     }
 
     #[tool(
         description = "Save an MCP-native assessment scored by the host LLM. Returns: text confirmation."
     )]
-    fn save_assessment(&self, #[tool(aggr)] req: SaveAssessmentRequest) -> Result<String, String> {
+    fn save_assessment(
+        &self,
+        Parameters(req): Parameters<SaveAssessmentRequest>,
+    ) -> Result<String, String> {
         tools::save_assessment_tool(&req.paper_id, &req.question_id, req.score, &req.reasoning)
     }
 
@@ -442,19 +538,14 @@ impl ScitadelServer {
     )]
     async fn download_paper(
         &self,
-        #[tool(param)]
-        #[schemars(
-            description = "Paper ID from the scitadel DB (preferred — unlocks arxiv/openalex/Unpaywall chain)"
-        )]
-        paper_id: Option<String>,
-        #[tool(param)]
-        #[schemars(description = "DOI (used only if paper_id is not provided)")]
-        doi: Option<String>,
-        #[tool(param)]
-        #[schemars(description = "Output directory (optional, defaults to .scitadel/papers/)")]
-        output_dir: Option<String>,
+        Parameters(req): Parameters<DownloadPaperRequest>,
     ) -> Result<String, String> {
-        tools::download_paper_tool(paper_id.as_deref(), doi.as_deref(), output_dir.as_deref()).await
+        tools::download_paper_tool(
+            req.paper_id.as_deref(),
+            req.doi.as_deref(),
+            req.output_dir.as_deref(),
+        )
+        .await
     }
 
     #[tool(
@@ -462,14 +553,9 @@ impl ScitadelServer {
     )]
     async fn read_paper(
         &self,
-        #[tool(param)]
-        #[schemars(description = "Paper ID")]
-        paper_id: String,
-        #[tool(param)]
-        #[schemars(description = "Max characters to return (default 20000)")]
-        max_chars: Option<usize>,
+        Parameters(req): Parameters<ReadPaperRequest>,
     ) -> Result<String, String> {
-        tools::read_paper_tool(&paper_id, max_chars).await
+        tools::read_paper_tool(&req.paper_id, req.max_chars).await
     }
 
     #[tool(
@@ -477,27 +563,14 @@ impl ScitadelServer {
     )]
     fn prepare_batch_assessments(
         &self,
-        #[tool(param)]
-        #[schemars(description = "Search ID")]
-        search_id: String,
-        #[tool(param)]
-        #[schemars(description = "Research question ID")]
-        question_id: String,
+        Parameters(req): Parameters<SearchQuestionRequest>,
     ) -> Result<String, String> {
-        tools::prepare_batch_assessments_tool(&search_id, &question_id)
+        tools::prepare_batch_assessments_tool(&req.search_id, &req.question_id)
     }
 }
 
-#[tool(tool_box)]
-impl ServerHandler for ScitadelServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo {
-            instructions: Some("Scitadel: scientific literature retrieval and assessment".into()),
-            capabilities: ServerCapabilities::builder().enable_tools().build(),
-            ..Default::default()
-        }
-    }
-}
+#[tool_handler(router = self.tool_router)]
+impl ServerHandler for ScitadelServer {}
 
 #[cfg(test)]
 mod tests {
@@ -519,7 +592,6 @@ mod tests {
         let mut tool_count = 0;
         while let Some(start) = src[offset..].find("#[tool(") {
             let abs_start = offset + start;
-            // Find matching close-paren by simple depth tracking.
             let mut depth = 0;
             let mut end = abs_start;
             for (i, c) in src[abs_start..].char_indices() {
@@ -538,7 +610,6 @@ mod tests {
             let attr = &src[abs_start..=end];
             offset = end + 1;
 
-            // Skip the macro-level `#[tool(tool_box)]` markers.
             if !attr.contains("description") {
                 continue;
             }

--- a/crates/scitadel-mcp/src/server.rs
+++ b/crates/scitadel-mcp/src/server.rs
@@ -303,6 +303,18 @@ impl ScitadelServer {
         tools::get_paper_tool(&paper_id)
     }
 
+    #[tool(
+        description = "Return JSON: paper {id,title,abstract,full_text}, annotations[] (live only, with parent_id/root_id and full anchor incl. char_range/quote/prefix/suffix/sentence_id/source_version/status), and source_version. One call replaces get_paper + list_annotations when an agent needs to reason over offsets."
+    )]
+    fn get_annotated_paper(
+        &self,
+        #[tool(param)]
+        #[schemars(description = "Paper ID")]
+        paper_id: String,
+    ) -> Result<String, String> {
+        tools::get_annotated_paper_tool(&paper_id)
+    }
+
     #[tool(description = "Export search results in a given format (json, csv, bibtex)")]
     fn export_search(
         &self,

--- a/crates/scitadel-mcp/src/tools.rs
+++ b/crates/scitadel-mcp/src/tools.rs
@@ -1495,6 +1495,41 @@ fn is_source_configured(src: &SourceInfo, config: &scitadel_core::config::Config
     }
 }
 
+// ===== TUI selection tool (#122) =====
+
+/// Read the singleton `tui_state` row written by the open scitadel TUI.
+/// Returns JSON: `{ tab, paper_id?, search_id?, question_id?,
+/// annotation_id?, updated_at, stale }`. `stale` is true when the
+/// row is older than 60s (TUI may have been closed).
+pub fn get_current_selection_tool() -> Result<String, String> {
+    let db = open_db()?;
+    let repo = scitadel_db::sqlite::SqliteTuiStateRepository::new(db);
+    match repo.get().map_err(|e| e.to_string())? {
+        Some(row) => {
+            let stale = chrono::DateTime::parse_from_rfc3339(&row.updated_at).map_or(true, |t| {
+                chrono::Utc::now().signed_duration_since(t.with_timezone(&chrono::Utc))
+                    > chrono::Duration::seconds(60)
+            });
+            Ok(serde_json::json!({
+                "tab": row.tab,
+                "paper_id": row.paper_id,
+                "search_id": row.search_id,
+                "question_id": row.question_id,
+                "annotation_id": row.annotation_id,
+                "updated_at": row.updated_at,
+                "stale": stale,
+            })
+            .to_string())
+        }
+        None => Ok(serde_json::json!({
+            "tab": null,
+            "stale": true,
+            "note": "no TUI has written state yet — start `scitadel tui` to populate"
+        })
+        .to_string()),
+    }
+}
+
 // ===== Star / paper-state tools (#120) =====
 
 /// Toggle the starred flag for `paper_id` under `reader`. Returns the

--- a/crates/scitadel-mcp/src/tools.rs
+++ b/crates/scitadel-mcp/src/tools.rs
@@ -10,7 +10,7 @@
 use scitadel_core::config::load_config;
 use scitadel_core::models::{Assessment, Paper, ResearchQuestion, SearchTerm};
 use scitadel_core::ports::{
-    AssessmentRepository, PaperRepository, QuestionRepository, SearchRepository,
+    AssessmentRepository, CitationRepository, PaperRepository, QuestionRepository, SearchRepository,
 };
 use scitadel_db::sqlite::Database;
 use scitadel_scoring::{SCORING_SYSTEM_PROMPT, build_user_prompt};
@@ -597,6 +597,213 @@ pub async fn read_paper_tool(paper_id: &str, max_chars: Option<usize>) -> Result
         path.display(),
         truncated
     ))
+}
+
+// ---------- Citation graph (#59 iter 1) ----------
+
+/// Fetch the OpenAlex `referenced_works` for a paper, materialise each
+/// cited work as a `Paper` row, and persist the citation edges. Returns
+/// JSON: `{ source_paper_id, count, references: [paper rows...] }`.
+///
+/// Iter 1 of #59. Forward-citation only (cited_by + snowball
+/// orchestration ship in later iters). Idempotent: existing papers
+/// upsert on the OpenAlex id, citation edges have a uniqueness
+/// constraint so re-runs are no-ops.
+pub async fn get_references_tool(paper_id: &str) -> Result<String, String> {
+    let stored = fetch_and_store_references(paper_id).await?;
+    let entries: Vec<serde_json::Value> = stored
+        .papers
+        .iter()
+        .map(|p| {
+            serde_json::json!({
+                "id": p.id.as_str(),
+                "title": p.title,
+                "authors": p.authors,
+                "year": p.year,
+                "doi": p.doi,
+                "openalex_id": p.openalex_id,
+            })
+        })
+        .collect();
+    let payload = serde_json::json!({
+        "source_paper_id": paper_id,
+        "count": stored.papers.len(),
+        "references": entries,
+    });
+    serde_json::to_string_pretty(&payload).map_err(|e| e.to_string())
+}
+
+/// Fetch the works that cite a given paper (`cited_by` direction).
+/// Mirrors `get_references_tool`; bounded by `limit` (default 25, cap
+/// 200 per the OpenAlex API).
+pub async fn get_citations_tool(paper_id: &str, limit: Option<usize>) -> Result<String, String> {
+    let stored = fetch_and_store_citations(paper_id, limit.unwrap_or(25)).await?;
+    let entries: Vec<serde_json::Value> = stored
+        .papers
+        .iter()
+        .map(|p| {
+            serde_json::json!({
+                "id": p.id.as_str(),
+                "title": p.title,
+                "authors": p.authors,
+                "year": p.year,
+                "doi": p.doi,
+                "openalex_id": p.openalex_id,
+            })
+        })
+        .collect();
+    let payload = serde_json::json!({
+        "source_paper_id": paper_id,
+        "count": stored.papers.len(),
+        "citations": entries,
+    });
+    serde_json::to_string_pretty(&payload).map_err(|e| e.to_string())
+}
+
+struct CitationFetchOutcome {
+    papers: Vec<scitadel_core::models::Paper>,
+}
+
+async fn fetch_and_store_references(paper_id: &str) -> Result<CitationFetchOutcome, String> {
+    let config = load_config();
+    let db = open_db()?;
+    let (paper_repo, _, _, _, citation_repo) = db.repositories();
+
+    let source_paper = paper_repo
+        .get(paper_id)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("Paper '{paper_id}' not found."))?;
+    let source_openalex = source_paper.openalex_id.clone().ok_or_else(|| {
+        format!("Paper '{paper_id}' has no openalex_id; reference fetch needs it.")
+    })?;
+
+    let adapter =
+        scitadel_adapters::openalex::OpenAlexAdapter::new(config.openalex.api_key.clone(), 30.0);
+    let work = adapter
+        .fetch_work_by_id(&source_openalex)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let referenced_ids: Vec<String> = work
+        .get("referenced_works")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str())
+                .filter_map(scitadel_adapters::openalex::short_openalex_id)
+                .collect()
+        })
+        .unwrap_or_default();
+
+    materialise_and_link(
+        &paper_repo,
+        &citation_repo,
+        &adapter,
+        paper_id,
+        &referenced_ids,
+        scitadel_core::models::CitationDirection::References,
+    )
+    .await
+}
+
+async fn fetch_and_store_citations(
+    paper_id: &str,
+    limit: usize,
+) -> Result<CitationFetchOutcome, String> {
+    let config = load_config();
+    let db = open_db()?;
+    let (paper_repo, _, _, _, citation_repo) = db.repositories();
+
+    let source_paper = paper_repo
+        .get(paper_id)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("Paper '{paper_id}' not found."))?;
+    let source_openalex = source_paper.openalex_id.clone().ok_or_else(|| {
+        format!("Paper '{paper_id}' has no openalex_id; citation fetch needs it.")
+    })?;
+
+    let adapter =
+        scitadel_adapters::openalex::OpenAlexAdapter::new(config.openalex.api_key.clone(), 30.0);
+
+    let citing_works = adapter
+        .fetch_cited_by(&source_openalex, limit)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let mut citing_ids: Vec<String> = Vec::with_capacity(citing_works.len());
+    for work in &citing_works {
+        if let Some(id) = work
+            .get("id")
+            .and_then(|v| v.as_str())
+            .and_then(scitadel_adapters::openalex::short_openalex_id)
+        {
+            citing_ids.push(id);
+        }
+    }
+
+    // Persist the works inline (we already have the metadata).
+    let papers: Vec<scitadel_core::models::Paper> = citing_works
+        .iter()
+        .map(scitadel_adapters::openalex::work_to_paper)
+        .collect();
+    paper_repo.save_many(&papers).map_err(|e| e.to_string())?;
+
+    let mut edges = Vec::with_capacity(citing_ids.len());
+    for cid in &citing_ids {
+        edges.push(scitadel_core::models::Citation {
+            source_paper_id: scitadel_core::models::PaperId::from(paper_id),
+            target_paper_id: scitadel_core::models::PaperId::from(cid.clone()),
+            direction: scitadel_core::models::CitationDirection::CitedBy,
+            discovered_by: "openalex".into(),
+            depth: 1,
+            snowball_run_id: None,
+        });
+    }
+    citation_repo.save_many(&edges).map_err(|e| e.to_string())?;
+    Ok(CitationFetchOutcome { papers })
+}
+
+async fn materialise_and_link(
+    paper_repo: &scitadel_db::sqlite::SqlitePaperRepository,
+    citation_repo: &scitadel_db::sqlite::SqliteCitationRepository,
+    adapter: &scitadel_adapters::openalex::OpenAlexAdapter,
+    source_paper_id: &str,
+    target_openalex_ids: &[String],
+    direction: scitadel_core::models::CitationDirection,
+) -> Result<CitationFetchOutcome, String> {
+    if target_openalex_ids.is_empty() {
+        return Ok(CitationFetchOutcome { papers: Vec::new() });
+    }
+    // Batch-fetch metadata in chunks of 50 (OpenAlex `openalex_id:`
+    // filter cap).
+    let mut all_papers: Vec<scitadel_core::models::Paper> = Vec::new();
+    for chunk in target_openalex_ids.chunks(50) {
+        let works = adapter
+            .fetch_works_by_ids(chunk)
+            .await
+            .map_err(|e| e.to_string())?;
+        for work in &works {
+            all_papers.push(scitadel_adapters::openalex::work_to_paper(work));
+        }
+    }
+    paper_repo
+        .save_many(&all_papers)
+        .map_err(|e| e.to_string())?;
+
+    let mut edges = Vec::with_capacity(all_papers.len());
+    for paper in &all_papers {
+        edges.push(scitadel_core::models::Citation {
+            source_paper_id: scitadel_core::models::PaperId::from(source_paper_id),
+            target_paper_id: paper.id.clone(),
+            direction: direction.clone(),
+            discovered_by: "openalex".into(),
+            depth: 1,
+            snowball_run_id: None,
+        });
+    }
+    citation_repo.save_many(&edges).map_err(|e| e.to_string())?;
+
+    Ok(CitationFetchOutcome { papers: all_papers })
 }
 
 fn html_to_text(html: &str) -> String {

--- a/crates/scitadel-mcp/src/tools.rs
+++ b/crates/scitadel-mcp/src/tools.rs
@@ -836,6 +836,17 @@ pub fn create_annotation_tool(
     }
 
     repo.create(&ann).map_err(|e| e.to_string())?;
+    // Trust-on-first-use audit log: `author` is whatever string the
+    // MCP client supplied. rmcp 0.1.5 doesn't surface a peer identity
+    // to tool handlers, so this is the best we can do until auth lands
+    // (see ADR-003 "Phase-5 auth"). #100.
+    tracing::info!(
+        op = "create_annotation",
+        annotation_id = ann.id.as_str(),
+        paper_id = paper_id,
+        author = author,
+        "annotation write (trust-on-first-use)"
+    );
     Ok(ann.id.as_str().to_string())
 }
 
@@ -854,6 +865,13 @@ pub fn reply_annotation_tool(parent_id: &str, note: &str, author: &str) -> Resul
     let reply =
         scitadel_core::models::Annotation::new_reply(&parent, author.to_string(), note.to_string());
     repo.create(&reply).map_err(|e| e.to_string())?;
+    tracing::info!(
+        op = "reply_annotation",
+        annotation_id = reply.id.as_str(),
+        parent_id = parent_id,
+        author = author,
+        "annotation write (trust-on-first-use)"
+    );
     Ok(reply.id.as_str().to_string())
 }
 
@@ -870,11 +888,18 @@ pub fn update_annotation_tool(
         .get(id)
         .map_err(|e| e.to_string())?
         .ok_or_else(|| format!("Annotation '{id}' not found."))?;
+    let original_author = existing.author.clone();
     let new_note = note.unwrap_or(&existing.note);
     let new_color = color.or(existing.color.as_deref());
     let new_tags = tags.unwrap_or(existing.tags);
     repo.update_note(id, new_note, new_color, &new_tags)
         .map_err(|e| e.to_string())?;
+    tracing::info!(
+        op = "update_annotation",
+        annotation_id = id,
+        author = original_author.as_str(),
+        "annotation write (trust-on-first-use)"
+    );
     Ok(format!("Annotation {id} updated."))
 }
 
@@ -884,6 +909,11 @@ pub fn delete_annotation_tool(id: &str) -> Result<String, String> {
     let db = open_db()?;
     let repo = scitadel_db::sqlite::SqliteAnnotationRepository::new(db);
     repo.soft_delete(id).map_err(|e| e.to_string())?;
+    tracing::info!(
+        op = "delete_annotation",
+        annotation_id = id,
+        "annotation write (trust-on-first-use)"
+    );
     Ok(format!("Annotation {id} deleted (soft)."))
 }
 

--- a/crates/scitadel-mcp/src/tools.rs
+++ b/crates/scitadel-mcp/src/tools.rs
@@ -963,6 +963,95 @@ pub fn list_annotations_tool(
     serde_json::to_string_pretty(&entries).map_err(|e| e.to_string())
 }
 
+/// Return the paper text + every live annotation anchored to it as a
+/// single structured JSON document, so an agent can reason over offsets
+/// without re-deriving the mapping from `get_paper` + `list_annotations`.
+///
+/// Soft-deleted annotations are excluded. Replies are flat with
+/// `parent_id` and `root_id` so threads can be reconstructed without
+/// extra round-trips.
+pub fn get_annotated_paper_tool(paper_id: &str) -> Result<String, String> {
+    let db = open_db()?;
+    build_annotated_paper(&db, paper_id)
+}
+
+fn build_annotated_paper(db: &Database, paper_id: &str) -> Result<String, String> {
+    use std::collections::HashMap;
+
+    let (paper_repo, _, _, _, _) = db.repositories();
+    let paper = paper_repo
+        .get(paper_id)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("Paper '{paper_id}' not found."))?;
+
+    let ann_repo = scitadel_db::sqlite::SqliteAnnotationRepository::new(db.clone());
+    let annotations = ann_repo
+        .list_by_paper(paper_id)
+        .map_err(|e| e.to_string())?;
+
+    let by_id: HashMap<&str, &scitadel_core::models::Annotation> =
+        annotations.iter().map(|a| (a.id.as_str(), a)).collect();
+    let root_of = |start: &scitadel_core::models::Annotation| -> String {
+        let mut cur = start;
+        // Bounded chase to avoid pathological loops if data is malformed.
+        for _ in 0..64 {
+            match &cur.parent_id {
+                None => return cur.id.as_str().to_string(),
+                Some(pid) => match by_id.get(pid.as_str()) {
+                    Some(parent) => cur = parent,
+                    None => return cur.id.as_str().to_string(),
+                },
+            }
+        }
+        cur.id.as_str().to_string()
+    };
+
+    let source_version = annotations
+        .iter()
+        .find_map(|a| a.anchor.source_version.clone());
+
+    let entries: Vec<serde_json::Value> = annotations
+        .iter()
+        .map(|a| {
+            serde_json::json!({
+                "id": a.id.as_str(),
+                "parent_id": a.parent_id.as_ref().map(|p| p.as_str()),
+                "root_id": root_of(a),
+                "paper_id": a.paper_id.as_str(),
+                "question_id": a.question_id.as_ref().map(|q| q.as_str()),
+                "anchor": {
+                    "char_range": a.anchor.char_range,
+                    "quote": a.anchor.quote,
+                    "prefix": a.anchor.prefix,
+                    "suffix": a.anchor.suffix,
+                    "sentence_id": a.anchor.sentence_id,
+                    "source_version": a.anchor.source_version,
+                    "status": a.anchor.status.as_str(),
+                },
+                "note": a.note,
+                "color": a.color,
+                "tags": a.tags,
+                "author": a.author,
+                "created_at": a.created_at.to_rfc3339(),
+                "updated_at": a.updated_at.to_rfc3339(),
+            })
+        })
+        .collect();
+
+    let response = serde_json::json!({
+        "paper": {
+            "id": paper.id.as_str(),
+            "title": paper.title,
+            "abstract": paper.r#abstract,
+            "full_text": paper.full_text,
+        },
+        "annotations": entries,
+        "source_version": source_version,
+    });
+
+    serde_json::to_string_pretty(&response).map_err(|e| e.to_string())
+}
+
 /// Full-text search over stored search queries. Returns a JSON array of
 /// past searches matching `query` (lower `rank` = more relevant per
 /// BM25). Agents should call this before running a fresh search to
@@ -1185,8 +1274,148 @@ fn is_source_configured(src: &SourceInfo, config: &scitadel_core::config::Config
 
 #[cfg(test)]
 mod tests {
-    use super::{SOURCE_REGISTRY, html_to_text, is_source_configured, truncate_abstract};
+    use super::{
+        SOURCE_REGISTRY, build_annotated_paper, html_to_text, is_source_configured,
+        truncate_abstract,
+    };
     use scitadel_core::config::Config;
+    use scitadel_core::models::{Anchor, Annotation, Paper, PaperId};
+    use scitadel_core::ports::PaperRepository;
+    use scitadel_db::sqlite::{Database, SqliteAnnotationRepository};
+
+    fn fresh_db() -> Database {
+        let db = Database::open_in_memory().expect("open in-memory db");
+        db.migrate().expect("migrate");
+        db
+    }
+
+    fn save_paper(db: &Database, id: &str, title: &str, full_text: Option<&str>) -> PaperId {
+        let (paper_repo, _, _, _, _) = db.repositories();
+        let mut p = Paper::new(title);
+        p.id = PaperId::from(id);
+        p.r#abstract = "abs".into();
+        p.full_text = full_text.map(str::to_string);
+        paper_repo.save(&p).expect("save paper");
+        p.id
+    }
+
+    #[test]
+    fn get_annotated_paper_roundtrip_includes_offsets_and_quote() {
+        let db = fresh_db();
+        let pid = save_paper(
+            &db,
+            "p-1",
+            "Neutron stars",
+            Some("Neutron stars are dense."),
+        );
+        let repo = SqliteAnnotationRepository::new(db.clone());
+        let mut ann = Annotation::new_root(
+            pid.clone(),
+            "lars".into(),
+            "key claim".into(),
+            Anchor {
+                char_range: Some((0, 13)),
+                quote: Some("Neutron stars".into()),
+                prefix: None,
+                suffix: Some(" are dense.".into()),
+                ..Anchor::default()
+            },
+        );
+        ann.tags = vec!["physics".into()];
+        repo.create(&ann).expect("create ann");
+
+        let json = build_annotated_paper(&db, "p-1").expect("build");
+        let v: serde_json::Value = serde_json::from_str(&json).expect("parse");
+        assert_eq!(v["paper"]["id"], "p-1");
+        assert_eq!(v["paper"]["full_text"], "Neutron stars are dense.");
+        let arr = v["annotations"].as_array().expect("annotations array");
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["anchor"]["quote"], "Neutron stars");
+        assert_eq!(arr[0]["anchor"]["char_range"][0], 0);
+        assert_eq!(arr[0]["anchor"]["char_range"][1], 13);
+        assert_eq!(arr[0]["root_id"], arr[0]["id"]);
+        assert!(arr[0]["parent_id"].is_null());
+    }
+
+    #[test]
+    fn get_annotated_paper_excludes_soft_deleted() {
+        let db = fresh_db();
+        let pid = save_paper(&db, "p-2", "T", None);
+        let repo = SqliteAnnotationRepository::new(db.clone());
+        let live = Annotation::new_root(
+            pid.clone(),
+            "lars".into(),
+            "live".into(),
+            Anchor {
+                quote: Some("q1".into()),
+                ..Anchor::default()
+            },
+        );
+        let doomed = Annotation::new_root(
+            pid,
+            "lars".into(),
+            "gone".into(),
+            Anchor {
+                quote: Some("q2".into()),
+                ..Anchor::default()
+            },
+        );
+        repo.create(&live).unwrap();
+        repo.create(&doomed).unwrap();
+        repo.soft_delete(doomed.id.as_str()).unwrap();
+
+        let v: serde_json::Value =
+            serde_json::from_str(&build_annotated_paper(&db, "p-2").unwrap()).unwrap();
+        let arr = v["annotations"].as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["note"], "live");
+    }
+
+    #[test]
+    fn get_annotated_paper_zero_annotations_returns_empty_array() {
+        let db = fresh_db();
+        save_paper(&db, "p-3", "Empty", None);
+        let v: serde_json::Value =
+            serde_json::from_str(&build_annotated_paper(&db, "p-3").unwrap()).unwrap();
+        assert_eq!(v["annotations"].as_array().unwrap().len(), 0);
+        assert!(v["source_version"].is_null());
+    }
+
+    #[test]
+    fn get_annotated_paper_replies_carry_root_id() {
+        let db = fresh_db();
+        let pid = save_paper(&db, "p-4", "T", None);
+        let repo = SqliteAnnotationRepository::new(db.clone());
+        let root = Annotation::new_root(
+            pid,
+            "lars".into(),
+            "root note".into(),
+            Anchor {
+                quote: Some("q".into()),
+                ..Anchor::default()
+            },
+        );
+        let reply = Annotation::new_reply(&root, "claude".into(), "agreed".into());
+        repo.create(&root).unwrap();
+        repo.create(&reply).unwrap();
+
+        let v: serde_json::Value =
+            serde_json::from_str(&build_annotated_paper(&db, "p-4").unwrap()).unwrap();
+        let arr = v["annotations"].as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        let reply_entry = arr
+            .iter()
+            .find(|a| a["parent_id"].is_string())
+            .expect("has reply");
+        assert_eq!(reply_entry["root_id"], root.id.as_str());
+    }
+
+    #[test]
+    fn get_annotated_paper_unknown_paper_errors() {
+        let db = fresh_db();
+        let err = build_annotated_paper(&db, "nope").unwrap_err();
+        assert!(err.contains("not found"));
+    }
 
     #[test]
     fn truncate_abstract_shorter_than_limit_untouched() {

--- a/crates/scitadel-mcp/src/tools.rs
+++ b/crates/scitadel-mcp/src/tools.rs
@@ -560,24 +560,43 @@ pub async fn read_paper_tool(paper_id: &str, max_chars: Option<usize>) -> Result
         .map_err(|e| e.to_string())?
         .ok_or_else(|| format!("paper not found: {paper_id}"))?;
 
-    let path = scitadel_adapters::download::find_cached_file(&paper, &config.papers_dir())
-        .ok_or_else(|| "paper not downloaded yet. Call download_paper first.".to_string())?;
+    // Cache hit: skip the (slow) PDF extract if the text was already
+    // persisted on a previous call. Same envelope as the cold path.
+    let mut text: Option<String> = paper.full_text.clone();
+    let mut path: Option<std::path::PathBuf> = None;
 
-    let text = match path.extension().and_then(|e| e.to_str()) {
-        Some("pdf") => {
-            let path_clone = path.clone();
-            tokio::task::spawn_blocking(move || pdf_extract::extract_text(&path_clone))
-                .await
-                .map_err(|e| format!("pdf extract task failed: {e}"))?
-                .map_err(|e| format!("pdf extract failed: {e}"))?
+    if text.is_none() {
+        let p = scitadel_adapters::download::find_cached_file(&paper, &config.papers_dir())
+            .ok_or_else(|| "paper not downloaded yet. Call download_paper first.".to_string())?;
+        let extracted = match p.extension().and_then(|e| e.to_str()) {
+            Some("pdf") => {
+                let path_clone = p.clone();
+                tokio::task::spawn_blocking(move || pdf_extract::extract_text(&path_clone))
+                    .await
+                    .map_err(|e| format!("pdf extract task failed: {e}"))?
+                    .map_err(|e| format!("pdf extract failed: {e}"))?
+            }
+            Some("html") => {
+                let bytes = tokio::fs::read(&p).await.map_err(|e| e.to_string())?;
+                let html = String::from_utf8_lossy(&bytes);
+                html_to_text(&html)
+            }
+            other => return Err(format!("unsupported file type: {other:?}")),
+        };
+        // Persist so future reads hit the cache (and the TUI two-pane
+        // reader has something to render). Failure is non-fatal; we
+        // still return what we just extracted.
+        if let Err(e) = paper_repo.update_full_text(paper_id, &extracted) {
+            tracing::warn!(paper_id, error = %e, "failed to cache full_text");
         }
-        Some("html") => {
-            let bytes = tokio::fs::read(&path).await.map_err(|e| e.to_string())?;
-            let html = String::from_utf8_lossy(&bytes);
-            html_to_text(&html)
-        }
-        other => return Err(format!("unsupported file type: {other:?}")),
-    };
+        path = Some(p);
+        text = Some(extracted);
+    }
+
+    let path_display = path
+        .as_ref()
+        .map_or_else(|| "(cached in db)".to_string(), |p| p.display().to_string());
+    let text = text.expect("text populated above");
 
     let limit = max_chars.unwrap_or(20_000);
     let truncated = if text.chars().count() > limit {
@@ -593,9 +612,7 @@ pub async fn read_paper_tool(paper_id: &str, max_chars: Option<usize>) -> Result
 
     Ok(format!(
         "Paper: {}\nPath: {}\n\n{}",
-        paper.title,
-        path.display(),
-        truncated
+        paper.title, path_display, truncated
     ))
 }
 

--- a/crates/scitadel-mcp/src/tools.rs
+++ b/crates/scitadel-mcp/src/tools.rs
@@ -1495,6 +1495,71 @@ fn is_source_configured(src: &SourceInfo, config: &scitadel_core::config::Config
     }
 }
 
+// ===== Star / paper-state tools (#120) =====
+
+/// Toggle the starred flag for `paper_id` under `reader`. Returns the
+/// new value as JSON: `{"paper_id": "...", "starred": true|false}`.
+pub fn toggle_star_tool(paper_id: &str, reader: &str) -> Result<String, String> {
+    if reader.trim().is_empty() {
+        return Err("reader is required (pass an identity string)".into());
+    }
+    let db = open_db()?;
+    let repo = scitadel_db::sqlite::SqlitePaperStateRepository::new(db);
+    let starred = repo
+        .toggle_starred(paper_id, reader)
+        .map_err(|e| e.to_string())?;
+    tracing::info!(
+        op = "toggle_star",
+        paper_id,
+        reader,
+        starred,
+        "star write (trust-on-first-use)"
+    );
+    Ok(serde_json::json!({ "paper_id": paper_id, "starred": starred }).to_string())
+}
+
+/// Idempotent "ensure starred state" — sets `starred` to the requested
+/// value regardless of current. Returns the same JSON shape as toggle.
+pub fn set_star_tool(paper_id: &str, starred: bool, reader: &str) -> Result<String, String> {
+    if reader.trim().is_empty() {
+        return Err("reader is required".into());
+    }
+    let db = open_db()?;
+    let repo = scitadel_db::sqlite::SqlitePaperStateRepository::new(db);
+    let existing = repo.get(paper_id, reader).map_err(|e| e.to_string())?;
+    let new_state = scitadel_db::sqlite::PaperState {
+        paper_id: paper_id.into(),
+        reader: reader.into(),
+        starred,
+        to_read: existing.as_ref().is_some_and(|s| s.to_read),
+        read_at: existing.and_then(|s| s.read_at),
+    };
+    repo.set(&new_state).map_err(|e| e.to_string())?;
+    tracing::info!(
+        op = "set_star",
+        paper_id,
+        reader,
+        starred,
+        "star write (trust-on-first-use)"
+    );
+    Ok(serde_json::json!({ "paper_id": paper_id, "starred": starred }).to_string())
+}
+
+/// List all paper IDs `reader` has starred. Returns a JSON array of
+/// strings (paper IDs only — call `get_paper` for each if you need
+/// metadata).
+pub fn list_starred_tool(reader: &str) -> Result<String, String> {
+    if reader.trim().is_empty() {
+        return Err("reader is required".into());
+    }
+    let db = open_db()?;
+    let repo = scitadel_db::sqlite::SqlitePaperStateRepository::new(db);
+    let ids = repo.starred_ids(reader).map_err(|e| e.to_string())?;
+    let mut sorted: Vec<String> = ids.into_iter().collect();
+    sorted.sort();
+    serde_json::to_string(&sorted).map_err(|e| e.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::{

--- a/crates/scitadel-mcp/src/tools.rs
+++ b/crates/scitadel-mcp/src/tools.rs
@@ -314,7 +314,7 @@ pub fn list_questions_tool() -> Result<String, String> {
 pub fn add_search_terms_tool(
     question_id: &str,
     terms: &[String],
-    query_string: &str,
+    query_string: Option<&str>,
 ) -> Result<String, String> {
     let db = open_db()?;
     let (_, _, q_repo, _, _) = db.repositories();
@@ -324,10 +324,9 @@ pub fn add_search_terms_tool(
         .map_err(|e| e.to_string())?
         .ok_or_else(|| format!("Question '{question_id}' not found."))?;
 
-    let query_str = if query_string.is_empty() {
-        terms.join(" ")
-    } else {
-        query_string.to_string()
+    let query_str = match query_string {
+        Some(s) if !s.is_empty() => s.to_string(),
+        _ => terms.join(" "),
     };
 
     let mut term = SearchTerm::new(question.id.clone());

--- a/crates/scitadel-scoring/Cargo.toml
+++ b/crates/scitadel-scoring/Cargo.toml
@@ -16,7 +16,7 @@ default = ["scoring"]
 scoring = []
 
 [dependencies]
-scitadel-core = { path = "../scitadel-core", version = "0.1.0" }
+scitadel-core = { path = "../scitadel-core", version = "0.5.0" }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/scitadel-tui/Cargo.toml
+++ b/crates/scitadel-tui/Cargo.toml
@@ -12,9 +12,9 @@ description = "Interactive TUI for browsing scitadel searches, papers, and asses
 readme = "../../README.md"
 
 [dependencies]
-scitadel-core = { path = "../scitadel-core", version = "0.1.0" }
-scitadel-db = { path = "../scitadel-db", version = "0.1.0" }
-scitadel-adapters = { path = "../scitadel-adapters", version = "0.1.0" }
+scitadel-core = { path = "../scitadel-core", version = "0.5.0" }
+scitadel-db = { path = "../scitadel-db", version = "0.5.0" }
+scitadel-adapters = { path = "../scitadel-adapters", version = "0.5.0" }
 ratatui = { workspace = true }
 crossterm = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/scitadel-tui/Cargo.toml
+++ b/crates/scitadel-tui/Cargo.toml
@@ -22,6 +22,7 @@ tracing = { workspace = true }
 tokio = { workspace = true }
 uuid = { workspace = true }
 reqwest = { workspace = true }
+chrono = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/scitadel-tui/src/app.rs
+++ b/crates/scitadel-tui/src/app.rs
@@ -171,6 +171,7 @@ impl App {
     fn drain_all_channels(&mut self) {
         self.drain_task_updates();
         self.drain_offline();
+        self.flush_completed_tasks();
     }
 
     fn drain_task_updates(&mut self) {
@@ -178,8 +179,14 @@ impl App {
             match update {
                 TaskUpdate::New(task) => {
                     self.tasks.push(task);
-                    if self.tasks.len() > 10 {
-                        self.tasks.remove(0);
+                    // Evict the oldest *terminal* task only — never drop
+                    // a Queued or Running download just because the panel
+                    // is full. If everything in the panel is still active,
+                    // grow past the cap rather than lose work.
+                    if self.tasks.len() > 10
+                        && let Some(idx) = self.tasks.iter().position(|t| t.terminal_at.is_some())
+                    {
+                        self.tasks.remove(idx);
                     }
                 }
                 TaskUpdate::Status { id, status } => {
@@ -198,10 +205,24 @@ impl App {
                     }
                     if let Some(t) = self.tasks.iter_mut().find(|t| t.id == id) {
                         t.status = status;
+                        if matches!(t.status, TaskStatus::Done { .. } | TaskStatus::Failed(_)) {
+                            t.terminal_at = Some(std::time::Instant::now());
+                        }
                     }
                 }
             }
         }
+    }
+
+    /// Drop terminal tasks once their linger window has elapsed (5s for
+    /// Done, 30s for Failed). Runs every drain pass — cheap.
+    fn flush_completed_tasks(&mut self) {
+        crate::tasks::retain_recent_terminal(&mut self.tasks, std::time::Instant::now());
+    }
+
+    /// Drop every terminal task immediately. Bound to `c` in tab mode (#113).
+    fn clear_completed_tasks(&mut self) {
+        crate::tasks::clear_terminal(&mut self.tasks);
     }
 
     /// Set of paper IDs that have a Queued or Running download task.
@@ -267,6 +288,9 @@ impl App {
         match code {
             KeyCode::Tab => self.tab = self.tab.next(),
             KeyCode::BackTab => self.tab = self.tab.prev(),
+            // `c` clears all terminal tasks (#113). Available globally
+            // in tab mode; no-op when the panel is already empty.
+            KeyCode::Char('c') => self.clear_completed_tasks(),
             _ => self.handle_tab_key(code),
         }
     }
@@ -758,8 +782,12 @@ fn draw(frame: &mut ratatui::Frame, app: &mut App) {
         (Some(Overlay::SearchPapers { .. }), _) => {
             "Esc/q: back | j/k: navigate | Enter: open paper"
         }
-        (None, Tab::Papers) => "Tab: switch tabs | j/k: navigate | Enter: open | s: star | q: quit",
-        (None, _) => "Tab/Shift-Tab: switch tabs | j/k: navigate | Enter: select | q: quit",
+        (None, Tab::Papers) => {
+            "Tab: switch tabs | j/k: navigate | Enter: open | s: star | c: clear tasks | q: quit"
+        }
+        (None, _) => {
+            "Tab/Shift-Tab: switch tabs | j/k: navigate | Enter: select | c: clear tasks | q: quit"
+        }
     };
     status_bar::draw(frame, chunks[3], help_text, app.offline);
 }

--- a/crates/scitadel-tui/src/app.rs
+++ b/crates/scitadel-tui/src/app.rs
@@ -64,13 +64,19 @@ pub enum Overlay {
         paper_id: String,
         scroll: u16,
         /// `None` = scroll mode; `Some(i)` = focused on annotation `i`
-        /// in the paper's annotation list. Set by `J` (or `Tab` while
-        /// in PaperDetail) and cleared by `Esc`. Required so e/d/r
-        /// have a target.
+        /// in the paper's annotation list. Set by `Shift+J` and
+        /// cleared by `Esc`. Required so e/d/r (#92) have a target.
         annotation_focus: Option<usize>,
-        /// Active n/e/r/d prompt overlay. Drawn on top of the detail
-        /// view; eats keystrokes until submitted or cancelled.
+        /// Active n/e/r/d prompt overlay (#92). Drawn on top of the
+        /// detail view; eats keystrokes until submitted or cancelled.
         prompt: Option<AnnotationPrompt>,
+        /// True = two-pane reader mode (#97); false = the existing
+        /// single-pane metadata + annotation list. Toggled with `R`.
+        /// Mutually exclusive with `annotation_focus`/`prompt`.
+        reader: bool,
+        /// Index into the paper's root annotations while the reader
+        /// is open; cycles via `J` / `K` to hop between highlights.
+        highlight_focus: Option<usize>,
     },
     SearchPapers {
         search_id: String,
@@ -238,6 +244,8 @@ impl App {
                             scroll: 0,
                             annotation_focus: None,
                             prompt: None,
+                            reader: false,
+                            highlight_focus: None,
                         });
                     }
                 }
@@ -260,20 +268,47 @@ impl App {
         );
     }
 
-    /// Routes a key inside the PaperDetail overlay through three layers:
-    /// (1) an active prompt, (2) annotation-focus mode, (3) plain
-    /// scroll mode. Each layer eats its own keys and falls through
-    /// otherwise.
+    /// Routes a key inside the PaperDetail overlay through four layers:
+    /// (0) reader mode (#97) — its own R/Esc/J/K loop;
+    /// (1) an active prompt (#92);
+    /// (2) annotation-focus mode (#92);
+    /// (3) plain scroll mode.
+    /// Each layer eats its own keys and falls through otherwise.
     fn handle_paper_detail_key(&mut self, code: KeyCode) {
         let Some(Overlay::PaperDetail {
             paper_id,
             scroll,
             annotation_focus,
             prompt,
+            reader,
+            highlight_focus,
         }) = self.overlay.as_mut()
         else {
             return;
         };
+
+        // Layer 0: reader mode owns the keystroke loop while it's open.
+        if *reader {
+            let count = crate::views::reader::highlight_count(&self.data, paper_id);
+            match code {
+                KeyCode::Esc | KeyCode::Char('q' | 'R') => {
+                    *reader = false;
+                    *highlight_focus = None;
+                }
+                KeyCode::Char('J') | KeyCode::Down if count > 0 => {
+                    *highlight_focus = Some(highlight_focus.map_or(0, |f| (f + 1).min(count - 1)));
+                }
+                KeyCode::Char('K') | KeyCode::Up if count > 0 => {
+                    *highlight_focus = Some(highlight_focus.map_or(0, |f| f.saturating_sub(1)));
+                }
+                KeyCode::Char('D') => {
+                    let pid = paper_id.clone();
+                    self.queue_download(&pid);
+                }
+                _ => {}
+            }
+            return;
+        }
 
         // Layer 1: an active prompt eats every keystroke.
         if prompt.is_some() {
@@ -358,6 +393,14 @@ impl App {
                 if count > 0 {
                     *annotation_focus = Some(0);
                 }
+            }
+            KeyCode::Char('R') => {
+                // Enter reader mode (#97). Highlight cursor starts at
+                // 0 if the paper has any root annotations.
+                let pid = paper_id.clone();
+                let count = crate::views::reader::highlight_count(&self.data, &pid);
+                *reader = true;
+                *highlight_focus = if count > 0 { Some(0) } else { None };
             }
             _ => {}
         }
@@ -452,6 +495,8 @@ impl App {
                                 scroll: 0,
                                 annotation_focus: None,
                                 prompt: None,
+                                reader: false,
+                                highlight_focus: None,
                             });
                         }
                     }
@@ -569,17 +614,23 @@ fn draw(frame: &mut ratatui::Frame, app: &mut App) {
             scroll,
             annotation_focus,
             prompt,
+            reader,
+            highlight_focus,
         }) => {
-            detail::draw(
-                frame,
-                chunks[1],
-                &app.data,
-                paper_id,
-                *scroll,
-                *annotation_focus,
-            );
-            if let Some(active) = prompt {
-                annotation_prompt::draw_overlay(frame, chunks[1], active);
+            if *reader {
+                crate::views::reader::draw(frame, chunks[1], &app.data, paper_id, *highlight_focus);
+            } else {
+                detail::draw(
+                    frame,
+                    chunks[1],
+                    &app.data,
+                    paper_id,
+                    *scroll,
+                    *annotation_focus,
+                );
+                if let Some(active) = prompt {
+                    annotation_prompt::draw_overlay(frame, chunks[1], active);
+                }
             }
         }
         Some(Overlay::SearchPapers {
@@ -619,24 +670,31 @@ fn draw(frame: &mut ratatui::Frame, app: &mut App) {
             Some(Overlay::PaperDetail {
                 annotation_focus,
                 prompt,
+                reader,
                 ..
             }),
             _,
-        ) => match (prompt, annotation_focus) {
-            (Some(p), _) => match p {
-                AnnotationPrompt::DeleteConfirm { .. } => "y: confirm | n/Esc: cancel",
-                AnnotationPrompt::Create { .. } => {
-                    "Enter: next/submit | Backspace: delete char | Esc: cancel"
+        ) => {
+            if *reader {
+                "Esc/R: leave reader | J/K: hop highlight | D: download"
+            } else {
+                match (prompt, annotation_focus) {
+                    (Some(p), _) => match p {
+                        AnnotationPrompt::DeleteConfirm { .. } => "y: confirm | n/Esc: cancel",
+                        AnnotationPrompt::Create { .. } => {
+                            "Enter: next/submit | Backspace: delete char | Esc: cancel"
+                        }
+                        _ => "Enter: submit | Backspace: delete char | Esc: cancel",
+                    },
+                    (None, Some(_)) => {
+                        "Esc: leave focus | j/k: navigate | n: new | e: edit | r: reply | d: delete"
+                    }
+                    (None, None) => {
+                        "Esc/q: back | j/k: scroll | d/u: page | D: download | n: new | J: focus | R: reader"
+                    }
                 }
-                _ => "Enter: submit | Backspace: delete char | Esc: cancel",
-            },
-            (None, Some(_)) => {
-                "Esc: leave focus | j/k: navigate | n: new | e: edit | r: reply | d: delete"
             }
-            (None, None) => {
-                "Esc/q: back | j/k: scroll | d/u: page | D: download | n: new annotation | J: focus annotations"
-            }
-        },
+        }
         (Some(Overlay::SearchPapers { .. }), _) => {
             "Esc/q: back | j/k: navigate | Enter: open paper"
         }

--- a/crates/scitadel-tui/src/app.rs
+++ b/crates/scitadel-tui/src/app.rs
@@ -17,7 +17,8 @@ use tokio::sync::mpsc;
 
 use crate::data::DataStore;
 use crate::tasks::{Task, TaskUpdate, spawn_download_paper};
-use crate::views::{detail, papers, questions, searches, tasks as tasks_view};
+use crate::views::annotation_prompt::{AnnotationPrompt, PromptCommit, PromptSubmission};
+use crate::views::{annotation_prompt, detail, papers, questions, searches, tasks as tasks_view};
 use crate::widgets::status_bar;
 
 /// Active tab in the TUI.
@@ -59,8 +60,22 @@ impl Tab {
 /// Overlay view shown on top of the current tab.
 #[derive(Debug, Clone)]
 pub enum Overlay {
-    PaperDetail { paper_id: String, scroll: u16 },
-    SearchPapers { search_id: String, selected: usize },
+    PaperDetail {
+        paper_id: String,
+        scroll: u16,
+        /// `None` = scroll mode; `Some(i)` = focused on annotation `i`
+        /// in the paper's annotation list. Set by `J` (or `Tab` while
+        /// in PaperDetail) and cleared by `Esc`. Required so e/d/r
+        /// have a target.
+        annotation_focus: Option<usize>,
+        /// Active n/e/r/d prompt overlay. Drawn on top of the detail
+        /// view; eats keystrokes until submitted or cancelled.
+        prompt: Option<AnnotationPrompt>,
+    },
+    SearchPapers {
+        search_id: String,
+        selected: usize,
+    },
 }
 
 /// Main application state.
@@ -194,21 +209,7 @@ impl App {
 
     fn handle_overlay_key(&mut self, code: KeyCode) {
         match self.overlay {
-            Some(Overlay::PaperDetail {
-                ref paper_id,
-                ref mut scroll,
-            }) => match code {
-                KeyCode::Esc | KeyCode::Char('q') => self.overlay = None,
-                KeyCode::Char('j') | KeyCode::Down => *scroll = scroll.saturating_add(1),
-                KeyCode::Char('k') | KeyCode::Up => *scroll = scroll.saturating_sub(1),
-                KeyCode::Char('d') => *scroll = scroll.saturating_add(10),
-                KeyCode::Char('u') => *scroll = scroll.saturating_sub(10),
-                KeyCode::Char('D') => {
-                    let paper_id = paper_id.clone();
-                    self.queue_download(&paper_id);
-                }
-                _ => {}
-            },
+            Some(Overlay::PaperDetail { .. }) => self.handle_paper_detail_key(code),
             Some(Overlay::SearchPapers {
                 ref search_id,
                 ref mut selected,
@@ -235,6 +236,8 @@ impl App {
                         self.overlay = Some(Overlay::PaperDetail {
                             paper_id: paper.id.as_str().to_string(),
                             scroll: 0,
+                            annotation_focus: None,
+                            prompt: None,
                         });
                     }
                 }
@@ -255,6 +258,156 @@ impl App {
             self.unpaywall_email.clone(),
             self.papers_dir.clone(),
         );
+    }
+
+    /// Routes a key inside the PaperDetail overlay through three layers:
+    /// (1) an active prompt, (2) annotation-focus mode, (3) plain
+    /// scroll mode. Each layer eats its own keys and falls through
+    /// otherwise.
+    fn handle_paper_detail_key(&mut self, code: KeyCode) {
+        let Some(Overlay::PaperDetail {
+            paper_id,
+            scroll,
+            annotation_focus,
+            prompt,
+        }) = self.overlay.as_mut()
+        else {
+            return;
+        };
+
+        // Layer 1: an active prompt eats every keystroke.
+        if prompt.is_some() {
+            let submission = step_prompt(prompt, code);
+            if let Some(s) = submission {
+                self.dispatch_submission(s);
+            }
+            return;
+        }
+
+        // Layer 2: annotation focus mode (e/d/r operate on a focused row).
+        if let Some(focus) = annotation_focus {
+            let pid = paper_id.clone();
+            let annotations = self
+                .data
+                .load_annotations_for_paper(&pid)
+                .unwrap_or_default();
+            if annotations.is_empty() {
+                *annotation_focus = None;
+            } else {
+                let count = annotations.len();
+                match code {
+                    KeyCode::Esc => *annotation_focus = None,
+                    KeyCode::Char('j') | KeyCode::Down => {
+                        *focus = (*focus + 1).min(count - 1);
+                    }
+                    KeyCode::Char('k') | KeyCode::Up => {
+                        *focus = focus.saturating_sub(1);
+                    }
+                    KeyCode::Char('e') => {
+                        let target = &annotations[*focus];
+                        *prompt = Some(AnnotationPrompt::edit(
+                            target.id.as_str(),
+                            target.note.clone(),
+                        ));
+                    }
+                    KeyCode::Char('r') => {
+                        let target = &annotations[*focus];
+                        // Replies anchor to the root; if the focused row is
+                        // already a reply, attach the new reply to its root.
+                        let parent = target
+                            .parent_id
+                            .as_ref()
+                            .map_or(target.id.as_str(), |p| p.as_str());
+                        *prompt = Some(AnnotationPrompt::reply(parent));
+                    }
+                    KeyCode::Char('d') => {
+                        *prompt = Some(AnnotationPrompt::delete_confirm(
+                            annotations[*focus].id.as_str(),
+                        ));
+                    }
+                    KeyCode::Char('n') => {
+                        *prompt = Some(AnnotationPrompt::create());
+                    }
+                    _ => {}
+                }
+                return;
+            }
+        }
+
+        // Layer 3: scroll mode.
+        match code {
+            KeyCode::Esc | KeyCode::Char('q') => self.overlay = None,
+            KeyCode::Char('j') | KeyCode::Down => *scroll = scroll.saturating_add(1),
+            KeyCode::Char('k') | KeyCode::Up => *scroll = scroll.saturating_sub(1),
+            KeyCode::Char('d') => *scroll = scroll.saturating_add(10),
+            KeyCode::Char('u') => *scroll = scroll.saturating_sub(10),
+            KeyCode::Char('D') => {
+                let pid = paper_id.clone();
+                self.queue_download(&pid);
+            }
+            KeyCode::Char('n') => {
+                *prompt = Some(AnnotationPrompt::create());
+            }
+            KeyCode::Char('J') => {
+                // Enter annotation focus mode if the paper has any.
+                let pid = paper_id.clone();
+                let count = self
+                    .data
+                    .load_annotations_for_paper(&pid)
+                    .map_or(0, |a| a.len());
+                if count > 0 {
+                    *annotation_focus = Some(0);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Translate a prompt submission into the matching repository call
+    /// and reconcile UI state afterwards (e.g. clamp annotation focus
+    /// when a delete shrinks the list).
+    fn dispatch_submission(&mut self, submission: PromptSubmission) {
+        let Some(Overlay::PaperDetail {
+            paper_id,
+            annotation_focus,
+            ..
+        }) = self.overlay.as_mut()
+        else {
+            return;
+        };
+        let pid = paper_id.clone();
+        let reader = self.reader.clone();
+        match submission {
+            PromptSubmission::Create { quote, note } => {
+                let _ = self
+                    .data
+                    .create_root_annotation(&pid, &quote, &note, &reader);
+            }
+            PromptSubmission::Edit {
+                annotation_id,
+                note,
+            } => {
+                let _ = self.data.update_annotation_note(&annotation_id, &note);
+            }
+            PromptSubmission::Reply { parent_id, note } => {
+                let _ = self.data.reply_annotation(&parent_id, &note, &reader);
+            }
+            PromptSubmission::Delete { annotation_id } => {
+                let _ = self.data.delete_annotation(&annotation_id);
+                // Keep focus inside the new (smaller) list.
+                if let Some(focus) = annotation_focus {
+                    let new_count = self
+                        .data
+                        .load_annotations_for_paper(&pid)
+                        .map_or(0, |a| a.len());
+                    if new_count == 0 {
+                        *annotation_focus = None;
+                    } else if *focus >= new_count {
+                        *focus = new_count - 1;
+                    }
+                }
+            }
+        }
     }
 
     fn handle_tab_key(&mut self, code: KeyCode) {
@@ -297,6 +450,8 @@ impl App {
                             self.overlay = Some(Overlay::PaperDetail {
                                 paper_id: paper.id.as_str().to_string(),
                                 scroll: 0,
+                                annotation_focus: None,
+                                prompt: None,
                             });
                         }
                     }
@@ -409,8 +564,23 @@ fn draw(frame: &mut ratatui::Frame, app: &mut App) {
     frame.render_widget(tabs, chunks[0]);
 
     match &app.overlay {
-        Some(Overlay::PaperDetail { paper_id, scroll }) => {
-            detail::draw(frame, chunks[1], &app.data, paper_id, *scroll);
+        Some(Overlay::PaperDetail {
+            paper_id,
+            scroll,
+            annotation_focus,
+            prompt,
+        }) => {
+            detail::draw(
+                frame,
+                chunks[1],
+                &app.data,
+                paper_id,
+                *scroll,
+                *annotation_focus,
+            );
+            if let Some(active) = prompt {
+                annotation_prompt::draw_overlay(frame, chunks[1], active);
+            }
         }
         Some(Overlay::SearchPapers {
             search_id,
@@ -445,9 +615,28 @@ fn draw(frame: &mut ratatui::Frame, app: &mut App) {
     }
 
     let help_text = match (&app.overlay, app.tab) {
-        (Some(Overlay::PaperDetail { .. }), _) => {
-            "Esc/q: back | j/k: scroll | d/u: page | D: download"
-        }
+        (
+            Some(Overlay::PaperDetail {
+                annotation_focus,
+                prompt,
+                ..
+            }),
+            _,
+        ) => match (prompt, annotation_focus) {
+            (Some(p), _) => match p {
+                AnnotationPrompt::DeleteConfirm { .. } => "y: confirm | n/Esc: cancel",
+                AnnotationPrompt::Create { .. } => {
+                    "Enter: next/submit | Backspace: delete char | Esc: cancel"
+                }
+                _ => "Enter: submit | Backspace: delete char | Esc: cancel",
+            },
+            (None, Some(_)) => {
+                "Esc: leave focus | j/k: navigate | n: new | e: edit | r: reply | d: delete"
+            }
+            (None, None) => {
+                "Esc/q: back | j/k: scroll | d/u: page | D: download | n: new annotation | J: focus annotations"
+            }
+        },
         (Some(Overlay::SearchPapers { .. }), _) => {
             "Esc/q: back | j/k: navigate | Enter: open paper"
         }
@@ -455,6 +644,52 @@ fn draw(frame: &mut ratatui::Frame, app: &mut App) {
         (None, _) => "Tab/Shift-Tab: switch tabs | j/k: navigate | Enter: select | q: quit",
     };
     status_bar::draw(frame, chunks[3], help_text, app.offline);
+}
+
+/// Step the active annotation prompt by one keystroke. Mutates the
+/// `prompt` slot (clears it on cancel/submit, advances stage on Enter
+/// in a Create's Quote stage). Returns `Some(submission)` when the
+/// prompt resolved to a write the app should dispatch.
+fn step_prompt(prompt: &mut Option<AnnotationPrompt>, code: KeyCode) -> Option<PromptSubmission> {
+    let active = prompt.as_mut()?;
+    match code {
+        KeyCode::Esc => {
+            *prompt = None;
+            None
+        }
+        KeyCode::Enter => match active.submit() {
+            PromptCommit::AdvanceStage(next) => {
+                *prompt = Some(next);
+                None
+            }
+            PromptCommit::Submit(s) => {
+                *prompt = None;
+                Some(s)
+            }
+            PromptCommit::Cancel => {
+                *prompt = None;
+                None
+            }
+        },
+        KeyCode::Backspace => {
+            active.backspace();
+            None
+        }
+        KeyCode::Char(ch) => {
+            // Confirm prompts route y/n through their own handler.
+            if let Some(commit) = active.confirm(ch) {
+                let result = match commit {
+                    PromptCommit::Submit(s) => Some(s),
+                    PromptCommit::Cancel | PromptCommit::AdvanceStage(_) => None,
+                };
+                *prompt = None;
+                return result;
+            }
+            active.push_char(ch);
+            None
+        }
+        _ => None,
+    }
 }
 
 /// One-shot check: is the internet reachable? Uses a 3s HEAD to a stable

--- a/crates/scitadel-tui/src/app.rs
+++ b/crates/scitadel-tui/src/app.rs
@@ -96,6 +96,9 @@ pub struct App {
     pub question_selected: usize,
 
     pub tasks: Vec<Task>,
+    /// Last `TuiState` written to the DB, used by `publish_tui_state`
+    /// to skip redundant UPDATEs when the user hasn't moved (#122).
+    pub last_published_state: Option<scitadel_db::sqlite::TuiState>,
     pub unpaywall_email: String,
     pub papers_dir: PathBuf,
     pub show_institutional_hint: bool,
@@ -139,6 +142,7 @@ impl App {
             paper_selected: 0,
             question_selected: 0,
             tasks: Vec::new(),
+            last_published_state: None,
             unpaywall_email,
             papers_dir,
             show_institutional_hint,
@@ -172,6 +176,72 @@ impl App {
         self.drain_task_updates();
         self.drain_offline();
         self.flush_completed_tasks();
+        self.publish_tui_state();
+    }
+
+    /// Write the TUI's current selection to the singleton `tui_state`
+    /// row so an MCP-side agent can ask "what's the user looking at?"
+    /// (#122). Runs every drain pass; only writes if the *selection*
+    /// (not the timestamp) changed since last publish — otherwise the
+    /// TUI would emit ~10 UPDATEs/sec on a static screen.
+    fn publish_tui_state(&mut self) {
+        let snapshot = self.current_tui_state();
+        if let Some(prev) = &self.last_published_state
+            && tui_state_key(prev) == tui_state_key(&snapshot)
+        {
+            return;
+        }
+        if let Err(e) = self.data.publish_tui_state(&snapshot) {
+            tracing::warn!(error = %e, "failed to publish TUI state");
+            return;
+        }
+        self.last_published_state = Some(snapshot);
+    }
+
+    fn current_tui_state(&self) -> scitadel_db::sqlite::TuiState {
+        let tab = match self.tab {
+            Tab::Searches => "Searches",
+            Tab::Papers => "Papers",
+            Tab::Questions => "Questions",
+        };
+        let (paper_id, search_id, annotation_id) = match &self.overlay {
+            Some(Overlay::PaperDetail {
+                paper_id,
+                annotation_focus,
+                ..
+            }) => {
+                // Resolve the focused annotation's id only when the
+                // user is actively in focus mode — otherwise leave None
+                // so agents don't think the user is "on" an annotation
+                // they happen to be scrolling past.
+                let ann_id = annotation_focus.and_then(|i| {
+                    self.data
+                        .load_annotations_for_paper(paper_id)
+                        .ok()
+                        .and_then(|anns| anns.get(i).map(|a| a.id.as_str().to_string()))
+                });
+                (Some(paper_id.clone()), None, ann_id)
+            }
+            Some(Overlay::SearchPapers { search_id, .. }) => (None, Some(search_id.clone()), None),
+            None => (None, None, None),
+        };
+        // Question id only when the user is actually on the Questions tab.
+        let question_id = if matches!(self.tab, Tab::Questions) {
+            self.data.load_questions().ok().and_then(|qs| {
+                qs.get(self.question_selected)
+                    .map(|q| q.id.as_str().to_string())
+            })
+        } else {
+            None
+        };
+        scitadel_db::sqlite::TuiState {
+            tab: tab.to_string(),
+            paper_id,
+            search_id,
+            question_id,
+            annotation_id,
+            updated_at: chrono::Utc::now().to_rfc3339(),
+        }
     }
 
     fn drain_task_updates(&mut self) {
@@ -607,6 +677,21 @@ impl App {
             }
         }
     }
+}
+
+/// Identity of a `TuiState` for dedup purposes — everything except
+/// `updated_at`. Two snapshots with the same key represent the same
+/// user-visible selection so we skip the redundant DB write (#122).
+fn tui_state_key(
+    s: &scitadel_db::sqlite::TuiState,
+) -> (&str, Option<&str>, Option<&str>, Option<&str>, Option<&str>) {
+    (
+        s.tab.as_str(),
+        s.paper_id.as_deref(),
+        s.search_id.as_deref(),
+        s.question_id.as_deref(),
+        s.annotation_id.as_deref(),
+    )
 }
 
 pub fn run(

--- a/crates/scitadel-tui/src/app.rs
+++ b/crates/scitadel-tui/src/app.rs
@@ -16,7 +16,7 @@ use ratatui::widgets::Tabs;
 use tokio::sync::mpsc;
 
 use crate::data::DataStore;
-use crate::tasks::{Task, TaskUpdate, spawn_download_paper};
+use crate::tasks::{Task, TaskKind, TaskStatus, TaskUpdate, spawn_download_paper};
 use crate::views::annotation_prompt::{AnnotationPrompt, PromptCommit, PromptSubmission};
 use crate::views::{annotation_prompt, detail, papers, questions, searches, tasks as tasks_view};
 use crate::widgets::status_bar;
@@ -183,10 +183,68 @@ impl App {
                     }
                 }
                 TaskUpdate::Status { id, status } => {
+                    // Persist Done/Failed back to papers.download_status
+                    // (#112) before mutating the in-memory task — borrow
+                    // the matching task once to read the paper_id.
+                    let paper_id = self
+                        .tasks
+                        .iter()
+                        .find(|t| t.id == id)
+                        .map(|t| match &t.kind {
+                            TaskKind::Download { paper_id, .. } => paper_id.clone(),
+                        });
+                    if let Some(pid) = paper_id {
+                        self.persist_download_outcome(&pid, &status);
+                    }
                     if let Some(t) = self.tasks.iter_mut().find(|t| t.id == id) {
                         t.status = status;
                     }
                 }
+            }
+        }
+    }
+
+    /// Set of paper IDs that have a Queued or Running download task.
+    /// Used by the Papers table to render the `↻` in-flight symbol.
+    fn downloading_paper_ids(&self) -> std::collections::HashSet<String> {
+        self.tasks
+            .iter()
+            .filter(|t| matches!(t.status, TaskStatus::Queued | TaskStatus::Running))
+            .map(|t| {
+                let TaskKind::Download { paper_id, .. } = &t.kind;
+                paper_id.clone()
+            })
+            .collect()
+    }
+
+    fn persist_download_outcome(&self, paper_id: &str, status: &TaskStatus) {
+        use scitadel_adapters::download::AccessStatus;
+        use scitadel_core::models::DownloadStatus;
+        let outcome = match status {
+            TaskStatus::Done { path, access, .. } => {
+                let download_status = match access {
+                    AccessStatus::FullText => DownloadStatus::Downloaded,
+                    AccessStatus::Abstract | AccessStatus::Paywall | AccessStatus::Unknown => {
+                        DownloadStatus::Paywall
+                    }
+                };
+                Some((path.to_string_lossy().into_owned(), download_status))
+            }
+            TaskStatus::Failed(_) => Some((String::new(), DownloadStatus::Failed)),
+            TaskStatus::Queued | TaskStatus::Running => None,
+        };
+        if let Some((path, ds)) = outcome {
+            let path_arg = if matches!(ds, DownloadStatus::Failed) {
+                None
+            } else {
+                Some(path.as_str())
+            };
+            if let Err(e) = self.data.record_download_outcome(paper_id, path_arg, ds) {
+                tracing::warn!(
+                    paper_id,
+                    error = %e,
+                    "failed to persist download outcome"
+                );
             }
         }
     }
@@ -644,6 +702,7 @@ fn draw(frame: &mut ratatui::Frame, app: &mut App) {
                 search_id,
                 *selected,
                 &app.starred,
+                &app.downloading_paper_ids(),
             );
         }
         None => match app.tab {
@@ -654,6 +713,7 @@ fn draw(frame: &mut ratatui::Frame, app: &mut App) {
                 &app.data,
                 app.paper_selected,
                 &app.starred,
+                &app.downloading_paper_ids(),
             ),
             Tab::Questions => {
                 questions::draw(frame, chunks[1], &app.data, app.question_selected);

--- a/crates/scitadel-tui/src/data.rs
+++ b/crates/scitadel-tui/src/data.rs
@@ -3,7 +3,10 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 
-use scitadel_core::models::{Annotation, Assessment, Paper, ResearchQuestion, Search, SearchTerm};
+use scitadel_core::models::{
+    Anchor, AnchorStatus, Annotation, Assessment, Paper, PaperId, ResearchQuestion, Search,
+    SearchTerm,
+};
 use scitadel_core::ports::{
     AssessmentRepository, PaperRepository, QuestionRepository, SearchRepository,
 };
@@ -80,5 +83,63 @@ impl DataStore {
     /// Toggle the starred flag for a paper and return the new value.
     pub fn toggle_starred(&self, paper_id: &str, reader: &str) -> Result<bool> {
         Ok(SqlitePaperStateRepository::new(self.db.clone()).toggle_starred(paper_id, reader)?)
+    }
+
+    /// Create a root annotation anchored to a quoted passage. Anchors
+    /// from the TUI carry only the quote (no offsets), so the resolver
+    /// will substring-match on next paper-open.
+    pub fn create_root_annotation(
+        &self,
+        paper_id: &str,
+        quote: &str,
+        note: &str,
+        author: &str,
+    ) -> Result<String> {
+        let anchor = Anchor {
+            quote: Some(quote.to_string()),
+            status: AnchorStatus::Ok,
+            ..Anchor::default()
+        };
+        let ann = Annotation::new_root(
+            PaperId::from(paper_id),
+            author.to_string(),
+            note.to_string(),
+            anchor,
+        );
+        SqliteAnnotationRepository::new(self.db.clone()).create(&ann)?;
+        Ok(ann.id.as_str().to_string())
+    }
+
+    /// Reply to an existing annotation; inherits paper_id + question_id
+    /// from the parent.
+    pub fn reply_annotation(&self, parent_id: &str, note: &str, author: &str) -> Result<String> {
+        let repo = SqliteAnnotationRepository::new(self.db.clone());
+        let parent = repo
+            .get(parent_id)?
+            .with_context(|| format!("annotation {parent_id} not found"))?;
+        let reply = Annotation::new_reply(&parent, author.to_string(), note.to_string());
+        repo.create(&reply)?;
+        Ok(reply.id.as_str().to_string())
+    }
+
+    /// Update the note body of an existing annotation; preserves color +
+    /// tags as-is.
+    pub fn update_annotation_note(&self, annotation_id: &str, note: &str) -> Result<()> {
+        let repo = SqliteAnnotationRepository::new(self.db.clone());
+        let existing = repo
+            .get(annotation_id)?
+            .with_context(|| format!("annotation {annotation_id} not found"))?;
+        repo.update_note(
+            annotation_id,
+            note,
+            existing.color.as_deref(),
+            &existing.tags,
+        )?;
+        Ok(())
+    }
+
+    /// Soft-delete an annotation (tombstone — replies stay readable).
+    pub fn delete_annotation(&self, annotation_id: &str) -> Result<()> {
+        Ok(SqliteAnnotationRepository::new(self.db.clone()).soft_delete(annotation_id)?)
     }
 }

--- a/crates/scitadel-tui/src/data.rs
+++ b/crates/scitadel-tui/src/data.rs
@@ -142,4 +142,17 @@ impl DataStore {
     pub fn delete_annotation(&self, annotation_id: &str) -> Result<()> {
         Ok(SqliteAnnotationRepository::new(self.db.clone()).soft_delete(annotation_id)?)
     }
+
+    /// Persist the outcome of a download attempt for the Papers-table
+    /// state column (#112). `local_path` is the absolute path to the
+    /// saved file on success, `None` on failure.
+    pub fn record_download_outcome(
+        &self,
+        paper_id: &str,
+        local_path: Option<&str>,
+        status: scitadel_core::models::DownloadStatus,
+    ) -> Result<()> {
+        let (paper_repo, _, _, _, _) = self.db.repositories();
+        Ok(paper_repo.update_download_state(paper_id, local_path, status)?)
+    }
 }

--- a/crates/scitadel-tui/src/data.rs
+++ b/crates/scitadel-tui/src/data.rs
@@ -155,4 +155,10 @@ impl DataStore {
         let (paper_repo, _, _, _, _) = self.db.repositories();
         Ok(paper_repo.update_download_state(paper_id, local_path, status)?)
     }
+
+    /// Persist the TUI's current selection so an MCP-side agent can
+    /// query it (#122).
+    pub fn publish_tui_state(&self, state: &scitadel_db::sqlite::TuiState) -> Result<()> {
+        Ok(scitadel_db::sqlite::SqliteTuiStateRepository::new(self.db.clone()).set(state)?)
+    }
 }

--- a/crates/scitadel-tui/src/tasks.rs
+++ b/crates/scitadel-tui/src/tasks.rs
@@ -1,15 +1,27 @@
 use std::path::PathBuf;
+use std::time::{Duration, Instant};
 
 use scitadel_adapters::download::{AccessStatus, DownloadFormat, PaperDownloader};
 use scitadel_core::models::Paper;
 use tokio::sync::mpsc::UnboundedSender;
 use uuid::Uuid;
 
+/// How long a `Done` task lingers in the panel after completing before
+/// it auto-flushes. Long enough for the user to see the result, short
+/// enough that it doesn't crowd out new work.
+pub const DONE_LINGER: Duration = Duration::from_secs(5);
+/// `Failed` tasks linger longer so the user has time to read the error.
+pub const FAILED_LINGER: Duration = Duration::from_secs(30);
+
 #[derive(Debug, Clone)]
 pub struct Task {
     pub id: Uuid,
     pub kind: TaskKind,
     pub status: TaskStatus,
+    /// Wall-clock instant when the task entered a terminal state
+    /// (`Done` / `Failed`). `None` while it's still `Queued` or
+    /// `Running`. Drives the auto-flush policy in `App::flush_completed_tasks`.
+    pub terminal_at: Option<Instant>,
 }
 
 #[derive(Debug, Clone)]
@@ -45,6 +57,22 @@ pub enum TaskUpdate {
     Status { id: Uuid, status: TaskStatus },
 }
 
+/// Drop terminal-state tasks whose linger window has elapsed (#113).
+/// Pure helper called from `App::flush_completed_tasks` so the policy
+/// is unit-testable without constructing the full TUI.
+pub fn retain_recent_terminal(tasks: &mut Vec<Task>, now: Instant) {
+    tasks.retain(|t| match (&t.status, t.terminal_at) {
+        (TaskStatus::Done { .. }, Some(at)) => now.duration_since(at) < DONE_LINGER,
+        (TaskStatus::Failed(_), Some(at)) => now.duration_since(at) < FAILED_LINGER,
+        _ => true,
+    });
+}
+
+/// Drop every Done/Failed task immediately. Bound to `c` (#113).
+pub fn clear_terminal(tasks: &mut Vec<Task>) {
+    tasks.retain(|t| matches!(t.status, TaskStatus::Queued | TaskStatus::Running));
+}
+
 /// Spawn a download for a full `Paper` (uses all available identifiers).
 pub fn spawn_download_paper(
     tx: UnboundedSender<TaskUpdate>,
@@ -69,6 +97,7 @@ pub fn spawn_download_paper(
             title: paper.title.clone(),
         },
         status: TaskStatus::Queued,
+        terminal_at: None,
     };
     let _ = tx.send(TaskUpdate::New(task));
 
@@ -93,4 +122,90 @@ pub fn spawn_download_paper(
     });
 
     id
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn t(status: TaskStatus, terminal_at: Option<Instant>) -> Task {
+        Task {
+            id: Uuid::new_v4(),
+            kind: TaskKind::Download {
+                paper_id: "p".into(),
+                ref_id: "ref".into(),
+                title: "title".into(),
+            },
+            status,
+            terminal_at,
+        }
+    }
+
+    fn done() -> TaskStatus {
+        TaskStatus::Done {
+            path: PathBuf::from("/tmp/x"),
+            format: DownloadFormat::Pdf,
+            access: AccessStatus::FullText,
+            publisher_url: None,
+        }
+    }
+
+    #[test]
+    fn retain_keeps_active_tasks() {
+        let now = Instant::now();
+        let mut tasks = vec![
+            t(TaskStatus::Queued, None),
+            t(TaskStatus::Running, None),
+            t(done(), Some(now)),
+        ];
+        retain_recent_terminal(&mut tasks, now);
+        assert_eq!(
+            tasks.len(),
+            3,
+            "fresh terminal task stays alongside actives"
+        );
+    }
+
+    #[test]
+    fn retain_drops_done_after_linger() {
+        // Use a fake "now" that's well past Instant::now so subtraction is safe.
+        let now = Instant::now() + Duration::from_mins(1);
+        let stale = Instant::now();
+        let mut tasks = vec![t(TaskStatus::Running, None), t(done(), Some(stale))];
+        retain_recent_terminal(&mut tasks, now);
+        assert_eq!(tasks.len(), 1, "stale Done task is flushed");
+        assert!(matches!(tasks[0].status, TaskStatus::Running));
+    }
+
+    #[test]
+    fn retain_keeps_failed_longer_than_done() {
+        // 10s past mid: past DONE_LINGER (5s) but before FAILED_LINGER (30s).
+        let mid = Instant::now();
+        let now = mid + Duration::from_secs(10);
+        let mut tasks = vec![
+            t(done(), Some(mid)),
+            t(TaskStatus::Failed("oops".into()), Some(mid)),
+        ];
+        retain_recent_terminal(&mut tasks, now);
+        assert_eq!(tasks.len(), 1, "Done flushed but Failed stays");
+        assert!(matches!(tasks[0].status, TaskStatus::Failed(_)));
+    }
+
+    #[test]
+    fn clear_drops_all_terminal_keeps_active() {
+        let now = Instant::now();
+        let mut tasks = vec![
+            t(TaskStatus::Queued, None),
+            t(TaskStatus::Running, None),
+            t(done(), Some(now)),
+            t(TaskStatus::Failed("x".into()), Some(now)),
+        ];
+        clear_terminal(&mut tasks);
+        assert_eq!(tasks.len(), 2);
+        assert!(
+            tasks
+                .iter()
+                .all(|t| matches!(t.status, TaskStatus::Queued | TaskStatus::Running))
+        );
+    }
 }

--- a/crates/scitadel-tui/src/tasks.rs
+++ b/crates/scitadel-tui/src/tasks.rs
@@ -15,7 +15,13 @@ pub struct Task {
 #[derive(Debug, Clone)]
 pub enum TaskKind {
     /// `ref_id` is the best identifier we have to show the user (DOI, arxiv id, or paper UUID prefix).
-    Download { ref_id: String, title: String },
+    /// `paper_id` lets the drain loop persist the outcome back to the
+    /// `papers.download_status` column (#112).
+    Download {
+        paper_id: String,
+        ref_id: String,
+        title: String,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -58,6 +64,7 @@ pub fn spawn_download_paper(
     let task = Task {
         id,
         kind: TaskKind::Download {
+            paper_id: paper.id.as_str().to_string(),
             ref_id,
             title: paper.title.clone(),
         },

--- a/crates/scitadel-tui/src/views/annotation_prompt.rs
+++ b/crates/scitadel-tui/src/views/annotation_prompt.rs
@@ -1,0 +1,450 @@
+//! In-TUI annotation create / edit / reply / delete prompt state.
+//!
+//! State machine + a small `draw_overlay` renderer. The state machine
+//! is pure (no I/O); the app drives it from key events in
+//! `Overlay::PaperDetail` and asks `submit()` / `confirm()` for the
+//! next side effect.
+//!
+//! Iter 3b of #49 (#92): the n / e / d / r keybindings on the paper
+//! detail overlay. Visual-mode char-range selection and full $EDITOR
+//! integration are out of scope; the note buffer is edited inline.
+
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
+
+/// Which buffer accepts keystrokes when a Create prompt is open.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CreateStage {
+    Quote,
+    Note,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AnnotationPrompt {
+    Create {
+        stage: CreateStage,
+        quote_buf: String,
+        note_buf: String,
+    },
+    Edit {
+        annotation_id: String,
+        note_buf: String,
+    },
+    Reply {
+        parent_id: String,
+        note_buf: String,
+    },
+    DeleteConfirm {
+        annotation_id: String,
+    },
+}
+
+/// What happens when the user submits the prompt. The app translates
+/// each variant into the matching repository call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PromptCommit {
+    /// Open a new prompt (e.g. Create stage transition Quote → Note).
+    AdvanceStage(AnnotationPrompt),
+    /// Submit the result; caller dispatches to the DB.
+    Submit(PromptSubmission),
+    /// User cancelled or nothing to do.
+    Cancel,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PromptSubmission {
+    Create { quote: String, note: String },
+    Edit { annotation_id: String, note: String },
+    Reply { parent_id: String, note: String },
+    Delete { annotation_id: String },
+}
+
+impl AnnotationPrompt {
+    /// Start a Create prompt at the Quote stage.
+    #[must_use]
+    pub fn create() -> Self {
+        Self::Create {
+            stage: CreateStage::Quote,
+            quote_buf: String::new(),
+            note_buf: String::new(),
+        }
+    }
+
+    /// Start an Edit prompt pre-filled with the existing note body.
+    #[must_use]
+    pub fn edit(annotation_id: impl Into<String>, current_note: impl Into<String>) -> Self {
+        Self::Edit {
+            annotation_id: annotation_id.into(),
+            note_buf: current_note.into(),
+        }
+    }
+
+    /// Start a Reply prompt against a parent annotation.
+    #[must_use]
+    pub fn reply(parent_id: impl Into<String>) -> Self {
+        Self::Reply {
+            parent_id: parent_id.into(),
+            note_buf: String::new(),
+        }
+    }
+
+    /// Start a Delete-confirmation prompt for an annotation.
+    #[must_use]
+    pub fn delete_confirm(annotation_id: impl Into<String>) -> Self {
+        Self::DeleteConfirm {
+            annotation_id: annotation_id.into(),
+        }
+    }
+
+    /// Append a character to the active buffer (whichever the prompt
+    /// is currently editing). Confirm prompts ignore character input
+    /// other than y/n/Esc; the app handles those at the key layer.
+    pub fn push_char(&mut self, ch: char) {
+        match self {
+            Self::Create {
+                stage, quote_buf, ..
+            } if *stage == CreateStage::Quote => quote_buf.push(ch),
+            Self::Create { note_buf, .. }
+            | Self::Edit { note_buf, .. }
+            | Self::Reply { note_buf, .. } => {
+                note_buf.push(ch);
+            }
+            Self::DeleteConfirm { .. } => {}
+        }
+    }
+
+    /// Pop the last character from the active buffer.
+    pub fn backspace(&mut self) {
+        match self {
+            Self::Create {
+                stage, quote_buf, ..
+            } if *stage == CreateStage::Quote => {
+                quote_buf.pop();
+            }
+            Self::Create { note_buf, .. }
+            | Self::Edit { note_buf, .. }
+            | Self::Reply { note_buf, .. } => {
+                note_buf.pop();
+            }
+            Self::DeleteConfirm { .. } => {}
+        }
+    }
+
+    /// Handle Enter. Either advances the stage of a Create prompt,
+    /// returns a Submit with whatever the user typed, or cancels if
+    /// the buffer is empty (so an empty Enter doesn't write a blank
+    /// note).
+    #[must_use]
+    pub fn submit(&self) -> PromptCommit {
+        match self {
+            Self::Create {
+                stage: CreateStage::Quote,
+                quote_buf,
+                note_buf,
+            } if !quote_buf.trim().is_empty() => PromptCommit::AdvanceStage(Self::Create {
+                stage: CreateStage::Note,
+                quote_buf: quote_buf.clone(),
+                note_buf: note_buf.clone(),
+            }),
+            Self::Create {
+                stage: CreateStage::Note,
+                quote_buf,
+                note_buf,
+            } if !note_buf.trim().is_empty() && !quote_buf.trim().is_empty() => {
+                PromptCommit::Submit(PromptSubmission::Create {
+                    quote: quote_buf.clone(),
+                    note: note_buf.clone(),
+                })
+            }
+            Self::Edit {
+                annotation_id,
+                note_buf,
+            } if !note_buf.trim().is_empty() => PromptCommit::Submit(PromptSubmission::Edit {
+                annotation_id: annotation_id.clone(),
+                note: note_buf.clone(),
+            }),
+            Self::Reply {
+                parent_id,
+                note_buf,
+            } if !note_buf.trim().is_empty() => PromptCommit::Submit(PromptSubmission::Reply {
+                parent_id: parent_id.clone(),
+                note: note_buf.clone(),
+            }),
+            // Empty buffer (or DeleteConfirm) — Enter is a no-op cancel.
+            _ => PromptCommit::Cancel,
+        }
+    }
+
+    /// Handle the y / n keys for a delete confirmation. Returns
+    /// `Some(Submit)` on `y`, `Some(Cancel)` on `n`, `None` otherwise
+    /// so the app can ignore irrelevant keys.
+    #[must_use]
+    pub fn confirm(&self, ch: char) -> Option<PromptCommit> {
+        match self {
+            Self::DeleteConfirm { annotation_id } => match ch {
+                'y' | 'Y' => Some(PromptCommit::Submit(PromptSubmission::Delete {
+                    annotation_id: annotation_id.clone(),
+                })),
+                'n' | 'N' => Some(PromptCommit::Cancel),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    /// Short label for the title bar of the prompt overlay.
+    #[must_use]
+    pub fn title(&self) -> &'static str {
+        match self {
+            Self::Create {
+                stage: CreateStage::Quote,
+                ..
+            } => " New Annotation — quote ",
+            Self::Create {
+                stage: CreateStage::Note,
+                ..
+            } => " New Annotation — note ",
+            Self::Edit { .. } => " Edit Annotation ",
+            Self::Reply { .. } => " Reply ",
+            Self::DeleteConfirm { .. } => " Delete annotation? ",
+        }
+    }
+
+    /// The user-facing text the prompt currently shows in its body.
+    /// For confirms, this is the y/N hint; otherwise the active buffer.
+    #[must_use]
+    pub fn body(&self) -> &str {
+        match self {
+            Self::Create {
+                stage: CreateStage::Quote,
+                quote_buf,
+                ..
+            } => quote_buf,
+            Self::Create {
+                stage: CreateStage::Note,
+                note_buf,
+                ..
+            }
+            | Self::Edit { note_buf, .. }
+            | Self::Reply { note_buf, .. } => note_buf,
+            Self::DeleteConfirm { .. } => "press y to delete, n/Esc to cancel",
+        }
+    }
+}
+
+/// Centred modal renderer. Draws on top of the parent area; the
+/// caller is responsible for painting the background view first so
+/// the modal layers cleanly.
+pub fn draw_overlay(frame: &mut Frame, area: Rect, prompt: &AnnotationPrompt) {
+    let modal = centered_rect(area, 70, 30);
+    frame.render_widget(Clear, modal);
+
+    // Stack: title block / quote summary (Create stage Note only) / body / hint.
+    let inner = Block::default()
+        .title(prompt.title())
+        .borders(Borders::ALL)
+        .style(Style::default().fg(Color::Yellow));
+    let inner_area = modal;
+    frame.render_widget(inner, inner_area);
+
+    // Body area = inside the border, with 1-cell padding.
+    let body_area = Rect {
+        x: inner_area.x + 2,
+        y: inner_area.y + 1,
+        width: inner_area.width.saturating_sub(4),
+        height: inner_area.height.saturating_sub(2),
+    };
+
+    let mut lines: Vec<Line<'_>> = Vec::new();
+    if let AnnotationPrompt::Create {
+        stage: CreateStage::Note,
+        quote_buf,
+        ..
+    } = prompt
+    {
+        lines.push(Line::from(vec![
+            Span::styled("quote: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(format!("\"{quote_buf}\""), Style::default().fg(Color::Cyan)),
+        ]));
+        lines.push(Line::from(""));
+    }
+
+    if let AnnotationPrompt::DeleteConfirm { annotation_id } = prompt {
+        lines.push(Line::from(vec![
+            Span::raw("Delete annotation "),
+            Span::styled(
+                annotation_id.clone(),
+                Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("?"),
+        ]));
+        lines.push(Line::from(""));
+        lines.push(Line::from(prompt.body()));
+    } else {
+        let prompt_label = match prompt {
+            AnnotationPrompt::Create {
+                stage: CreateStage::Quote,
+                ..
+            } => "quoted passage",
+            AnnotationPrompt::Create {
+                stage: CreateStage::Note,
+                ..
+            }
+            | AnnotationPrompt::Edit { .. } => "note body",
+            AnnotationPrompt::Reply { .. } => "reply",
+            AnnotationPrompt::DeleteConfirm { .. } => "",
+        };
+        lines.push(Line::from(vec![
+            Span::styled(
+                format!("{prompt_label}: "),
+                Style::default().fg(Color::DarkGray),
+            ),
+            Span::raw(prompt.body().to_string()),
+            // Trailing block-cursor hint so the user can see the caret.
+            Span::styled("█", Style::default().fg(Color::Yellow)),
+        ]));
+    }
+
+    let para = Paragraph::new(lines).wrap(Wrap { trim: false });
+    frame.render_widget(para, body_area);
+}
+
+fn centered_rect(area: Rect, percent_x: u16, percent_y: u16) -> Rect {
+    let vertical = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage((100 - percent_y) / 2),
+            Constraint::Percentage(percent_y),
+            Constraint::Percentage((100 - percent_y) / 2),
+        ])
+        .split(area);
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(vertical[1])[1]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_prompt_advances_quote_to_note_then_submits() {
+        let mut p = AnnotationPrompt::create();
+        for c in "hello".chars() {
+            p.push_char(c);
+        }
+        // Enter on Quote with non-empty buf advances to Note stage.
+        let next = p.submit();
+        let advanced = match next {
+            PromptCommit::AdvanceStage(a) => a,
+            other => panic!("expected AdvanceStage, got {other:?}"),
+        };
+        match &advanced {
+            AnnotationPrompt::Create {
+                stage: CreateStage::Note,
+                quote_buf,
+                ..
+            } => assert_eq!(quote_buf, "hello"),
+            other => panic!("expected Create at Note, got {other:?}"),
+        }
+
+        let mut p = advanced;
+        for c in "my note".chars() {
+            p.push_char(c);
+        }
+        let submission = match p.submit() {
+            PromptCommit::Submit(s) => s,
+            other => panic!("expected Submit, got {other:?}"),
+        };
+        assert_eq!(
+            submission,
+            PromptSubmission::Create {
+                quote: "hello".into(),
+                note: "my note".into()
+            }
+        );
+    }
+
+    #[test]
+    fn enter_with_empty_buffer_cancels_instead_of_submitting() {
+        let p = AnnotationPrompt::create();
+        assert_eq!(p.submit(), PromptCommit::Cancel);
+
+        let p = AnnotationPrompt::reply("parent-id");
+        assert_eq!(p.submit(), PromptCommit::Cancel);
+    }
+
+    #[test]
+    fn edit_pre_fills_and_submits() {
+        let mut p = AnnotationPrompt::edit("a-1", "old note");
+        // Tweak the buffer.
+        p.backspace();
+        for c in " body".chars() {
+            p.push_char(c);
+        }
+        let submission = match p.submit() {
+            PromptCommit::Submit(s) => s,
+            other => panic!("expected Submit, got {other:?}"),
+        };
+        assert_eq!(
+            submission,
+            PromptSubmission::Edit {
+                annotation_id: "a-1".into(),
+                note: "old not body".into()
+            }
+        );
+    }
+
+    #[test]
+    fn reply_submits_with_parent() {
+        let mut p = AnnotationPrompt::reply("root-id");
+        for c in "agreed".chars() {
+            p.push_char(c);
+        }
+        assert_eq!(
+            p.submit(),
+            PromptCommit::Submit(PromptSubmission::Reply {
+                parent_id: "root-id".into(),
+                note: "agreed".into()
+            })
+        );
+    }
+
+    #[test]
+    fn delete_confirm_only_responds_to_y_n() {
+        let p = AnnotationPrompt::delete_confirm("a-1");
+        assert_eq!(
+            p.confirm('y'),
+            Some(PromptCommit::Submit(PromptSubmission::Delete {
+                annotation_id: "a-1".into()
+            }))
+        );
+        assert_eq!(p.confirm('n'), Some(PromptCommit::Cancel));
+        assert_eq!(p.confirm('Y'), p.confirm('y'));
+        assert_eq!(p.confirm('x'), None);
+    }
+
+    #[test]
+    fn delete_confirm_ignores_text_input() {
+        let mut p = AnnotationPrompt::delete_confirm("a-1");
+        p.push_char('q'); // should be a no-op
+        p.backspace();
+        assert_eq!(p, AnnotationPrompt::delete_confirm("a-1"));
+    }
+
+    #[test]
+    fn whitespace_only_buffer_is_treated_as_empty() {
+        let mut p = AnnotationPrompt::create();
+        p.push_char(' ');
+        p.push_char(' ');
+        assert_eq!(p.submit(), PromptCommit::Cancel);
+    }
+}

--- a/crates/scitadel-tui/src/views/detail.rs
+++ b/crates/scitadel-tui/src/views/detail.rs
@@ -6,7 +6,14 @@ use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
 
 use crate::data::DataStore;
 
-pub fn draw(frame: &mut Frame, area: Rect, data: &DataStore, paper_id: &str, scroll: u16) {
+pub fn draw(
+    frame: &mut Frame,
+    area: Rect,
+    data: &DataStore,
+    paper_id: &str,
+    scroll: u16,
+    annotation_focus: Option<usize>,
+) {
     let Ok(Some(paper)) = data.load_paper(paper_id) else {
         let block = Block::default()
             .title(" Paper Detail ")
@@ -107,8 +114,9 @@ pub fn draw(frame: &mut Frame, area: Rect, data: &DataStore, paper_id: &str, scr
         }
     }
 
-    // Annotations panel — view-only in iter 3. Create/edit happen via MCP
-    // (`create_annotation` etc.) until iter 3b wires in-TUI writes.
+    // Annotations panel. Iter 3b (#92): focused annotation is
+    // highlighted via a leading marker so the user can see what e/d/r
+    // would target.
     let annotations = data
         .load_annotations_for_paper(paper_id)
         .unwrap_or_default();
@@ -118,11 +126,24 @@ pub fn draw(frame: &mut Frame, area: Rect, data: &DataStore, paper_id: &str, scr
             format!("Annotations ({}):", annotations.len()),
             label_style,
         )));
-        for ann in &annotations {
-            let prefix = if ann.is_reply() { "  └ " } else { "  • " };
+        for (idx, ann) in annotations.iter().enumerate() {
+            let is_focused = annotation_focus == Some(idx);
+            let marker = match (ann.is_reply(), is_focused) {
+                (false, true) => "▶ • ",
+                (false, false) => "  • ",
+                (true, true) => "▶ └ ",
+                (true, false) => "  └ ",
+            };
+            let marker_style = if is_focused {
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default()
+            };
             if let Some(quote) = ann.anchor.quote.as_deref() {
                 lines.push(Line::from(vec![
-                    Span::raw(prefix),
+                    Span::styled(marker, marker_style),
                     Span::styled(format!("\"{quote}\" "), Style::default().fg(Color::Cyan)),
                     Span::styled(
                         format!("— {}", ann.anchor.status.as_str()),
@@ -138,7 +159,7 @@ pub fn draw(frame: &mut Frame, area: Rect, data: &DataStore, paper_id: &str, scr
             } else {
                 // Reply — no anchor, just author + note, indented.
                 lines.push(Line::from(vec![
-                    Span::raw(prefix),
+                    Span::styled(marker, marker_style),
                     Span::styled(
                         format!("{}: ", ann.author),
                         Style::default().fg(Color::Yellow),

--- a/crates/scitadel-tui/src/views/mod.rs
+++ b/crates/scitadel-tui/src/views/mod.rs
@@ -2,6 +2,7 @@ pub mod annotation_prompt;
 pub mod detail;
 pub mod papers;
 pub mod questions;
+pub mod reader;
 pub mod searches;
 pub mod tasks;
 pub(crate) mod util;

--- a/crates/scitadel-tui/src/views/mod.rs
+++ b/crates/scitadel-tui/src/views/mod.rs
@@ -1,3 +1,4 @@
+pub mod annotation_prompt;
 pub mod detail;
 pub mod papers;
 pub mod questions;

--- a/crates/scitadel-tui/src/views/papers.rs
+++ b/crates/scitadel-tui/src/views/papers.rs
@@ -5,7 +5,7 @@ use ratatui::layout::{Constraint, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table, TableState};
 
-use scitadel_core::models::Paper;
+use scitadel_core::models::{DownloadStatus, Paper};
 
 use crate::data::DataStore;
 use crate::views::util::truncate;
@@ -16,9 +16,18 @@ pub fn draw(
     data: &DataStore,
     selected: usize,
     starred: &HashSet<String>,
+    downloading: &HashSet<String>,
 ) {
     let papers = data.load_papers(1000, 0).unwrap_or_default();
-    render_paper_table(frame, area, &papers, selected, " Papers ", starred);
+    render_paper_table(
+        frame,
+        area,
+        &papers,
+        selected,
+        " Papers ",
+        starred,
+        downloading,
+    );
 }
 
 pub fn draw_for_search(
@@ -28,13 +37,29 @@ pub fn draw_for_search(
     search_id: &str,
     selected: usize,
     starred: &HashSet<String>,
+    downloading: &HashSet<String>,
 ) {
     let papers = data.load_papers_for_search(search_id).unwrap_or_default();
     let title = format!(
         " Papers for search {} ",
         search_id.chars().take(8).collect::<String>()
     );
-    render_paper_table(frame, area, &papers, selected, &title, starred);
+    render_paper_table(frame, area, &papers, selected, &title, starred, downloading);
+}
+
+/// Returns (symbol, color) for the Papers-table state column.
+/// `↻` if a download is currently running for this paper, otherwise
+/// derived from the persisted `download_status` (#112).
+fn download_cell(paper: &Paper, downloading: &HashSet<String>) -> (&'static str, Color) {
+    if downloading.contains(paper.id.as_str()) {
+        return ("↻", Color::Yellow);
+    }
+    match paper.download_status {
+        Some(DownloadStatus::Downloaded) => ("✓", Color::Green),
+        Some(DownloadStatus::Paywall) => ("⊘", Color::Yellow),
+        Some(DownloadStatus::Failed) => ("✗", Color::Red),
+        None => (" ", Color::DarkGray),
+    }
 }
 
 fn render_paper_table(
@@ -44,6 +69,7 @@ fn render_paper_table(
     selected: usize,
     title: &str,
     starred: &HashSet<String>,
+    downloading: &HashSet<String>,
 ) {
     if papers.is_empty() {
         let block = Block::default()
@@ -56,6 +82,7 @@ fn render_paper_table(
 
     let header = Row::new(vec![
         Cell::from("#"),
+        Cell::from(""),
         Cell::from(""),
         Cell::from("Title"),
         Cell::from("Authors"),
@@ -78,10 +105,12 @@ fn render_paper_table(
             } else {
                 " "
             };
+            let (dl_symbol, dl_color) = download_cell(p, downloading);
 
             Row::new(vec![
                 Cell::from((i + 1).to_string()),
                 Cell::from(star).style(Style::default().fg(Color::Yellow)),
+                Cell::from(dl_symbol).style(Style::default().fg(dl_color)),
                 Cell::from(truncate(&p.title, 60)),
                 Cell::from(truncate(&authors, 30)),
                 Cell::from(year),
@@ -91,6 +120,7 @@ fn render_paper_table(
 
     let widths = [
         Constraint::Length(5),
+        Constraint::Length(2),
         Constraint::Length(2),
         Constraint::Min(30),
         Constraint::Length(32),

--- a/crates/scitadel-tui/src/views/reader.rs
+++ b/crates/scitadel-tui/src/views/reader.rs
@@ -1,0 +1,400 @@
+//! Two-pane annotation reader (#97).
+//!
+//! Left pane: paper text (`full_text` if cached, otherwise the
+//! abstract) with background-color highlights over annotated ranges.
+//! Right pane: the annotation list synced with the focused highlight.
+//!
+//! Falls back to a single-pane "no body text" notice when neither
+//! `full_text` nor a non-empty abstract is available.
+//!
+//! Out of scope (future iterations of #97):
+//! - Multi-line gutter bars when several threads overlap on the same span
+//! - Variable-width font / proper PDF overlay
+//! - Fuzzy-orphan re-anchor prompt (resolver lives in scitadel-db; the
+//!   reader currently shows the resolver-derived `anchor.status`).
+
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
+
+use crate::data::DataStore;
+use scitadel_core::models::Annotation;
+
+/// Palette of muted background tints for highlighting annotation
+/// spans. Hashed by the annotation's root_id so a thread keeps the
+/// same color on every render. 8 entries — enough for a typical
+/// paper without every passage looking identical.
+const HIGHLIGHT_COLORS: [Color; 8] = [
+    Color::Rgb(80, 60, 30), // dim amber
+    Color::Rgb(30, 60, 80), // dim teal
+    Color::Rgb(60, 30, 80), // dim purple
+    Color::Rgb(30, 80, 50), // dim green
+    Color::Rgb(80, 30, 60), // dim magenta
+    Color::Rgb(60, 70, 30), // dim olive
+    Color::Rgb(30, 70, 80), // dim cyan
+    Color::Rgb(80, 50, 30), // dim rust
+];
+
+pub fn draw(frame: &mut Frame, area: Rect, data: &DataStore, paper_id: &str, focus: Option<usize>) {
+    let Ok(Some(paper)) = data.load_paper(paper_id) else {
+        let block = Block::default().title(" Reader ").borders(Borders::ALL);
+        let msg = Paragraph::new("Paper not found.").block(block);
+        frame.render_widget(msg, area);
+        return;
+    };
+
+    let annotations = data
+        .load_annotations_for_paper(paper_id)
+        .unwrap_or_default();
+    // Roots only on the left pane — replies don't carry their own anchor.
+    let roots: Vec<&Annotation> = annotations.iter().filter(|a| !a.is_reply()).collect();
+
+    let body = paper
+        .full_text
+        .as_deref()
+        .filter(|t| !t.trim().is_empty())
+        .unwrap_or(&paper.r#abstract);
+
+    if body.trim().is_empty() {
+        let block = Block::default()
+            .title(format!(" Reader — {} ", paper.title))
+            .borders(Borders::ALL);
+        let msg = Paragraph::new(
+            "No body text available yet. Run `scitadel download <id>` then \
+             open the paper via MCP `read_paper` to populate full_text.",
+        )
+        .block(block)
+        .wrap(Wrap { trim: false });
+        frame.render_widget(msg, area);
+        return;
+    }
+
+    let chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(60), Constraint::Percentage(40)])
+        .split(area);
+
+    draw_text_pane(frame, chunks[0], &paper.title, body, &roots, focus);
+    draw_notes_pane(frame, chunks[1], &annotations, &roots, focus);
+}
+
+fn draw_text_pane(
+    frame: &mut Frame,
+    area: Rect,
+    title: &str,
+    body: &str,
+    roots: &[&Annotation],
+    focus: Option<usize>,
+) {
+    let highlights = build_highlights(body, roots);
+    let lines = render_with_highlights(body, &highlights, focus);
+    let para = Paragraph::new(lines)
+        .block(
+            Block::default()
+                .title(format!(" Reader — {title} "))
+                .borders(Borders::ALL),
+        )
+        .wrap(Wrap { trim: false });
+    frame.render_widget(para, area);
+}
+
+fn draw_notes_pane(
+    frame: &mut Frame,
+    area: Rect,
+    annotations: &[Annotation],
+    roots: &[&Annotation],
+    focus: Option<usize>,
+) {
+    let mut lines: Vec<Line<'_>> = Vec::new();
+    for (idx, root) in roots.iter().enumerate() {
+        let color = color_for(root.id.as_str());
+        let is_focused = focus == Some(idx);
+        let marker = if is_focused { "▶ " } else { "  " };
+        let marker_style = if is_focused {
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default()
+        };
+        if let Some(quote) = root.anchor.quote.as_deref() {
+            lines.push(Line::from(vec![
+                Span::styled(marker, marker_style),
+                Span::styled(
+                    format!(" \"{quote}\" "),
+                    Style::default().bg(color).fg(Color::White),
+                ),
+                Span::styled(
+                    format!(" — {}", root.anchor.status.as_str()),
+                    Style::default().fg(Color::DarkGray),
+                ),
+            ]));
+        } else {
+            lines.push(Line::from(vec![
+                Span::styled(marker, marker_style),
+                Span::styled("(no quote)", Style::default().fg(Color::DarkGray)),
+            ]));
+        }
+        lines.push(Line::from(format!(
+            "    {} ({}): {}",
+            root.author,
+            root.created_at.format("%Y-%m-%d"),
+            root.note
+        )));
+        // Replies threaded under the root.
+        for ann in annotations.iter().filter(|a| {
+            a.parent_id
+                .as_ref()
+                .is_some_and(|p| p.as_str() == root.id.as_str())
+        }) {
+            lines.push(Line::from(vec![
+                Span::raw("    └ "),
+                Span::styled(
+                    format!("{}: ", ann.author),
+                    Style::default().fg(Color::Yellow),
+                ),
+                Span::raw(ann.note.clone()),
+            ]));
+        }
+        lines.push(Line::from(""));
+    }
+    let para = Paragraph::new(lines)
+        .block(
+            Block::default()
+                .title(format!(" Notes ({}) ", roots.len()))
+                .borders(Borders::ALL),
+        )
+        .wrap(Wrap { trim: false });
+    frame.render_widget(para, area);
+}
+
+/// Resolved highlight: where a root's quote currently sits in the body
+/// text + which color to paint it. None of the work below mutates the
+/// paper text — we only style over it.
+#[derive(Debug, Clone)]
+struct Highlight {
+    char_start: usize,
+    char_end: usize,
+    color: Color,
+    /// Index into the parent `roots` slice, used to pair with the focus
+    /// cursor.
+    root_index: usize,
+}
+
+/// Best-effort positions for each root annotation in the body. Tries
+/// `anchor.char_range` first, falls back to a substring lookup of the
+/// quote. Anchors that don't match are silently skipped (they're
+/// already surfaced as `orphan` in the right pane).
+fn build_highlights(body: &str, roots: &[&Annotation]) -> Vec<Highlight> {
+    let mut out = Vec::new();
+    for (idx, root) in roots.iter().enumerate() {
+        let color = color_for(root.id.as_str());
+        if let Some((s, e)) = root.anchor.char_range {
+            // Bounds-check; skip if offsets don't fit the current body.
+            let total_chars = body.chars().count();
+            if e <= total_chars && s < e {
+                out.push(Highlight {
+                    char_start: s,
+                    char_end: e,
+                    color,
+                    root_index: idx,
+                });
+                continue;
+            }
+        }
+        if let Some(quote) = root.anchor.quote.as_deref()
+            && let Some(byte_pos) = body.find(quote)
+        {
+            let start_char = body[..byte_pos].chars().count();
+            let end_char = start_char + quote.chars().count();
+            out.push(Highlight {
+                char_start: start_char,
+                char_end: end_char,
+                color,
+                root_index: idx,
+            });
+        }
+    }
+    // Sort + dedupe by start so the renderer can walk them in order.
+    out.sort_by_key(|h| h.char_start);
+    out
+}
+
+/// Render `body` as styled lines, painting background colors over
+/// highlight spans. The focused highlight gets an underline so it's
+/// distinguishable from the others.
+fn render_with_highlights(
+    body: &str,
+    highlights: &[Highlight],
+    focus: Option<usize>,
+) -> Vec<Line<'static>> {
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    let chars: Vec<char> = body.chars().collect();
+    let mut current_pos = 0;
+
+    for raw_line in body.split('\n') {
+        let line_start = current_pos;
+        let line_end = current_pos + raw_line.chars().count();
+        let mut spans: Vec<Span<'static>> = Vec::new();
+        let mut cursor = line_start;
+
+        // Walk highlights that overlap this line, in order.
+        for h in highlights
+            .iter()
+            .filter(|h| h.char_start < line_end && h.char_end > line_start)
+        {
+            // Plain text up to the highlight's start.
+            let plain_end = h.char_start.max(line_start);
+            if cursor < plain_end {
+                spans.push(Span::raw(slice_chars(&chars, cursor, plain_end)));
+            }
+            // The highlight, clipped to this line.
+            let hi_start = h.char_start.max(line_start);
+            let hi_end = h.char_end.min(line_end);
+            if hi_start < hi_end {
+                let mut style = Style::default().bg(h.color).fg(Color::White);
+                if focus == Some(h.root_index) {
+                    style = style.add_modifier(Modifier::UNDERLINED | Modifier::BOLD);
+                }
+                spans.push(Span::styled(slice_chars(&chars, hi_start, hi_end), style));
+            }
+            cursor = hi_end;
+        }
+        if cursor < line_end {
+            spans.push(Span::raw(slice_chars(&chars, cursor, line_end)));
+        }
+        if spans.is_empty() {
+            spans.push(Span::raw(String::new()));
+        }
+        lines.push(Line::from(spans));
+        current_pos = line_end + 1; // +1 for the consumed '\n'
+    }
+    lines
+}
+
+fn slice_chars(chars: &[char], start: usize, end: usize) -> String {
+    let start = start.min(chars.len());
+    let end = end.min(chars.len());
+    if end <= start {
+        return String::new();
+    }
+    chars[start..end].iter().collect()
+}
+
+/// Stable-per-thread color: hash the root_id and pick from the palette.
+fn color_for(root_id: &str) -> Color {
+    let mut hash: u32 = 0;
+    for b in root_id.bytes() {
+        hash = hash.wrapping_mul(31).wrapping_add(u32::from(b));
+    }
+    HIGHLIGHT_COLORS[(hash as usize) % HIGHLIGHT_COLORS.len()]
+}
+
+/// How many root annotations does this paper have? Used by the app
+/// layer to know whether `J`/`K` should hop between highlights.
+pub fn highlight_count(data: &DataStore, paper_id: &str) -> usize {
+    data.load_annotations_for_paper(paper_id)
+        .map_or(0, |anns| anns.iter().filter(|a| !a.is_reply()).count())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use scitadel_core::models::{Anchor, AnchorStatus, Annotation, PaperId};
+
+    fn root_at(quote: &str, range: Option<(usize, usize)>) -> Annotation {
+        let mut a = Annotation::new_root(
+            PaperId::from("p1"),
+            "lars".into(),
+            "note".into(),
+            Anchor {
+                char_range: range,
+                quote: Some(quote.into()),
+                status: AnchorStatus::Ok,
+                ..Anchor::default()
+            },
+        );
+        // Force a stable id so color_for() is deterministic across test runs.
+        a.id = scitadel_core::models::AnnotationId::from(format!("ann-{quote}"));
+        a
+    }
+
+    #[test]
+    fn build_highlights_uses_char_range_when_in_bounds() {
+        let body = "hello world, this is a test.";
+        let r1 = root_at("world", Some((6, 11)));
+        let highlights = build_highlights(body, &[&r1]);
+        assert_eq!(highlights.len(), 1);
+        assert_eq!((highlights[0].char_start, highlights[0].char_end), (6, 11));
+    }
+
+    #[test]
+    fn build_highlights_falls_back_to_substring_when_offsets_oob() {
+        let body = "hello world";
+        let r1 = root_at("world", Some((9000, 9100)));
+        let highlights = build_highlights(body, &[&r1]);
+        assert_eq!(highlights.len(), 1);
+        assert_eq!((highlights[0].char_start, highlights[0].char_end), (6, 11));
+    }
+
+    #[test]
+    fn build_highlights_skips_unmatched_quotes() {
+        let body = "hello";
+        let r1 = root_at("nowhere", None);
+        assert!(build_highlights(body, &[&r1]).is_empty());
+    }
+
+    #[test]
+    fn render_with_highlights_paints_background_only_over_quote() {
+        let body = "hello world";
+        let r1 = root_at("world", Some((6, 11)));
+        let highlights = build_highlights(body, &[&r1]);
+        let lines = render_with_highlights(body, &highlights, None);
+        assert_eq!(lines.len(), 1);
+        // Spans: ["hello ", "world"] — the second one carries a bg.
+        let line = &lines[0];
+        assert!(
+            line.spans.iter().any(|s| s.style.bg.is_some()),
+            "expected at least one styled span with a background"
+        );
+        let total: String = line
+            .spans
+            .iter()
+            .map(|s| s.content.clone().into_owned())
+            .collect();
+        assert_eq!(total, "hello world");
+    }
+
+    #[test]
+    fn focus_adds_underline_to_focused_highlight() {
+        let body = "hello world";
+        let r1 = root_at("world", Some((6, 11)));
+        let highlights = build_highlights(body, &[&r1]);
+        let lines = render_with_highlights(body, &highlights, Some(0));
+        let styled = lines[0]
+            .spans
+            .iter()
+            .find(|s| s.style.bg.is_some())
+            .expect("styled span");
+        assert!(
+            styled.style.add_modifier.contains(Modifier::UNDERLINED),
+            "focused highlight should be underlined"
+        );
+    }
+
+    #[test]
+    fn color_for_is_deterministic() {
+        assert_eq!(color_for("ann-foo"), color_for("ann-foo"));
+    }
+
+    #[test]
+    fn render_handles_multiline_body_without_panic() {
+        let body = "line one\nline two\nline three";
+        let r1 = root_at("two", None); // substring match → middle line
+        let highlights = build_highlights(body, &[&r1]);
+        let lines = render_with_highlights(body, &highlights, None);
+        assert_eq!(lines.len(), 3);
+    }
+}

--- a/crates/scitadel-tui/src/views/tasks.rs
+++ b/crates/scitadel-tui/src/views/tasks.rs
@@ -36,7 +36,7 @@ fn render_row(task: &Task, show_institutional_hint: bool) -> ListItem<'_> {
     };
 
     let (title, ref_id) = match &task.kind {
-        TaskKind::Download { title, ref_id } => (truncate(title, 55), ref_id.as_str()),
+        TaskKind::Download { title, ref_id, .. } => (truncate(title, 55), ref_id.as_str()),
     };
 
     let status_tail = status_tail_text(&task.status, show_institutional_hint);

--- a/docs/decisions/ADR-004-2026-04-19-sentence-id-normalization.md
+++ b/docs/decisions/ADR-004-2026-04-19-sentence-id-normalization.md
@@ -1,0 +1,76 @@
+# ADR-004 — sentence-id normalization for the annotation resolver
+
+- Status: accepted
+- Date: 2026-04-19
+- Driver: #96 (multi-selector resolver completion in 0.4.0)
+
+## Context
+
+The annotation anchor (#49 / `crates/scitadel-core/src/models/annotation.rs`)
+carries a `sentence_id: Option<String>` field — a stable identifier for
+the sentence containing the quoted passage. The resolver uses it as a
+last-resort selector before declaring the anchor an orphan. Without a
+written normalization spec, two correct implementations of "hash the
+sentence" can disagree on whitespace, case, or ligature handling and
+silently mis-anchor.
+
+This ADR pins the spec so the writer (annotation creation) and reader
+(`resolve_anchor` step 4) cannot diverge.
+
+## Decision
+
+`sentence_id(s: &str) -> String` is defined as:
+
+1. **NFKC normalize** the input (`unicode_normalization::nfkc`).
+   Compatibility decomposition + canonical composition. This folds
+   ligatures (e.g. `ﬁ` U+FB01 → `fi`), full-width forms, and other
+   compatibility-equivalent codepoints into their canonical
+   representation.
+2. **Lowercase** via `char::to_lowercase` (full Unicode lowercasing,
+   not ASCII-only — handles German `ẞ` → `ß`, Turkish `İ` → `i̇`,
+   etc.).
+3. **Collapse whitespace**: every run of `char::is_whitespace`
+   (ASCII space, tab, newline, NBSP, en-space, etc.) becomes a single
+   ASCII `' '`. Trim leading and trailing whitespace.
+4. **SHA1** the resulting bytes, encode as lowercase hex (40 chars).
+
+Two sentences that differ only in case, whitespace presentation, or
+ligature form will hash to the same value. Substantive edits — a
+changed word, a reordered clause, a different number — will hash
+differently and the resolver will fall through to `Orphan` for that
+selector.
+
+## Sentence boundaries
+
+The current resolver splits paper text on `.`, `!`, `?` and treats each
+run between terminators as a sentence (after trimming). This is
+deliberately simple — good enough for paper bodies and abstracts that
+don't contain abbreviations like "Dr.", "et al.", "i.e.". Proper ICU
+sentence segmentation is a follow-up if mis-segmentation becomes a
+real-world problem; switching the boundary algorithm without changing
+`normalize_sentence` will not change existing `sentence_id` values
+because the function operates on whatever sentence string is handed to
+it.
+
+## Out of scope
+
+- **Stemming** — would conflate different words that share a stem
+  (e.g. "ran" / "running") and cause sentence collisions.
+- **Diacritic stripping** — preserves meaning across European
+  languages where it would not (`über` ≠ `uber`).
+- **Punctuation stripping** — same rationale; "the model failed." vs.
+  "the model failed?" should hash differently.
+
+## Consequences
+
+- One canonical implementation in `scitadel-core`
+  (`models::annotation::sentence_id`); both writers and the resolver
+  call it. Cross-crate impls are forbidden.
+- Stored `sentence_id` values are stable across scitadel versions as
+  long as this ADR holds. Changes to normalization semantics require a
+  superseding ADR and a one-shot migration that re-hashes anchors
+  against the new spec.
+- The `unicode-normalization` and `sha1` workspace dependencies are
+  load-bearing — a major version bump that changes NFKC tables or
+  SHA1 output (the latter shouldn't happen, but) requires a re-hash
+  migration.

--- a/docs/decisions/ADR-005-2026-04-19-0.4.0-execution.md
+++ b/docs/decisions/ADR-005-2026-04-19-0.4.0-execution.md
@@ -1,0 +1,138 @@
+# ADR-005 — 0.4.0 execution tracker (loop-driven, mirroring ADR-003)
+
+- Status: in progress
+- Date: 2026-04-19
+- Driver: `/loop 30m` autonomous execution across Claude sessions
+
+## Context
+
+0.4.0 inherited 9 issues:
+
+1. **#58** MCP progress notifications — deferred from 0.3.0 (see ADR-003)
+2. **#92** TUI-native annotation create/edit/delete — iter 3b of #49
+3. **#95** `get_annotated_paper` MCP endpoint — silent drop from #49
+4. **#96** Multi-selector anchor resolver completion — gaps from #49 iter 2
+5. **#97** TUI two-pane reader — the original #49 reader UI
+6. **#98** MCP tool-signature consistency pass
+7. **#99** VHS coverage for `scitadel search` + `scitadel question`
+8. **#100** Annotation hardening (read-receipt race + author docs)
+9. **#59** Citation graph (snowball)
+
+Same shape as ADR-003: loop-driven execution, branches off `dev`, every
+unit of work a PR. Tick interval bumped from 15m to 30m so each tick
+can land a non-trivial PR end-to-end (build, test, clippy, fmt, push,
+open PR) without rushing.
+
+## Decision
+
+**Same operating model as ADR-003.** `dev` is the integration branch;
+each issue gets its own `feat/<n>-<slug>` (or `chore/`, `fix/`, `test/`)
+branch → PR → squash-merge. `main` lands one release merge when 0.4.0
+closes.
+
+**Iterate large issues into mergeable slices.** #97 ships in at least
+two iters (iter 1: split layout + per-thread highlights + J/K nav;
+iter 2: gutter bars, multi-line spans, fuzzy-orphan re-anchor prompt).
+#59 ships in at least two iters (iter 1: OpenAlex helpers + 2 MCP
+tools; iter 2: TUI graph view + snowball orchestration).
+
+**Bundle related infra prep with the feature it unblocks.** #97 was
+useless without a path to populate `Paper.full_text`; the iter 1 PR
+also wires `read_paper_tool` to persist the extracted text via a new
+`PaperRepository::update_full_text` method.
+
+**Defer #58 (rmcp upgrade) until the eight in-flight PRs land.** Every
+0.4.0 PR adds tools using the rmcp 0.1.5 `#[tool(tool_box)]` macro
+syntax. rmcp 0.17 replaces it with `#[tool_router]` + `Parameters<T>`
+wrappers — a sweeping rewrite. Doing the upgrade with eight unmerged
+PRs in flight would force a rebase ladder on every one of them. Better
+to land the feature work first and then make the rmcp upgrade a clean
+cross-cutting PR.
+
+## Execution order
+
+| #  | Size | Branch / PR              | Status                  |
+|----|------|--------------------------|-------------------------|
+| 95 | S    | `feat/95-…`  (PR #101)   | ✅ open                 |
+| 100| S    | `chore/100-…`(PR #102)   | ✅ open                 |
+| 98 | S    | `chore/98-…` (PR #103)   | ✅ open                 |
+| 99 | S    | `test/99-…`  (PR #104)   | ✅ open                 |
+| 96 | M    | `fix/96-…`   (PR #105)   | ✅ open                 |
+| 92 | M    | `feat/92-…`  (PR #106)   | ✅ open                 |
+| 97 | L    | `feat/97-…`  (PR #107)   | ✅ open (iter 1)        |
+| 59 | L    | `feat/59-…`  (PR #108)   | ✅ open (iter 1)        |
+| 58 | M    | (deferred — see below)   | ⏳ blocked on rmcp 0.17 |
+
+Eight PRs opened in this session, all green CI; #58 deferred.
+
+## #58 deferral rationale (updated from ADR-003)
+
+ADR-003 noted three options for #58:
+
+1. rmcp upgrade (0.17 exists)
+2. Custom `#[tool]` wrapper exposing `RequestContext`
+3. `start_X` + `get_X_status` polling pairs over an async task registry
+
+Option 1 is now the obvious choice — rmcp 0.17 ships first-class
+progress notifications, a `Peer<RoleServer>` extractor for tool
+handlers, and a `tool_router`-based macro that's a clean break from
+0.1.5's `tool_box`. The migration is mechanical but **every** tool
+needs rewriting. Doing it with PRs #101–#108 unmerged would force
+each one to be rebased through the rewrite.
+
+**Decision**: hold #58 until #101–#108 land on `dev`. Then ship the
+rmcp upgrade as a single cross-cutting PR, then add progress
+notifications as a follow-up that depends on the upgrade.
+
+This is the same pattern ADR-003 used for deferring #58 the first
+time: don't bundle architectural rework with feature work.
+
+## Observations (append-only)
+
+*Tick 2026-04-19 T1*: 4 PRs in. #95 / #100 / #98 / #99 — all small
+effort, no dependencies. Going in priority order from the issue list.
+Next: #96 (resolver completion, medium effort, real design).
+
+*Tick 2026-04-19 T2*: 6 PRs in. #96 + #92 added. #96 also added
+`sentence_id` + `normalize_sentence` to `scitadel-core` plus ADR-004
+pinning the normalisation spec — two writers (annotation create + the
+resolver's step 4) cannot diverge on whitespace/case/ligature handling
+because they share one canonical implementation.
+
+*Tick 2026-04-19 T3*: 7 PRs in. #97 iter 1 (two-pane reader). Bundled
+the `update_full_text` plumbing because the reader was useless without
+it. Iter 1 ships split layout + per-thread background highlights with
+hashed colors + J/K hop navigation; iter 2 will add gutter bars,
+multi-line span handling, and the fuzzy-orphan re-anchor prompt.
+
+*Tick 2026-04-19 T4*: 8 PRs in. #59 iter 1 (citation graph
+foundation): OpenAlex `fetch_work_by_id` / `fetch_works_by_ids` /
+`fetch_cited_by` / `short_openalex_id` / `work_to_paper` plus two
+MCP tools (`get_references`, `get_citations`). The DB side
+(`citations` table, `CitationRepository`) was already in place; this
+just wired the missing client + tool surface. Iter 2 will add the TUI
+graph view and the `snowball(seed_paper_ids, depth, stop_condition)`
+orchestration tool.
+
+## Follow-ups worth tracking (not 0.4.0 blockers)
+
+- **rmcp 0.1.5 → 0.17 upgrade** (then #58 on top). Single cross-cutting
+  PR after the in-flight 0.4.0 work merges.
+- **wiremock-based integration tests for OpenAlex client** — the new
+  helpers in #59 iter 1 hardcode the OpenAlex base URL; refactoring
+  to take a `base_url` parameter unlocks deterministic tests.
+- **#97 iter 2** — gutter bars for multi-line spans, fuzzy-orphan
+  re-anchor prompt, variable-width considerations.
+- **#59 iter 2** — TUI citation graph view + snowball orchestration.
+- **CHANGELOG `Unreleased` is now substantial** — when 0.4.0 cuts,
+  reorganise it into a release section mirroring 0.3.0's structure.
+
+## When this loop ends
+
+When PRs #101–#108 are merged to `dev`. Then either:
+- start the rmcp upgrade + #58 (a 9th PR for the milestone), or
+- ship 0.4.0 without #58 and carry it to 0.5.0 — same pattern as
+  0.2.0 → 0.3.0 → 0.4.0 has done with this issue twice now.
+
+User picks. Either way: PR `dev → main`, tag `0.4.0`, GH Release,
+close milestone.

--- a/tests/vhs/annotations-in-detail.tape
+++ b/tests/vhs/annotations-in-detail.tape
@@ -13,7 +13,7 @@ Set Padding 10
 Set TypingSpeed 40ms
 
 Hide
-Type `export PATH="$HOME/.cargo/bin:$PWD/target/release:$PATH"`
+Type `export PATH="$PWD/target/release:$HOME/.cargo/bin:$PATH"`
 Enter
 Type `export PS1="$ "`
 Enter

--- a/tests/vhs/annotations-in-detail.tape
+++ b/tests/vhs/annotations-in-detail.tape
@@ -39,14 +39,14 @@ Show
 
 Type "scitadel tui"
 Enter
-Sleep 1500ms
+Sleep 2500ms
 
 Tab
-Sleep 500ms
+Sleep 1500ms
 Screenshot "tests/vhs/snapshots/annotations-in-detail/01-papers-tab.png"
 
 Enter
-Sleep 1500ms
+Sleep 2500ms
 Screenshot "tests/vhs/snapshots/annotations-in-detail/02-paper-detail-with-annotations.png"
 
 Type "q"

--- a/tests/vhs/annotations-in-detail.tape
+++ b/tests/vhs/annotations-in-detail.tape
@@ -39,14 +39,14 @@ Show
 
 Type "scitadel tui"
 Enter
-Sleep 2500ms
+Sleep 3500ms
 
 Tab
-Sleep 1500ms
+Sleep 2500ms
 Screenshot "tests/vhs/snapshots/annotations-in-detail/01-papers-tab.png"
 
 Enter
-Sleep 2500ms
+Sleep 3500ms
 Screenshot "tests/vhs/snapshots/annotations-in-detail/02-paper-detail-with-annotations.png"
 
 Type "q"

--- a/tests/vhs/cli-question-workflow.tape
+++ b/tests/vhs/cli-question-workflow.tape
@@ -14,7 +14,7 @@ Set Padding 10
 Set TypingSpeed 40ms
 
 Hide
-Type `export PATH="$HOME/.cargo/bin:$PWD/target/release:$PATH"`
+Type `export PATH="$PWD/target/release:$HOME/.cargo/bin:$PATH"`
 Enter
 Type `export PS1="$ "`
 Enter

--- a/tests/vhs/cli-question-workflow.tape
+++ b/tests/vhs/cli-question-workflow.tape
@@ -1,0 +1,64 @@
+# VHS tape: `scitadel question` subcommand workflow (#99 / 0.4.0).
+#
+# Deterministic — no network. Creates a question, captures its ID via
+# `awk`, attaches search terms, lists, then opens the TUI Questions
+# tab to show the row populated.
+
+Output "tests/vhs/snapshots/cli-question-workflow/run.gif"
+
+Set Shell "bash"
+Set FontSize 14
+Set Width 1400
+Set Height 900
+Set Padding 10
+Set TypingSpeed 40ms
+
+Hide
+Type `export PATH="$HOME/.cargo/bin:$PWD/target/release:$PATH"`
+Enter
+Type `export PS1="$ "`
+Enter
+Type `export SCITADEL_DB=$(mktemp -d)/scitadel.db`
+Enter
+Type "scitadel init --yes --email demo@example.org --sources arxiv --db $SCITADEL_DB"
+Enter
+Sleep 800ms
+Type "clear"
+Enter
+Show
+
+Type `scitadel question create "How do transformers handle long-range dependencies?" --description "compare attention variants vs. recurrence"`
+Sleep 300ms
+Enter
+Sleep 1s
+Screenshot "tests/vhs/snapshots/cli-question-workflow/01-create.png"
+
+Type `QID=$(scitadel question list | tail -n 1 | awk '{print $1}')`
+Enter
+Sleep 300ms
+
+Type `scitadel question add-terms $QID "long-range attention" "sparse transformer" "linformer"`
+Sleep 300ms
+Enter
+Sleep 800ms
+Screenshot "tests/vhs/snapshots/cli-question-workflow/02-add-terms.png"
+
+Type "clear"
+Enter
+Type "scitadel question list"
+Sleep 300ms
+Enter
+Sleep 800ms
+Screenshot "tests/vhs/snapshots/cli-question-workflow/03-list.png"
+
+Type "scitadel tui"
+Enter
+Sleep 1500ms
+Tab
+Sleep 300ms
+Tab
+Sleep 500ms
+Screenshot "tests/vhs/snapshots/cli-question-workflow/04-tui-questions-tab.png"
+
+Type "q"
+Sleep 300ms

--- a/tests/vhs/cli-search.tape
+++ b/tests/vhs/cli-search.tape
@@ -15,7 +15,7 @@ Set Padding 10
 Set TypingSpeed 40ms
 
 Hide
-Type `export PATH="$HOME/.cargo/bin:$PWD/target/release:$PATH"`
+Type `export PATH="$PWD/target/release:$HOME/.cargo/bin:$PATH"`
 Enter
 Type `export PS1="$ "`
 Enter

--- a/tests/vhs/cli-search.tape
+++ b/tests/vhs/cli-search.tape
@@ -1,0 +1,43 @@
+# VHS tape: CLI `scitadel search` + `scitadel history` (#99 / 0.4.0).
+#
+# Uses arXiv (no auth needed) for a small, real network call. If CI
+# turns out to be flaky on the live arXiv lookup, swap to a sqlite3
+# seed of papers + a search row (same pattern as
+# annotations-in-detail.tape).
+
+Output "tests/vhs/snapshots/cli-search/run.gif"
+
+Set Shell "bash"
+Set FontSize 14
+Set Width 1400
+Set Height 900
+Set Padding 10
+Set TypingSpeed 40ms
+
+Hide
+Type `export PATH="$HOME/.cargo/bin:$PWD/target/release:$PATH"`
+Enter
+Type `export PS1="$ "`
+Enter
+Type `export SCITADEL_DB=$(mktemp -d)/scitadel.db`
+Enter
+Type "scitadel init --yes --email demo@example.org --sources arxiv,openalex --db $SCITADEL_DB"
+Enter
+Sleep 800ms
+Type "clear"
+Enter
+Show
+
+Type `scitadel search "transformer attention" --sources arxiv -n 3`
+Sleep 300ms
+Enter
+Sleep 8s
+Screenshot "tests/vhs/snapshots/cli-search/01-search-results.png"
+
+Type "clear"
+Enter
+Type "scitadel history -n 1"
+Sleep 300ms
+Enter
+Sleep 1s
+Screenshot "tests/vhs/snapshots/cli-search/02-history-shows-search.png"

--- a/tests/vhs/init-wizard.tape
+++ b/tests/vhs/init-wizard.tape
@@ -13,7 +13,7 @@ Set Padding 10
 Set TypingSpeed 40ms
 
 Hide
-Type `export PATH="$HOME/.cargo/bin:$PWD/target/release:$PATH"`
+Type `export PATH="$PWD/target/release:$HOME/.cargo/bin:$PATH"`
 Enter
 Type `export PS1="$ "`
 Enter

--- a/tests/vhs/offline-indicator.tape
+++ b/tests/vhs/offline-indicator.tape
@@ -13,7 +13,7 @@ Set Padding 10
 Set TypingSpeed 40ms
 
 Hide
-Type `export PATH="$HOME/.cargo/bin:$PWD/target/release:$PATH"`
+Type `export PATH="$PWD/target/release:$HOME/.cargo/bin:$PATH"`
 Enter
 Type `export PS1="$ "`
 Enter

--- a/tests/vhs/offline-indicator.tape
+++ b/tests/vhs/offline-indicator.tape
@@ -30,11 +30,11 @@ Show
 
 Type "scitadel tui"
 Enter
-Sleep 2s
+Sleep 2500ms
 Screenshot "tests/vhs/snapshots/offline-indicator/01-offline-badge.png"
 
 Tab
-Sleep 500ms
+Sleep 1500ms
 Screenshot "tests/vhs/snapshots/offline-indicator/02-papers-still-works.png"
 
 Type "q"

--- a/tests/vhs/papers-download-state.tape
+++ b/tests/vhs/papers-download-state.tape
@@ -1,0 +1,56 @@
+# VHS tape: Papers table renders the download-state column (#112).
+#
+# Seeds 4 papers, each in a different download_status state
+# (none / downloaded / paywall / failed) so the symbol column
+# renders all four glyphs side-by-side: blank, ✓, ⊘, ✗.
+
+Output "tests/vhs/snapshots/papers-download-state/run.gif"
+
+Set Shell "bash"
+Set FontSize 14
+Set Width 1400
+Set Height 600
+Set Padding 10
+Set TypingSpeed 40ms
+
+Hide
+Type `export PATH="$PWD/target/release:$HOME/.cargo/bin:$PATH"`
+Enter
+Type `export PS1="$ "`
+Enter
+Type `export SCITADEL_DB=$(mktemp -d)/scitadel.db`
+Enter
+Type "scitadel init --yes --email demo@example.org --sources arxiv --db $SCITADEL_DB"
+Enter
+Sleep 800ms
+
+# Seed 4 papers with distinct download states.
+Type `sqlite3 $SCITADEL_DB "INSERT INTO papers (id, title, authors, abstract, created_at, updated_at) VALUES ('p-none', 'Paper Never Tried', '[\"Alice\"]', '', datetime('now', '-4 hours'), datetime('now'));"`
+Enter
+Sleep 100ms
+Type `sqlite3 $SCITADEL_DB "INSERT INTO papers (id, title, authors, abstract, local_path, download_status, last_attempt_at, created_at, updated_at) VALUES ('p-ok', 'Paper Successfully Downloaded', '[\"Bob\"]', '', '/tmp/p-ok.pdf', 'downloaded', datetime('now'), datetime('now', '-3 hours'), datetime('now'));"`
+Enter
+Sleep 100ms
+Type `sqlite3 $SCITADEL_DB "INSERT INTO papers (id, title, authors, abstract, local_path, download_status, last_attempt_at, created_at, updated_at) VALUES ('p-pay', 'Paper Behind Paywall', '[\"Carol\"]', '', '/tmp/p-pay.html', 'paywall', datetime('now'), datetime('now', '-2 hours'), datetime('now'));"`
+Enter
+Sleep 100ms
+Type `sqlite3 $SCITADEL_DB "INSERT INTO papers (id, title, authors, abstract, download_status, last_attempt_at, created_at, updated_at) VALUES ('p-fail', 'Paper Download Failed', '[\"Dave\"]', '', 'failed', datetime('now'), datetime('now', '-1 hours'), datetime('now'));"`
+Enter
+Sleep 200ms
+
+Type "clear"
+Enter
+Show
+
+Type "scitadel tui"
+Enter
+Sleep 1500ms
+
+# Tab to Papers tab — table should show 4 rows with blank/✓/⊘/✗ symbols.
+Tab
+Sleep 500ms
+Screenshot "tests/vhs/snapshots/papers-download-state/01-papers-table.png"
+
+Type "q"
+Sleep 300ms
+Screenshot "tests/vhs/snapshots/papers-download-state/02-quit.png"

--- a/tests/vhs/reading-queue-star.tape
+++ b/tests/vhs/reading-queue-star.tape
@@ -13,7 +13,7 @@ Set Padding 10
 Set TypingSpeed 40ms
 
 Hide
-Type `export PATH="$HOME/.cargo/bin:$PWD/target/release:$PATH"`
+Type `export PATH="$PWD/target/release:$HOME/.cargo/bin:$PATH"`
 Enter
 Type `export PS1="$ "`
 Enter

--- a/tests/vhs/reading-queue-star.tape
+++ b/tests/vhs/reading-queue-star.tape
@@ -31,18 +31,18 @@ Show
 
 Type "scitadel tui"
 Enter
-Sleep 1500ms
+Sleep 2500ms
 
 Tab
-Sleep 600ms
+Sleep 1500ms
 Screenshot "tests/vhs/snapshots/reading-queue-star/01-papers-unstarred.png"
 
 Type "s"
-Sleep 600ms
+Sleep 1500ms
 Screenshot "tests/vhs/snapshots/reading-queue-star/02-papers-starred.png"
 
 Type "s"
-Sleep 600ms
+Sleep 1500ms
 Screenshot "tests/vhs/snapshots/reading-queue-star/03-papers-unstarred-again.png"
 
 Type "q"

--- a/tests/vhs/tui-annotation-write.tape
+++ b/tests/vhs/tui-annotation-write.tape
@@ -1,0 +1,97 @@
+# VHS tape: TUI-native annotation create / edit / delete / reply (#92).
+#
+# Iter 3b of #49: n / e / d / r keybindings on the paper detail
+# overlay. Seeds a paper via sqlite3 (no network), opens the TUI,
+# steps through the four-action lifecycle.
+
+Output "tests/vhs/snapshots/tui-annotation-write/run.gif"
+
+Set Shell "bash"
+Set FontSize 14
+Set Width 1400
+Set Height 900
+Set Padding 10
+Set TypingSpeed 40ms
+
+Hide
+Type `export PATH="$HOME/.cargo/bin:$PWD/target/release:$PATH"`
+Enter
+Type `export PS1="$ "`
+Enter
+Type `export SCITADEL_DB=$(mktemp -d)/scitadel.db`
+Enter
+Type "scitadel init --yes --email demo@example.org --sources arxiv --db $SCITADEL_DB"
+Enter
+Sleep 800ms
+
+# Seed a paper. Annotations will be created via the TUI itself so the
+# tape exercises every keybinding listed in #92.
+Type `sqlite3 $SCITADEL_DB "INSERT INTO papers (id, title, authors, year, abstract, created_at, updated_at) VALUES ('p-demo', 'Attention Is All You Need', '[\"Vaswani, A.\"]', 2017, 'The dominant sequence transduction models are based on complex recurrent or convolutional neural networks. We propose the Transformer, a new simple network architecture.', datetime('now'), datetime('now'));"`
+Enter
+Sleep 300ms
+Type "clear"
+Enter
+Show
+
+Type "scitadel tui"
+Enter
+Sleep 1500ms
+
+# Tab → Papers, open the seeded paper.
+Tab
+Sleep 500ms
+Enter
+Sleep 1s
+Screenshot "tests/vhs/snapshots/tui-annotation-write/01-paper-detail.png"
+
+# n → Create prompt, type quote, Enter, type note, Enter.
+Type "n"
+Sleep 500ms
+Screenshot "tests/vhs/snapshots/tui-annotation-write/02-create-quote.png"
+Type "the Transformer"
+Sleep 300ms
+Enter
+Sleep 500ms
+Screenshot "tests/vhs/snapshots/tui-annotation-write/03-create-note.png"
+Type "foundational architecture choice"
+Sleep 300ms
+Enter
+Sleep 800ms
+Screenshot "tests/vhs/snapshots/tui-annotation-write/04-after-create.png"
+
+# Shift+J → focus the new annotation.
+Shift+J
+Sleep 500ms
+Screenshot "tests/vhs/snapshots/tui-annotation-write/05-focused.png"
+
+# e → Edit prompt with note pre-filled.
+Type "e"
+Sleep 400ms
+Screenshot "tests/vhs/snapshots/tui-annotation-write/06-edit-prefilled.png"
+Type " — see fig 1"
+Sleep 300ms
+Enter
+Sleep 800ms
+Screenshot "tests/vhs/snapshots/tui-annotation-write/07-after-edit.png"
+
+# r → Reply prompt.
+Type "r"
+Sleep 400ms
+Type "agreed; matches section 3.1"
+Sleep 300ms
+Enter
+Sleep 800ms
+Screenshot "tests/vhs/snapshots/tui-annotation-write/08-after-reply.png"
+
+# d → Delete confirm, y to confirm.
+Type "d"
+Sleep 400ms
+Screenshot "tests/vhs/snapshots/tui-annotation-write/09-delete-confirm.png"
+Type "y"
+Sleep 800ms
+Screenshot "tests/vhs/snapshots/tui-annotation-write/10-after-delete.png"
+
+Type "q"
+Sleep 300ms
+Type "q"
+Sleep 300ms

--- a/tests/vhs/tui-annotation-write.tape
+++ b/tests/vhs/tui-annotation-write.tape
@@ -14,7 +14,7 @@ Set Padding 10
 Set TypingSpeed 40ms
 
 Hide
-Type `export PATH="$HOME/.cargo/bin:$PWD/target/release:$PATH"`
+Type `export PATH="$PWD/target/release:$HOME/.cargo/bin:$PATH"`
 Enter
 Type `export PS1="$ "`
 Enter

--- a/tests/vhs/tui-annotations-reader.tape
+++ b/tests/vhs/tui-annotations-reader.tape
@@ -1,0 +1,94 @@
+# VHS tape: TUI two-pane annotation reader (#97).
+#
+# Iter 1 of #97: split layout + per-thread background highlights +
+# J/K hop between highlights. Multi-line gutter bars and PDF overlay
+# stay deferred (separate iter once a real full_text is available).
+#
+# Seeds a paper with full_text + 3 overlapping annotations + 1
+# spanning multiple lines so the highlight palette + multi-line
+# wrapping are both exercised.
+
+Output "tests/vhs/snapshots/tui-annotations-reader/run.gif"
+
+Set Shell "bash"
+Set FontSize 14
+Set Width 1600
+Set Height 900
+Set Padding 10
+Set TypingSpeed 40ms
+
+Hide
+Type `export PATH="$HOME/.cargo/bin:$PWD/target/release:$PATH"`
+Enter
+Type `export PS1="$ "`
+Enter
+Type `export SCITADEL_DB=$(mktemp -d)/scitadel.db`
+Enter
+Type "scitadel init --yes --email demo@example.org --sources arxiv --db $SCITADEL_DB"
+Enter
+Sleep 800ms
+
+# Seed a paper whose `full_text` spans multiple sentences across
+# multiple lines.
+Type `sqlite3 $SCITADEL_DB "INSERT INTO papers (id, title, authors, year, abstract, full_text, created_at, updated_at) VALUES ('p-demo', 'Attention Is All You Need', '[\"Vaswani, A.\"]', 2017, 'short abstract here', 'The dominant sequence transduction models are based on complex recurrent or convolutional neural networks. We propose the Transformer, a new simple network architecture based solely on self-attention mechanisms, dispensing with recurrence and convolutions entirely.', datetime('now'), datetime('now'));"`
+Enter
+Sleep 300ms
+
+# Three overlapping annotations on the seeded full_text; one spans the
+# multi-line "based solely on self-attention mechanisms" string so the
+# wrapping branch in render_with_highlights gets exercised.
+Type `sqlite3 $SCITADEL_DB "INSERT INTO annotations (id, paper_id, quote, note, author, anchor_status, tags_json, created_at, updated_at) VALUES ('a-rec', 'p-demo', 'recurrent or convolutional neural networks', 'these are the prior art', 'lars', 'ok', '[]', datetime('now'), datetime('now'));"`
+Enter
+Sleep 200ms
+Type `sqlite3 $SCITADEL_DB "INSERT INTO annotations (id, paper_id, quote, note, author, anchor_status, tags_json, created_at, updated_at) VALUES ('a-trans', 'p-demo', 'the Transformer', 'foundational architecture choice', 'claude-opus-4-7', 'ok', '[]', datetime('now'), datetime('now'));"`
+Enter
+Sleep 200ms
+Type `sqlite3 $SCITADEL_DB "INSERT INTO annotations (id, paper_id, quote, note, author, anchor_status, tags_json, created_at, updated_at) VALUES ('a-attn', 'p-demo', 'self-attention mechanisms', 'core mechanism — see fig 1', 'lars', 'ok', '[]', datetime('now'), datetime('now'));"`
+Enter
+Sleep 200ms
+# Reply to the Transformer annotation so the right-pane threading path
+# is also exercised.
+Type `sqlite3 $SCITADEL_DB "INSERT INTO annotations (id, parent_id, paper_id, note, author, anchor_status, tags_json, created_at, updated_at) VALUES ('a-trans-reply', 'a-trans', 'p-demo', 'matches section 3.1 of the paper', 'claude-opus-4-7', 'ok', '[]', datetime('now'), datetime('now'));"`
+Enter
+Sleep 300ms
+
+Type "clear"
+Enter
+Show
+
+Type "scitadel tui"
+Enter
+Sleep 1500ms
+
+# Tab → Papers, open the seeded paper.
+Tab
+Sleep 500ms
+Enter
+Sleep 1s
+Screenshot "tests/vhs/snapshots/tui-annotations-reader/01-detail.png"
+
+# R → enter the two-pane reader; left pane shows highlights.
+Type "R"
+Sleep 800ms
+Screenshot "tests/vhs/snapshots/tui-annotations-reader/02-reader-open.png"
+
+# J / K → cycle through highlights; the focused one underlines.
+Shift+J
+Sleep 400ms
+Screenshot "tests/vhs/snapshots/tui-annotations-reader/03-second-highlight.png"
+Shift+J
+Sleep 400ms
+Screenshot "tests/vhs/snapshots/tui-annotations-reader/04-third-highlight.png"
+Shift+K
+Sleep 400ms
+Screenshot "tests/vhs/snapshots/tui-annotations-reader/05-back-to-second.png"
+
+# R → leave the reader, back to single-pane.
+Type "R"
+Sleep 400ms
+Screenshot "tests/vhs/snapshots/tui-annotations-reader/06-back-to-detail.png"
+
+Type "q"
+Sleep 300ms
+Type "q"
+Sleep 300ms

--- a/tests/vhs/tui-annotations-reader.tape
+++ b/tests/vhs/tui-annotations-reader.tape
@@ -18,7 +18,7 @@ Set Padding 10
 Set TypingSpeed 40ms
 
 Hide
-Type `export PATH="$HOME/.cargo/bin:$PWD/target/release:$PATH"`
+Type `export PATH="$PWD/target/release:$HOME/.cargo/bin:$PATH"`
 Enter
 Type `export PS1="$ "`
 Enter

--- a/tests/vhs/tui-launch.tape
+++ b/tests/vhs/tui-launch.tape
@@ -13,7 +13,7 @@ Set Padding 10
 Set TypingSpeed 40ms
 
 Hide
-Type `export PATH="$HOME/.cargo/bin:$PWD/target/release:$PATH"`
+Type `export PATH="$PWD/target/release:$HOME/.cargo/bin:$PATH"`
 Enter
 Type `export PS1="$ "`
 Enter

--- a/tests/vhs/tui-launch.tape
+++ b/tests/vhs/tui-launch.tape
@@ -39,6 +39,18 @@ Tab
 Sleep 500ms
 Screenshot "tests/vhs/snapshots/tui-launch/03-questions-tab.png"
 
+# BackTab cycles tabs in reverse — back to Papers (#99 audit gap).
+Shift+Tab
+Sleep 500ms
+Screenshot "tests/vhs/snapshots/tui-launch/04-backtab-papers.png"
+
+# `d` / `u` page-scroll bindings.
+Type "d"
+Sleep 200ms
+Type "u"
+Sleep 200ms
+Screenshot "tests/vhs/snapshots/tui-launch/05-page-scroll.png"
+
 Type "q"
 Sleep 500ms
-Screenshot "tests/vhs/snapshots/tui-launch/04-quit.png"
+Screenshot "tests/vhs/snapshots/tui-launch/06-quit.png"


### PR DESCRIPTION
## Release v0.5.0

First release where on-disk crate versions actually match the documented release. Combines all 0.4.0 + 0.5.0 milestone work into a single tag (the 0.4.0 milestone was never properly cut as a release).

## Headline changes

**Agent-side affordances (the 2-pane workflow)**
- 40+ MCP tools spanning search, scoring, annotations, citation graph, stars, TUI selection
- \`get_current_selection\` (#122): agent in adjacent pane can ask "what is the user looking at?" without IDs
- \`toggle_star\` / \`set_star\` / \`list_starred\` (#120): closes the only TUI-only affordance gap
- MCP progress notifications (#58): \`search\`, \`download_paper\`, \`prepare_batch_assessments\` emit \`notifications/progress\`
- Citation graph iter 1 (#59): \`get_references\` + \`get_citations\` via OpenAlex
- \`get_annotated_paper\` (#95): one-call paper + threads + anchors

**TUI**
- Two-pane annotation reader with colored highlights (#97)
- TUI-native annotation CRUD via n/e/r/d (#92)
- Papers-table download-state column (#112)
- Task panel flush policy + \`c\` clear keybind (#113)

**Foundations**
- SQLite WAL + cross-process visibility test (#121) — required for the 2-pane workflow's live-reload property
- rmcp 0.17 macro-API rewrite (#58 prep)
- Multi-selector annotation anchor resolver (#96)

**CI / docs**
- VHS render gate that asserts distinct snapshots (#116) — caught the #97 silent rendering failure that motivated it
- Retry-once on tape flakes (#127)
- README repositions the 2-pane workflow as primary (#123)

**Architectural pivot**
- Closed #60 (\`scitadel-agent\` crate) and #61 (in-TUI gestures) as superseded after a four-reviewer spike concluded that the 2-pane setup with MCP is the cleaner answer than bundling LLM code into scitadel itself

## Post-merge

- Tag \`v0.5.0\` on the merge commit
- Open 0.6.0 milestone for surviving backlog: #48 reading queue (to-read/read state), #51 graceful offline TUI, #52 Typst live-bib

## Test plan

- [x] \`cargo build --workspace\` clean at v0.5.0 versions
- [x] \`cargo test --workspace\` clean
- [x] CI green on every contributing PR (#117 #118 #119 #124 #125 #126 #127 #128 plus all 0.4.0 PRs)