### PR TITLE
chore: sync v0.5.0 release housekeeping back to dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.5.0] - 2026-04-21
+
+The 2-pane workflow release. Combines the agent-side affordances
+shipped under the 0.4.0 milestone (citation graph, MCP progress
+notifications, rmcp 0.17 upgrade, annotations CRUD via TUI + MCP,
+two-pane reader, get_annotated_paper, multi-selector resolver) with
+the 0.5.0 milestone's affordance-gap closures (download-state column,
+task-panel flush, star MCP tools, get_current_selection, SQLite
+cross-process visibility) and the meta-pivot away from a bundled LLM
+abstraction (#60/#61 closed as superseded) toward MCP-driven
+2-pane workflow as the primary recommendation.
+
+`Cargo.toml` workspace version is bumped 0.1.0 → 0.5.0 to align with
+the changelog narrative; this is the first release where the on-disk
+crate version actually matches the documented release. Earlier 0.2.x
+and 0.3.x sections in this file are CHANGELOG-only milestones — no
+git tags exist for them.
+
 ### Fixed
 
 - **SQLite cross-process write visibility** (#121). Added `synchronous=NORMAL`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2388,7 +2388,7 @@ dependencies = [
 
 [[package]]
 name = "scitadel-adapters"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "insta",
@@ -2405,7 +2405,7 @@ dependencies = [
 
 [[package]]
 name = "scitadel-cli"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2431,7 +2431,7 @@ dependencies = [
 
 [[package]]
 name = "scitadel-core"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2451,7 +2451,7 @@ dependencies = [
 
 [[package]]
 name = "scitadel-db"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "insta",
@@ -2469,7 +2469,7 @@ dependencies = [
 
 [[package]]
 name = "scitadel-export"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "csv",
@@ -2482,7 +2482,7 @@ dependencies = [
 
 [[package]]
 name = "scitadel-mcp"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2504,7 +2504,7 @@ dependencies = [
 
 [[package]]
 name = "scitadel-scoring"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2521,7 +2521,7 @@ dependencies = [
 
 [[package]]
 name = "scitadel-tui"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.5.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/vig-os/scitadel"

--- a/crates/scitadel-adapters/Cargo.toml
+++ b/crates/scitadel-adapters/Cargo.toml
@@ -16,7 +16,7 @@ default = []
 contract-tests = []
 
 [dependencies]
-scitadel-core = { path = "../scitadel-core", version = "0.1.0" }
+scitadel-core = { path = "../scitadel-core", version = "0.5.0" }
 reqwest = { workspace = true }
 quick-xml = { workspace = true }
 serde = { workspace = true }

--- a/crates/scitadel-cli/Cargo.toml
+++ b/crates/scitadel-cli/Cargo.toml
@@ -16,13 +16,13 @@ name = "scitadel"
 path = "src/main.rs"
 
 [dependencies]
-scitadel-core = { path = "../scitadel-core", version = "0.1.0" }
-scitadel-db = { path = "../scitadel-db", version = "0.1.0" }
-scitadel-adapters = { path = "../scitadel-adapters", version = "0.1.0" }
-scitadel-scoring = { path = "../scitadel-scoring", version = "0.1.0" }
-scitadel-export = { path = "../scitadel-export", version = "0.1.0" }
-scitadel-mcp = { path = "../scitadel-mcp", version = "0.1.0" }
-scitadel-tui = { path = "../scitadel-tui", version = "0.1.0" }
+scitadel-core = { path = "../scitadel-core", version = "0.5.0" }
+scitadel-db = { path = "../scitadel-db", version = "0.5.0" }
+scitadel-adapters = { path = "../scitadel-adapters", version = "0.5.0" }
+scitadel-scoring = { path = "../scitadel-scoring", version = "0.5.0" }
+scitadel-export = { path = "../scitadel-export", version = "0.5.0" }
+scitadel-mcp = { path = "../scitadel-mcp", version = "0.5.0" }
+scitadel-tui = { path = "../scitadel-tui", version = "0.5.0" }
 rmcp = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }

--- a/crates/scitadel-db/Cargo.toml
+++ b/crates/scitadel-db/Cargo.toml
@@ -12,7 +12,7 @@ description = "SQLite-backed repositories and migrations for scitadel."
 readme = "../../README.md"
 
 [dependencies]
-scitadel-core = { path = "../scitadel-core", version = "0.1.0" }
+scitadel-core = { path = "../scitadel-core", version = "0.5.0" }
 rusqlite = { workspace = true }
 r2d2 = { workspace = true }
 r2d2_sqlite = { workspace = true }

--- a/crates/scitadel-export/Cargo.toml
+++ b/crates/scitadel-export/Cargo.toml
@@ -12,7 +12,7 @@ description = "BibTeX, JSON, and CSV exporters for scitadel search results."
 readme = "../../README.md"
 
 [dependencies]
-scitadel-core = { path = "../scitadel-core", version = "0.1.0" }
+scitadel-core = { path = "../scitadel-core", version = "0.5.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 csv = "1"

--- a/crates/scitadel-mcp/Cargo.toml
+++ b/crates/scitadel-mcp/Cargo.toml
@@ -12,11 +12,11 @@ description = "MCP server exposing scitadel tools to host LLMs."
 readme = "../../README.md"
 
 [dependencies]
-scitadel-core = { path = "../scitadel-core", version = "0.1.0" }
-scitadel-db = { path = "../scitadel-db", version = "0.1.0" }
-scitadel-adapters = { path = "../scitadel-adapters", version = "0.1.0" }
-scitadel-scoring = { path = "../scitadel-scoring", version = "0.1.0" }
-scitadel-export = { path = "../scitadel-export", version = "0.1.0" }
+scitadel-core = { path = "../scitadel-core", version = "0.5.0" }
+scitadel-db = { path = "../scitadel-db", version = "0.5.0" }
+scitadel-adapters = { path = "../scitadel-adapters", version = "0.5.0" }
+scitadel-scoring = { path = "../scitadel-scoring", version = "0.5.0" }
+scitadel-export = { path = "../scitadel-export", version = "0.5.0" }
 rmcp = { workspace = true }
 schemars = { workspace = true }
 tokio = { workspace = true }

--- a/crates/scitadel-scoring/Cargo.toml
+++ b/crates/scitadel-scoring/Cargo.toml
@@ -16,7 +16,7 @@ default = ["scoring"]
 scoring = []
 
 [dependencies]
-scitadel-core = { path = "../scitadel-core", version = "0.1.0" }
+scitadel-core = { path = "../scitadel-core", version = "0.5.0" }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/scitadel-tui/Cargo.toml
+++ b/crates/scitadel-tui/Cargo.toml
@@ -12,9 +12,9 @@ description = "Interactive TUI for browsing scitadel searches, papers, and asses
 readme = "../../README.md"
 
 [dependencies]
-scitadel-core = { path = "../scitadel-core", version = "0.1.0" }
-scitadel-db = { path = "../scitadel-db", version = "0.1.0" }
-scitadel-adapters = { path = "../scitadel-adapters", version = "0.1.0" }
+scitadel-core = { path = "../scitadel-core", version = "0.5.0" }
+scitadel-db = { path = "../scitadel-db", version = "0.5.0" }
+scitadel-adapters = { path = "../scitadel-adapters", version = "0.5.0" }
 ratatui = { workspace = true }
 crossterm = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
Sync the version bump and dated CHANGELOG section from main (post-release-merge) back to dev so dev doesn't think it's still at 0.1.0.