### PR TITLE
fix(tui): fail fast on D download when offline + offline-safety test (#51)

### DIFF
--- a/crates/scitadel-db/src/sqlite/annotations.rs
+++ b/crates/scitadel-db/src/sqlite/annotations.rs
@@ -549,6 +549,42 @@ mod tests {
         )
     }
 
+    /// Offline-safe invariant (#51). Every annotation write path
+    /// (`create`, replies, `update_note`, `soft_delete`) must be purely
+    /// local — no network, no auth probe, no reqwest. The 2-pane
+    /// workflow makes this trust-critical: a user on a plane still
+    /// captures their reading notes; the TUI's offline badge only
+    /// gates network-requiring operations (search / download), not
+    /// annotations.
+    ///
+    /// This test locks that invariant in: the entire annotation
+    /// lifecycle round-trips through a fresh in-memory SQLite DB with
+    /// no `reqwest::Client`, no environment, no adapters instantiated.
+    /// If a future refactor introduces a network dep on this path,
+    /// the construction of that dep will either force this test to
+    /// change or will be catchable by review.
+    #[test]
+    fn annotation_writes_are_offline_safe() {
+        let db = fresh_db_with_paper();
+        let repo = SqliteAnnotationRepository::new(db);
+
+        // Create root → reply → update root note → soft-delete reply.
+        // If any of these silently required network access, the call
+        // chain wouldn't compile (no reqwest in this crate's deps).
+        let root = sample_root();
+        repo.create(&root).unwrap();
+        let reply = Annotation::new_reply(&root, "claude".into(), "seconded".into());
+        repo.create(&reply).unwrap();
+        repo.update_note(root.id.as_str(), "edited offline", None, &[])
+            .unwrap();
+        repo.soft_delete(reply.id.as_str()).unwrap();
+
+        // Survivors visible on next read.
+        let all = repo.list_by_paper("p1").unwrap();
+        assert_eq!(all.len(), 1, "root survives; reply tombstoned out");
+        assert_eq!(all[0].note, "edited offline");
+    }
+
     #[test]
     fn create_and_get_roundtrip() {
         let db = fresh_db_with_paper();

--- a/crates/scitadel-tui/src/app.rs
+++ b/crates/scitadel-tui/src/app.rs
@@ -418,10 +418,7 @@ impl App {
         // offline badge is already showing; the user can retry after
         // reconnecting.
         if self.offline {
-            let _ = crate::tasks::synthesize_offline_failure(
-                self.task_tx.clone(),
-                &paper,
-            );
+            let _ = crate::tasks::synthesize_offline_failure(self.task_tx.clone(), &paper);
             return;
         }
         spawn_download_paper(

--- a/crates/scitadel-tui/src/app.rs
+++ b/crates/scitadel-tui/src/app.rs
@@ -412,6 +412,18 @@ impl App {
             Ok(Some(p)) => p,
             _ => return,
         };
+        // Fail fast when we know the network is down — spawning the
+        // download task anyway would waste ~60s on a reqwest timeout
+        // before surfacing the failure in the task panel (#51). The
+        // offline badge is already showing; the user can retry after
+        // reconnecting.
+        if self.offline {
+            let _ = crate::tasks::synthesize_offline_failure(
+                self.task_tx.clone(),
+                &paper,
+            );
+            return;
+        }
         spawn_download_paper(
             self.task_tx.clone(),
             paper,

--- a/crates/scitadel-tui/src/tasks.rs
+++ b/crates/scitadel-tui/src/tasks.rs
@@ -73,6 +73,40 @@ pub fn clear_terminal(tasks: &mut Vec<Task>) {
     tasks.retain(|t| matches!(t.status, TaskStatus::Queued | TaskStatus::Running));
 }
 
+/// Fail-fast variant for when the TUI knows the network is down (#51).
+/// Instead of spawning a download that will time out on reqwest after
+/// ~60s, synthesize a task that transitions immediately to `Failed`
+/// with a clear offline message. Returns the task id so callers can
+/// reference it.
+pub fn synthesize_offline_failure(tx: UnboundedSender<TaskUpdate>, paper: &Paper) -> Uuid {
+    let id = Uuid::new_v4();
+    let ref_id = paper
+        .doi
+        .clone()
+        .filter(|s| !s.is_empty())
+        .or_else(|| paper.arxiv_id.clone().filter(|s| !s.is_empty()))
+        .or_else(|| paper.openalex_id.clone().filter(|s| !s.is_empty()))
+        .unwrap_or_else(|| paper.id.as_str().chars().take(8).collect());
+    let task = Task {
+        id,
+        kind: TaskKind::Download {
+            paper_id: paper.id.as_str().to_string(),
+            ref_id,
+            title: paper.title.clone(),
+        },
+        status: TaskStatus::Queued,
+        terminal_at: None,
+    };
+    let _ = tx.send(TaskUpdate::New(task));
+    let _ = tx.send(TaskUpdate::Status {
+        id,
+        status: TaskStatus::Failed(
+            "offline: download requires network — retry after reconnecting".to_string(),
+        ),
+    });
+    id
+}
+
 /// Spawn a download for a full `Paper` (uses all available identifiers).
 pub fn spawn_download_paper(
     tx: UnboundedSender<TaskUpdate>,


### PR DESCRIPTION
## Summary

- \`App::queue_download\` checks \`self.offline\` and synthesises an immediate \`Failed\` task instead of waiting ~60s for reqwest timeout.
- New \`synthesize_offline_failure\` helper in \`tasks.rs\` — emits New + Failed frames through the normal channel.
- New \`annotation_writes_are_offline_safe\` test locks the invariant that annotation CRUD is pure SQLite (no reqwest dep in the path).

## Test plan

- [x] \`cargo test --workspace\` — 18 annotation tests incl. the new offline-safe round-trip
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean

Closes #51.