### PR TITLE
feat(tui): Dalton Dark theme + theme.rs abstraction (#136)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- **Dalton Dark theme + central `theme.rs` abstraction** (#136). TUI now
+  pulls colours through semantic roles (`emphasis`, `muted`,
+  `selection_bg`, `quote`, `info`, `success`, `warning`, `danger`, plus
+  an 8-slot highlight palette) rather than hardcoding `Color::Yellow` /
+  `Color::Rgb(...)`. Default palette is [Dalton
+  Dark](https://github.com/gerchowl/dalton-colorscheme), a
+  colourblind-friendly scheme tuned for deuteranopia and protanopia.
+  Light mode and auto-detection ship in #137.
+
 ## [0.5.0] - 2026-04-21
 
 The 2-pane workflow release. Combines the agent-side affordances

--- a/crates/scitadel-tui/src/app.rs
+++ b/crates/scitadel-tui/src/app.rs
@@ -10,7 +10,7 @@ use crossterm::terminal::{
 use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
 use ratatui::layout::{Constraint, Direction, Layout};
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Tabs;
 use tokio::sync::mpsc;
@@ -768,7 +768,7 @@ fn draw(frame: &mut ratatui::Frame, app: &mut App) {
         .select(app.tab.index())
         .highlight_style(
             Style::default()
-                .fg(Color::Yellow)
+                .fg(crate::theme::theme().emphasis)
                 .add_modifier(Modifier::BOLD),
         )
         .divider(Span::raw(" | "));

--- a/crates/scitadel-tui/src/lib.rs
+++ b/crates/scitadel-tui/src/lib.rs
@@ -1,6 +1,7 @@
 mod app;
 mod data;
 mod tasks;
+mod theme;
 mod views;
 mod widgets;
 

--- a/crates/scitadel-tui/src/theme.rs
+++ b/crates/scitadel-tui/src/theme.rs
@@ -45,13 +45,13 @@ impl Theme {
     /// impairing readability.
     pub const DALTON_DARK: Theme = Theme {
         emphasis: Color::Rgb(0xc4, 0xc4, 0x0c),     // dalton yellow
-        muted: Color::Rgb(0x56, 0x71, 0x7f),        // dalton cyan (desaturated; works as secondary text on dark)
+        muted: Color::Rgb(0x56, 0x71, 0x7f), // dalton cyan (desaturated; works as secondary text on dark)
         selection_bg: Color::Rgb(0x33, 0x33, 0x33), // dalton selection
-        quote: Color::Rgb(0x66, 0x91, 0xa7),        // dalton bright-cyan
-        info: Color::Rgb(0x7a, 0xa2, 0xf7),         // dalton blue
-        success: Color::Rgb(0x5b, 0x91, 0x4e),      // dalton green
-        warning: Color::Rgb(0xc4, 0xc4, 0x0c),      // dalton yellow (same as emphasis — attention-worthy)
-        danger: Color::Rgb(0xd8, 0x50, 0x50),       // dalton red
+        quote: Color::Rgb(0x66, 0x91, 0xa7), // dalton bright-cyan
+        info: Color::Rgb(0x7a, 0xa2, 0xf7),  // dalton blue
+        success: Color::Rgb(0x5b, 0x91, 0x4e), // dalton green
+        warning: Color::Rgb(0xc4, 0xc4, 0x0c), // dalton yellow (same as emphasis — attention-worthy)
+        danger: Color::Rgb(0xd8, 0x50, 0x50),  // dalton red
         highlights: [
             Color::Rgb(0x56, 0x1f, 0x1f), // muted red
             Color::Rgb(0x24, 0x3a, 0x1f), // muted green

--- a/crates/scitadel-tui/src/theme.rs
+++ b/crates/scitadel-tui/src/theme.rs
@@ -1,0 +1,119 @@
+//! Semantic color theming for the TUI (#136).
+//!
+//! Every TUI view pulls colors through named roles on [`Theme`] rather
+//! than hardcoding palette (`Color::Yellow`) or RGB values. That lets
+//! the theme be swapped wholesale — currently Dalton Dark by default;
+//! light mode + auto-detection ships in #137.
+//!
+//! Dalton Dark is a colorblind-friendly scheme tuned for deuteranopia
+//! and protanopia. Source: <https://github.com/gerchowl/dalton-colorscheme>.
+
+use ratatui::style::Color;
+
+/// Semantic color roles used across all TUI views.
+#[derive(Debug, Clone, Copy)]
+pub struct Theme {
+    /// Borders, headers, status-bar mode labels, the active-tab marker.
+    pub emphasis: Color,
+    /// Secondary text — labels on form prompts, metadata under titles,
+    /// empty-state messages, help-bar body text.
+    pub muted: Color,
+    /// Background of the currently-selected table row / list item.
+    pub selection_bg: Color,
+    /// Annotation quoted text (the literal quoted-passage spans in
+    /// the paper detail and annotation prompt).
+    pub quote: Color,
+    /// Neutral informational colour — task-panel ref IDs, links.
+    pub info: Color,
+    /// Positive state — downloaded, task done, healthy.
+    pub success: Color,
+    /// Attention-worthy but not broken — paywall, in-flight download,
+    /// [OFFLINE] badge.
+    pub warning: Color,
+    /// Error state — failed download, delete-confirm prompt cursor.
+    pub danger: Color,
+    /// 8 muted background tints used behind annotation highlights in the
+    /// two-pane reader (#97). Palette is hashed by thread `root_id` so
+    /// a thread keeps the same colour across renders.
+    pub highlights: [Color; 8],
+}
+
+impl Theme {
+    /// Colourblind-friendly dark theme. Foreground roles use Dalton's
+    /// base palette; the 8 highlight backgrounds are muted chromatic
+    /// variants tuned to sit behind default-foreground text without
+    /// impairing readability.
+    pub const DALTON_DARK: Theme = Theme {
+        emphasis: Color::Rgb(0xc4, 0xc4, 0x0c),     // dalton yellow
+        muted: Color::Rgb(0x56, 0x71, 0x7f),        // dalton cyan (desaturated; works as secondary text on dark)
+        selection_bg: Color::Rgb(0x33, 0x33, 0x33), // dalton selection
+        quote: Color::Rgb(0x66, 0x91, 0xa7),        // dalton bright-cyan
+        info: Color::Rgb(0x7a, 0xa2, 0xf7),         // dalton blue
+        success: Color::Rgb(0x5b, 0x91, 0x4e),      // dalton green
+        warning: Color::Rgb(0xc4, 0xc4, 0x0c),      // dalton yellow (same as emphasis — attention-worthy)
+        danger: Color::Rgb(0xd8, 0x50, 0x50),       // dalton red
+        highlights: [
+            Color::Rgb(0x56, 0x1f, 0x1f), // muted red
+            Color::Rgb(0x24, 0x3a, 0x1f), // muted green
+            Color::Rgb(0x4e, 0x4e, 0x05), // muted yellow
+            Color::Rgb(0x30, 0x40, 0x60), // muted blue
+            Color::Rgb(0x40, 0x20, 0x53), // muted magenta
+            Color::Rgb(0x22, 0x2d, 0x33), // muted cyan
+            Color::Rgb(0x3c, 0x48, 0x60), // muted bright-blue
+            Color::Rgb(0x4d, 0x2d, 0x60), // muted bright-magenta
+        ],
+    };
+
+    /// Pick a highlight colour for a string key (e.g. annotation
+    /// root_id). djb2 hash modulo palette size so the mapping is
+    /// stable across runs.
+    #[must_use]
+    pub fn highlight_for(&self, key: &str) -> Color {
+        let mut h: u64 = 5381;
+        for b in key.as_bytes() {
+            h = h.wrapping_mul(33).wrapping_add(u64::from(*b));
+        }
+        self.highlights[(h as usize) % self.highlights.len()]
+    }
+}
+
+/// Process-wide active theme. Currently a const alias for Dalton Dark;
+/// #137 replaces this with a runtime-resolved value (config, flag,
+/// env, auto-detect).
+pub const ACTIVE: &Theme = &Theme::DALTON_DARK;
+
+/// Convenience accessor. `crate::theme::theme().emphasis` reads better
+/// at call sites than `crate::theme::ACTIVE.emphasis`.
+#[must_use]
+pub fn theme() -> &'static Theme {
+    ACTIVE
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn highlight_for_is_stable() {
+        let t = Theme::DALTON_DARK;
+        // Same input → same colour, every call, every process.
+        let a1 = t.highlight_for("ann-root-1");
+        let a2 = t.highlight_for("ann-root-1");
+        assert_eq!(a1, a2);
+    }
+
+    #[test]
+    fn highlight_for_covers_palette() {
+        let t = Theme::DALTON_DARK;
+        // A small sample of distinct keys should hit multiple slots —
+        // not all 8, but > 1 — otherwise the hash is broken.
+        let distinct: std::collections::HashSet<_> = (0..50)
+            .map(|i| t.highlight_for(&format!("root-{i}")))
+            .collect();
+        assert!(
+            distinct.len() > 3,
+            "expected hash to spread across palette; got {} distinct slots",
+            distinct.len()
+        );
+    }
+}

--- a/crates/scitadel-tui/src/views/annotation_prompt.rs
+++ b/crates/scitadel-tui/src/views/annotation_prompt.rs
@@ -11,7 +11,7 @@
 
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 
@@ -246,7 +246,7 @@ pub fn draw_overlay(frame: &mut Frame, area: Rect, prompt: &AnnotationPrompt) {
     let inner = Block::default()
         .title(prompt.title())
         .borders(Borders::ALL)
-        .style(Style::default().fg(Color::Yellow));
+        .style(Style::default().fg(crate::theme::theme().emphasis));
     let inner_area = modal;
     frame.render_widget(inner, inner_area);
 
@@ -266,8 +266,8 @@ pub fn draw_overlay(frame: &mut Frame, area: Rect, prompt: &AnnotationPrompt) {
     } = prompt
     {
         lines.push(Line::from(vec![
-            Span::styled("quote: ", Style::default().fg(Color::DarkGray)),
-            Span::styled(format!("\"{quote_buf}\""), Style::default().fg(Color::Cyan)),
+            Span::styled("quote: ", Style::default().fg(crate::theme::theme().muted)),
+            Span::styled(format!("\"{quote_buf}\""), Style::default().fg(crate::theme::theme().quote)),
         ]));
         lines.push(Line::from(""));
     }
@@ -277,7 +277,7 @@ pub fn draw_overlay(frame: &mut Frame, area: Rect, prompt: &AnnotationPrompt) {
             Span::raw("Delete annotation "),
             Span::styled(
                 annotation_id.clone(),
-                Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+                Style::default().fg(crate::theme::theme().danger).add_modifier(Modifier::BOLD),
             ),
             Span::raw("?"),
         ]));
@@ -300,11 +300,11 @@ pub fn draw_overlay(frame: &mut Frame, area: Rect, prompt: &AnnotationPrompt) {
         lines.push(Line::from(vec![
             Span::styled(
                 format!("{prompt_label}: "),
-                Style::default().fg(Color::DarkGray),
+                Style::default().fg(crate::theme::theme().muted),
             ),
             Span::raw(prompt.body().to_string()),
             // Trailing block-cursor hint so the user can see the caret.
-            Span::styled("█", Style::default().fg(Color::Yellow)),
+            Span::styled("█", Style::default().fg(crate::theme::theme().emphasis)),
         ]));
     }
 

--- a/crates/scitadel-tui/src/views/annotation_prompt.rs
+++ b/crates/scitadel-tui/src/views/annotation_prompt.rs
@@ -267,7 +267,10 @@ pub fn draw_overlay(frame: &mut Frame, area: Rect, prompt: &AnnotationPrompt) {
     {
         lines.push(Line::from(vec![
             Span::styled("quote: ", Style::default().fg(crate::theme::theme().muted)),
-            Span::styled(format!("\"{quote_buf}\""), Style::default().fg(crate::theme::theme().quote)),
+            Span::styled(
+                format!("\"{quote_buf}\""),
+                Style::default().fg(crate::theme::theme().quote),
+            ),
         ]));
         lines.push(Line::from(""));
     }
@@ -277,7 +280,9 @@ pub fn draw_overlay(frame: &mut Frame, area: Rect, prompt: &AnnotationPrompt) {
             Span::raw("Delete annotation "),
             Span::styled(
                 annotation_id.clone(),
-                Style::default().fg(crate::theme::theme().danger).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(crate::theme::theme().danger)
+                    .add_modifier(Modifier::BOLD),
             ),
             Span::raw("?"),
         ]));

--- a/crates/scitadel-tui/src/views/detail.rs
+++ b/crates/scitadel-tui/src/views/detail.rs
@@ -144,7 +144,10 @@ pub fn draw(
             if let Some(quote) = ann.anchor.quote.as_deref() {
                 lines.push(Line::from(vec![
                     Span::styled(marker, marker_style),
-                    Span::styled(format!("\"{quote}\" "), Style::default().fg(crate::theme::theme().quote)),
+                    Span::styled(
+                        format!("\"{quote}\" "),
+                        Style::default().fg(crate::theme::theme().quote),
+                    ),
                     Span::styled(
                         format!("— {}", ann.anchor.status.as_str()),
                         Style::default().fg(crate::theme::theme().muted),

--- a/crates/scitadel-tui/src/views/detail.rs
+++ b/crates/scitadel-tui/src/views/detail.rs
@@ -1,6 +1,6 @@
 use ratatui::Frame;
 use ratatui::layout::Rect;
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
 
@@ -28,7 +28,7 @@ pub fn draw(
         .unwrap_or_default();
 
     let label_style = Style::default()
-        .fg(Color::Yellow)
+        .fg(crate::theme::theme().emphasis)
         .add_modifier(Modifier::BOLD);
 
     let mut lines: Vec<Line<'_>> = Vec::new();
@@ -136,7 +136,7 @@ pub fn draw(
             };
             let marker_style = if is_focused {
                 Style::default()
-                    .fg(Color::Yellow)
+                    .fg(crate::theme::theme().emphasis)
                     .add_modifier(Modifier::BOLD)
             } else {
                 Style::default()
@@ -144,10 +144,10 @@ pub fn draw(
             if let Some(quote) = ann.anchor.quote.as_deref() {
                 lines.push(Line::from(vec![
                     Span::styled(marker, marker_style),
-                    Span::styled(format!("\"{quote}\" "), Style::default().fg(Color::Cyan)),
+                    Span::styled(format!("\"{quote}\" "), Style::default().fg(crate::theme::theme().quote)),
                     Span::styled(
                         format!("— {}", ann.anchor.status.as_str()),
-                        Style::default().fg(Color::DarkGray),
+                        Style::default().fg(crate::theme::theme().muted),
                     ),
                 ]));
                 lines.push(Line::from(format!(
@@ -162,7 +162,7 @@ pub fn draw(
                     Span::styled(marker, marker_style),
                     Span::styled(
                         format!("{}: ", ann.author),
-                        Style::default().fg(Color::Yellow),
+                        Style::default().fg(crate::theme::theme().emphasis),
                     ),
                     Span::raw(ann.note.clone()),
                 ]));

--- a/crates/scitadel-tui/src/views/papers.rs
+++ b/crates/scitadel-tui/src/views/papers.rs
@@ -51,14 +51,15 @@ pub fn draw_for_search(
 /// `↻` if a download is currently running for this paper, otherwise
 /// derived from the persisted `download_status` (#112).
 fn download_cell(paper: &Paper, downloading: &HashSet<String>) -> (&'static str, Color) {
+    let t = crate::theme::theme();
     if downloading.contains(paper.id.as_str()) {
-        return ("↻", Color::Yellow);
+        return ("↻", t.warning);
     }
     match paper.download_status {
-        Some(DownloadStatus::Downloaded) => ("✓", Color::Green),
-        Some(DownloadStatus::Paywall) => ("⊘", Color::Yellow),
-        Some(DownloadStatus::Failed) => ("✗", Color::Red),
-        None => (" ", Color::DarkGray),
+        Some(DownloadStatus::Downloaded) => ("✓", t.success),
+        Some(DownloadStatus::Paywall) => ("⊘", t.warning),
+        Some(DownloadStatus::Failed) => ("✗", t.danger),
+        None => (" ", t.muted),
     }
 }
 
@@ -90,7 +91,7 @@ fn render_paper_table(
     ])
     .style(
         Style::default()
-            .fg(Color::Yellow)
+            .fg(crate::theme::theme().emphasis)
             .add_modifier(Modifier::BOLD),
     );
 
@@ -109,7 +110,7 @@ fn render_paper_table(
 
             Row::new(vec![
                 Cell::from((i + 1).to_string()),
-                Cell::from(star).style(Style::default().fg(Color::Yellow)),
+                Cell::from(star).style(Style::default().fg(crate::theme::theme().emphasis)),
                 Cell::from(dl_symbol).style(Style::default().fg(dl_color)),
                 Cell::from(truncate(&p.title, 60)),
                 Cell::from(truncate(&authors, 30)),
@@ -136,7 +137,7 @@ fn render_paper_table(
         )
         .row_highlight_style(
             Style::default()
-                .bg(Color::DarkGray)
+                .bg(crate::theme::theme().selection_bg)
                 .add_modifier(Modifier::BOLD),
         );
 

--- a/crates/scitadel-tui/src/views/questions.rs
+++ b/crates/scitadel-tui/src/views/questions.rs
@@ -1,6 +1,6 @@
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Rect};
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::{Modifier, Style};
 use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table, TableState};
 
 use crate::data::DataStore;
@@ -28,7 +28,7 @@ pub fn draw(frame: &mut Frame, area: Rect, data: &DataStore, selected: usize) {
     ])
     .style(
         Style::default()
-            .fg(Color::Yellow)
+            .fg(crate::theme::theme().emphasis)
             .add_modifier(Modifier::BOLD),
     );
 
@@ -62,7 +62,7 @@ pub fn draw(frame: &mut Frame, area: Rect, data: &DataStore, selected: usize) {
         )
         .row_highlight_style(
             Style::default()
-                .bg(Color::DarkGray)
+                .bg(crate::theme::theme().selection_bg)
                 .add_modifier(Modifier::BOLD),
         );
 

--- a/crates/scitadel-tui/src/views/reader.rs
+++ b/crates/scitadel-tui/src/views/reader.rs
@@ -22,20 +22,9 @@ use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
 use crate::data::DataStore;
 use scitadel_core::models::Annotation;
 
-/// Palette of muted background tints for highlighting annotation
-/// spans. Hashed by the annotation's root_id so a thread keeps the
-/// same color on every render. 8 entries — enough for a typical
-/// paper without every passage looking identical.
-const HIGHLIGHT_COLORS: [Color; 8] = [
-    Color::Rgb(80, 60, 30), // dim amber
-    Color::Rgb(30, 60, 80), // dim teal
-    Color::Rgb(60, 30, 80), // dim purple
-    Color::Rgb(30, 80, 50), // dim green
-    Color::Rgb(80, 30, 60), // dim magenta
-    Color::Rgb(60, 70, 30), // dim olive
-    Color::Rgb(30, 70, 80), // dim cyan
-    Color::Rgb(80, 50, 30), // dim rust
-];
+// Highlight palette lives in `crate::theme` (#136). This keeps the 8
+// annotation-background tints swappable alongside the rest of the UI
+// when light-mode / auto-detect ships in #137.
 
 pub fn draw(frame: &mut Frame, area: Rect, data: &DataStore, paper_id: &str, focus: Option<usize>) {
     let Ok(Some(paper)) = data.load_paper(paper_id) else {
@@ -114,7 +103,7 @@ fn draw_notes_pane(
         let marker = if is_focused { "▶ " } else { "  " };
         let marker_style = if is_focused {
             Style::default()
-                .fg(Color::Yellow)
+                .fg(crate::theme::theme().emphasis)
                 .add_modifier(Modifier::BOLD)
         } else {
             Style::default()
@@ -128,13 +117,13 @@ fn draw_notes_pane(
                 ),
                 Span::styled(
                     format!(" — {}", root.anchor.status.as_str()),
-                    Style::default().fg(Color::DarkGray),
+                    Style::default().fg(crate::theme::theme().muted),
                 ),
             ]));
         } else {
             lines.push(Line::from(vec![
                 Span::styled(marker, marker_style),
-                Span::styled("(no quote)", Style::default().fg(Color::DarkGray)),
+                Span::styled("(no quote)", Style::default().fg(crate::theme::theme().muted)),
             ]));
         }
         lines.push(Line::from(format!(
@@ -153,7 +142,7 @@ fn draw_notes_pane(
                 Span::raw("    └ "),
                 Span::styled(
                     format!("{}: ", ann.author),
-                    Style::default().fg(Color::Yellow),
+                    Style::default().fg(crate::theme::theme().emphasis),
                 ),
                 Span::raw(ann.note.clone()),
             ]));
@@ -283,13 +272,10 @@ fn slice_chars(chars: &[char], start: usize, end: usize) -> String {
     chars[start..end].iter().collect()
 }
 
-/// Stable-per-thread color: hash the root_id and pick from the palette.
+/// Stable-per-thread color: delegates to `Theme::highlight_for` on the
+/// active theme so this module stays palette-agnostic (#136).
 fn color_for(root_id: &str) -> Color {
-    let mut hash: u32 = 0;
-    for b in root_id.bytes() {
-        hash = hash.wrapping_mul(31).wrapping_add(u32::from(b));
-    }
-    HIGHLIGHT_COLORS[(hash as usize) % HIGHLIGHT_COLORS.len()]
+    crate::theme::theme().highlight_for(root_id)
 }
 
 /// How many root annotations does this paper have? Used by the app

--- a/crates/scitadel-tui/src/views/reader.rs
+++ b/crates/scitadel-tui/src/views/reader.rs
@@ -123,7 +123,10 @@ fn draw_notes_pane(
         } else {
             lines.push(Line::from(vec![
                 Span::styled(marker, marker_style),
-                Span::styled("(no quote)", Style::default().fg(crate::theme::theme().muted)),
+                Span::styled(
+                    "(no quote)",
+                    Style::default().fg(crate::theme::theme().muted),
+                ),
             ]));
         }
         lines.push(Line::from(format!(

--- a/crates/scitadel-tui/src/views/searches.rs
+++ b/crates/scitadel-tui/src/views/searches.rs
@@ -1,6 +1,6 @@
 use ratatui::Frame;
 use ratatui::layout::Rect;
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::{Modifier, Style};
 use ratatui::widgets::{Block, Borders, Cell, Row, Table, TableState};
 
 use scitadel_core::models::SourceStatus;
@@ -30,7 +30,7 @@ pub fn draw(frame: &mut Frame, area: Rect, data: &DataStore, selected: usize) {
     ])
     .style(
         Style::default()
-            .fg(Color::Yellow)
+            .fg(crate::theme::theme().emphasis)
             .add_modifier(Modifier::BOLD),
     );
 
@@ -67,7 +67,7 @@ pub fn draw(frame: &mut Frame, area: Rect, data: &DataStore, selected: usize) {
         .block(Block::default().title(" Searches ").borders(Borders::ALL))
         .row_highlight_style(
             Style::default()
-                .bg(Color::DarkGray)
+                .bg(crate::theme::theme().selection_bg)
                 .add_modifier(Modifier::BOLD),
         );
 

--- a/crates/scitadel-tui/src/views/tasks.rs
+++ b/crates/scitadel-tui/src/views/tasks.rs
@@ -1,6 +1,6 @@
 use ratatui::Frame;
 use ratatui::layout::Rect;
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, List, ListItem};
 use scitadel_adapters::download::AccessStatus;
@@ -28,11 +28,12 @@ pub fn draw(frame: &mut Frame, area: Rect, tasks: &[Task], show_institutional_hi
 }
 
 fn render_row(task: &Task, show_institutional_hint: bool) -> ListItem<'_> {
+    let t = crate::theme::theme();
     let (icon, color) = match &task.status {
-        TaskStatus::Queued => ("…", Color::DarkGray),
-        TaskStatus::Running => ("◐", Color::Yellow),
-        TaskStatus::Done { .. } => ("✓", Color::Green),
-        TaskStatus::Failed(_) => ("✗", Color::Red),
+        TaskStatus::Queued => ("…", t.muted),
+        TaskStatus::Running => ("◐", t.warning),
+        TaskStatus::Done { .. } => ("✓", t.success),
+        TaskStatus::Failed(_) => ("✗", t.danger),
     };
 
     let (title, ref_id) = match &task.kind {
@@ -48,8 +49,8 @@ fn render_row(task: &Task, show_institutional_hint: bool) -> ListItem<'_> {
         ),
         Span::raw(title),
         Span::raw("  "),
-        Span::styled(format!("[{ref_id}] "), Style::default().fg(Color::Blue)),
-        Span::styled(status_tail, Style::default().fg(Color::DarkGray)),
+        Span::styled(format!("[{ref_id}] "), Style::default().fg(crate::theme::theme().info)),
+        Span::styled(status_tail, Style::default().fg(crate::theme::theme().muted)),
     ]))
 }
 

--- a/crates/scitadel-tui/src/views/tasks.rs
+++ b/crates/scitadel-tui/src/views/tasks.rs
@@ -49,8 +49,14 @@ fn render_row(task: &Task, show_institutional_hint: bool) -> ListItem<'_> {
         ),
         Span::raw(title),
         Span::raw("  "),
-        Span::styled(format!("[{ref_id}] "), Style::default().fg(crate::theme::theme().info)),
-        Span::styled(status_tail, Style::default().fg(crate::theme::theme().muted)),
+        Span::styled(
+            format!("[{ref_id}] "),
+            Style::default().fg(crate::theme::theme().info),
+        ),
+        Span::styled(
+            status_tail,
+            Style::default().fg(crate::theme::theme().muted),
+        ),
     ]))
 }
 

--- a/crates/scitadel-tui/src/widgets/status_bar.rs
+++ b/crates/scitadel-tui/src/widgets/status_bar.rs
@@ -1,6 +1,6 @@
 use ratatui::Frame;
 use ratatui::layout::Rect;
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 
@@ -10,13 +10,13 @@ pub fn draw(frame: &mut Frame, area: Rect, help_text: &str, offline: bool) {
         spans.push(Span::styled(
             "[OFFLINE] ",
             Style::default()
-                .fg(Color::Yellow)
+                .fg(crate::theme::theme().emphasis)
                 .add_modifier(Modifier::BOLD),
         ));
     }
     spans.push(Span::styled(
         help_text.to_string(),
-        Style::default().fg(Color::DarkGray),
+        Style::default().fg(crate::theme::theme().muted),
     ));
     let bar = Paragraph::new(Line::from(spans));
     frame.render_widget(bar, area);


### PR DESCRIPTION
## Summary

- New \`crates/scitadel-tui/src/theme.rs\` with 9 semantic roles (emphasis, muted, selection_bg, quote, info, success, warning, danger, highlights[8]).
- Default palette is [Dalton Dark](https://github.com/gerchowl/dalton-colorscheme) — colourblind-friendly, tuned for deuteranopia + protanopia.
- Every \`Color::Yellow\` / \`Color::Rgb(...)\` / etc. call in TUI views now routes through the theme — 55 sites total.
- Groundwork for #137 (light mode + auto-detect via COLORFGBG / OSC 11).

## Test plan

- [x] Unit tests: \`highlight_for\` stable across calls, palette coverage test
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] Reader VHS tape re-rendered locally — three distinct muted-chromatic highlights visible

Closes #136.