### PR TITLE
feat(tui): Queue tab — cross-search starred aggregator (#48 reduced)

### DIFF
--- a/crates/scitadel-db/src/sqlite/paper_state.rs
+++ b/crates/scitadel-db/src/sqlite/paper_state.rs
@@ -104,6 +104,22 @@ impl SqlitePaperStateRepository {
         }
         Ok(out)
     }
+
+    /// Paper IDs starred by `reader`, ordered by when the star was set
+    /// (most recent first). Drives the Queue tab (#48) — a cross-search
+    /// aggregator of starred papers. The partial index on
+    /// `paper_state(starred) WHERE starred = 1` keeps this cheap even
+    /// with thousands of rows.
+    pub fn starred_ids_ordered(&self, reader: &str) -> Result<Vec<String>, DbError> {
+        let conn = self.db.conn()?;
+        let mut stmt = conn.prepare(
+            "SELECT paper_id FROM paper_state
+             WHERE reader = ?1 AND starred = 1
+             ORDER BY updated_at DESC",
+        )?;
+        let rows = stmt.query_map(params![reader], |row| row.get::<_, String>(0))?;
+        Ok(rows.filter_map(Result::ok).collect())
+    }
 }
 
 #[cfg(test)]
@@ -150,5 +166,40 @@ mod tests {
         repo.toggle_starred("p1", "me").unwrap();
         let ids = repo.starred_ids("me").unwrap();
         assert!(ids.contains("p1"));
+    }
+
+    #[test]
+    fn starred_ids_ordered_returns_most_recent_first() {
+        let db = fresh_db();
+        // Add a second paper so we can observe ordering.
+        db.conn()
+            .unwrap()
+            .execute(
+                "INSERT INTO papers (id, title, created_at, updated_at)
+                 VALUES ('p2', 't2', datetime('now'), datetime('now'))",
+                [],
+            )
+            .unwrap();
+        let repo = SqlitePaperStateRepository::new(db);
+
+        // Star p1 first, then p2; the Queue tab (#48) expects the most
+        // recently starred to surface at the top of the list.
+        repo.toggle_starred("p1", "lars").unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        repo.toggle_starred("p2", "lars").unwrap();
+
+        let ordered = repo.starred_ids_ordered("lars").unwrap();
+        assert_eq!(ordered.len(), 2);
+        assert_eq!(ordered[0], "p2", "most recent first");
+        assert_eq!(ordered[1], "p1");
+    }
+
+    #[test]
+    fn starred_ids_ordered_drops_unstarred() {
+        let db = fresh_db();
+        let repo = SqlitePaperStateRepository::new(db);
+        repo.toggle_starred("p1", "lars").unwrap();
+        repo.toggle_starred("p1", "lars").unwrap(); // back to unstarred
+        assert!(repo.starred_ids_ordered("lars").unwrap().is_empty());
     }
 }

--- a/crates/scitadel-tui/src/app.rs
+++ b/crates/scitadel-tui/src/app.rs
@@ -18,7 +18,9 @@ use tokio::sync::mpsc;
 use crate::data::DataStore;
 use crate::tasks::{Task, TaskKind, TaskStatus, TaskUpdate, spawn_download_paper};
 use crate::views::annotation_prompt::{AnnotationPrompt, PromptCommit, PromptSubmission};
-use crate::views::{annotation_prompt, detail, papers, questions, searches, tasks as tasks_view};
+use crate::views::{
+    annotation_prompt, detail, papers, queue, questions, searches, tasks as tasks_view,
+};
 use crate::widgets::status_bar;
 
 /// Active tab in the TUI.
@@ -27,16 +29,27 @@ pub enum Tab {
     Searches,
     Papers,
     Questions,
+    /// Cross-search aggregator showing all starred papers (#48).
+    /// Reuses the Papers-tab rendering + Enter-to-open-detail flow
+    /// but backs the data by `paper_state.starred = 1` instead of
+    /// a single search.
+    Queue,
 }
 
 impl Tab {
-    const ALL: [Self; 3] = [Self::Searches, Self::Papers, Self::Questions];
+    const ALL: [Self; 4] = [
+        Self::Searches,
+        Self::Papers,
+        Self::Questions,
+        Self::Queue,
+    ];
 
     fn index(self) -> usize {
         match self {
             Self::Searches => 0,
             Self::Papers => 1,
             Self::Questions => 2,
+            Self::Queue => 3,
         }
     }
 
@@ -44,15 +57,17 @@ impl Tab {
         match self {
             Self::Searches => Self::Papers,
             Self::Papers => Self::Questions,
-            Self::Questions => Self::Searches,
+            Self::Questions => Self::Queue,
+            Self::Queue => Self::Searches,
         }
     }
 
     fn prev(self) -> Self {
         match self {
-            Self::Searches => Self::Questions,
+            Self::Searches => Self::Queue,
             Self::Papers => Self::Searches,
             Self::Questions => Self::Papers,
+            Self::Queue => Self::Questions,
         }
     }
 }
@@ -94,6 +109,7 @@ pub struct App {
     pub search_selected: usize,
     pub paper_selected: usize,
     pub question_selected: usize,
+    pub queue_selected: usize,
 
     pub tasks: Vec<Task>,
     /// Last `TuiState` written to the DB, used by `publish_tui_state`
@@ -141,6 +157,7 @@ impl App {
             search_selected: 0,
             paper_selected: 0,
             question_selected: 0,
+            queue_selected: 0,
             tasks: Vec::new(),
             last_published_state: None,
             unpaywall_email,
@@ -203,6 +220,7 @@ impl App {
             Tab::Searches => "Searches",
             Tab::Papers => "Papers",
             Tab::Questions => "Questions",
+            Tab::Queue => "Queue",
         };
         let (paper_id, search_id, annotation_id) = match &self.overlay {
             Some(Overlay::PaperDetail {
@@ -675,6 +693,54 @@ impl App {
                     _ => {}
                 }
             }
+            Tab::Queue => {
+                let count = self
+                    .data
+                    .load_starred_papers(&self.reader)
+                    .map_or(0, |p| p.len());
+                match code {
+                    KeyCode::Char('j') | KeyCode::Down if count > 0 => {
+                        self.queue_selected = (self.queue_selected + 1).min(count - 1);
+                    }
+                    KeyCode::Char('k') | KeyCode::Up => {
+                        self.queue_selected = self.queue_selected.saturating_sub(1);
+                    }
+                    KeyCode::Enter => {
+                        if let Ok(papers) = self.data.load_starred_papers(&self.reader)
+                            && let Some(paper) = papers.get(self.queue_selected)
+                        {
+                            self.overlay = Some(Overlay::PaperDetail {
+                                paper_id: paper.id.as_str().to_string(),
+                                scroll: 0,
+                                annotation_focus: None,
+                                prompt: None,
+                                reader: false,
+                                highlight_focus: None,
+                            });
+                        }
+                    }
+                    KeyCode::Char('s') => {
+                        // Unstar: consistent with Papers tab behaviour.
+                        if let Ok(papers) = self.data.load_starred_papers(&self.reader)
+                            && let Some(paper) = papers.get(self.queue_selected)
+                        {
+                            let pid = paper.id.as_str().to_string();
+                            self.toggle_star(&pid);
+                            // Clamp cursor — list just shrank by one.
+                            let new_count = self
+                                .data
+                                .load_starred_papers(&self.reader)
+                                .map_or(0, |p| p.len());
+                            if new_count > 0 {
+                                self.queue_selected = self.queue_selected.min(new_count - 1);
+                            } else {
+                                self.queue_selected = 0;
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
         }
     }
 }
@@ -759,6 +825,7 @@ fn draw(frame: &mut ratatui::Frame, app: &mut App) {
                 Tab::Searches => "Searches",
                 Tab::Papers => "Papers",
                 Tab::Questions => "Questions",
+                Tab::Queue => "Queue",
             };
             Line::from(Span::raw(label))
         })
@@ -827,6 +894,14 @@ fn draw(frame: &mut ratatui::Frame, app: &mut App) {
             Tab::Questions => {
                 questions::draw(frame, chunks[1], &app.data, app.question_selected);
             }
+            Tab::Queue => queue::draw(
+                frame,
+                chunks[1],
+                &app.data,
+                &app.reader,
+                app.queue_selected,
+                &app.downloading_paper_ids(),
+            ),
         },
     }
 
@@ -867,8 +942,8 @@ fn draw(frame: &mut ratatui::Frame, app: &mut App) {
         (Some(Overlay::SearchPapers { .. }), _) => {
             "Esc/q: back | j/k: navigate | Enter: open paper"
         }
-        (None, Tab::Papers) => {
-            "Tab: switch tabs | j/k: navigate | Enter: open | s: star | c: clear tasks | q: quit"
+        (None, Tab::Papers | Tab::Queue) => {
+            "Tab: switch tabs | j/k: navigate | Enter: open | s: (un)star | c: clear tasks | q: quit"
         }
         (None, _) => {
             "Tab/Shift-Tab: switch tabs | j/k: navigate | Enter: select | c: clear tasks | q: quit"

--- a/crates/scitadel-tui/src/app.rs
+++ b/crates/scitadel-tui/src/app.rs
@@ -19,7 +19,7 @@ use crate::data::DataStore;
 use crate::tasks::{Task, TaskKind, TaskStatus, TaskUpdate, spawn_download_paper};
 use crate::views::annotation_prompt::{AnnotationPrompt, PromptCommit, PromptSubmission};
 use crate::views::{
-    annotation_prompt, detail, papers, queue, questions, searches, tasks as tasks_view,
+    annotation_prompt, detail, papers, questions, queue, searches, tasks as tasks_view,
 };
 use crate::widgets::status_bar;
 
@@ -37,12 +37,7 @@ pub enum Tab {
 }
 
 impl Tab {
-    const ALL: [Self; 4] = [
-        Self::Searches,
-        Self::Papers,
-        Self::Questions,
-        Self::Queue,
-    ];
+    const ALL: [Self; 4] = [Self::Searches, Self::Papers, Self::Questions, Self::Queue];
 
     fn index(self) -> usize {
         match self {

--- a/crates/scitadel-tui/src/data.rs
+++ b/crates/scitadel-tui/src/data.rs
@@ -75,6 +75,21 @@ impl DataStore {
         Ok(SqlitePaperStateRepository::new(self.db.clone()).starred_ids(reader)?)
     }
 
+    /// Load starred papers for this reader in most-recently-starred-first
+    /// order, fully hydrated. Drives the Queue tab (#48) — a cross-
+    /// search aggregator of starred papers across all questions.
+    pub fn load_starred_papers(&self, reader: &str) -> Result<Vec<Paper>> {
+        let ids = SqlitePaperStateRepository::new(self.db.clone()).starred_ids_ordered(reader)?;
+        let (paper_repo, _, _, _, _) = self.db.repositories();
+        let mut out = Vec::with_capacity(ids.len());
+        for id in ids {
+            if let Ok(Some(p)) = paper_repo.get(&id) {
+                out.push(p);
+            }
+        }
+        Ok(out)
+    }
+
     /// Load live annotations for a paper (roots + replies), ordered oldest-first.
     pub fn load_annotations_for_paper(&self, paper_id: &str) -> Result<Vec<Annotation>> {
         Ok(SqliteAnnotationRepository::new(self.db.clone()).list_by_paper(paper_id)?)

--- a/crates/scitadel-tui/src/views/mod.rs
+++ b/crates/scitadel-tui/src/views/mod.rs
@@ -1,6 +1,7 @@
 pub mod annotation_prompt;
 pub mod detail;
 pub mod papers;
+pub mod queue;
 pub mod questions;
 pub mod reader;
 pub mod searches;

--- a/crates/scitadel-tui/src/views/mod.rs
+++ b/crates/scitadel-tui/src/views/mod.rs
@@ -1,8 +1,8 @@
 pub mod annotation_prompt;
 pub mod detail;
 pub mod papers;
-pub mod queue;
 pub mod questions;
+pub mod queue;
 pub mod reader;
 pub mod searches;
 pub mod tasks;

--- a/crates/scitadel-tui/src/views/queue.rs
+++ b/crates/scitadel-tui/src/views/queue.rs
@@ -1,0 +1,127 @@
+//! Queue tab — cross-search aggregator of starred papers (#48).
+//!
+//! A deliberately minimal view: one table of every paper the current
+//! reader has starred, sorted most-recent-star-first. No `to_read`
+//! flag (cut per the 0.6.0 researcher review — "will rot within a
+//! week"); no filter toggles (cut per the maintenance review —
+//! filter+selection-index state desync is an unforced error).
+//!
+//! The rendering reuses the Papers-tab table so a future 0.7.0 pass
+//! can consolidate the two views behind a shared component; right now
+//! the Queue's data source is `DataStore::load_starred_papers` and the
+//! rendering is otherwise identical (same download-state column, same
+//! star indicator, same Enter-to-open-detail flow).
+
+use std::collections::HashSet;
+
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table, TableState};
+
+use scitadel_core::models::{DownloadStatus, Paper};
+
+use crate::data::DataStore;
+use crate::views::util::truncate;
+
+pub fn draw(
+    frame: &mut Frame,
+    area: Rect,
+    data: &DataStore,
+    reader: &str,
+    selected: usize,
+    downloading: &HashSet<String>,
+) {
+    let papers = data.load_starred_papers(reader).unwrap_or_default();
+    let title = format!(" Queue — {} starred ", papers.len());
+
+    if papers.is_empty() {
+        let block = Block::default().title(title).borders(Borders::ALL);
+        let empty = Paragraph::new(
+            "No starred papers yet. Press `s` on the Papers tab to star one.\n\
+             The Queue aggregates stars across every search and question.",
+        )
+        .block(block);
+        frame.render_widget(empty, area);
+        return;
+    }
+
+    let header = Row::new(vec![
+        Cell::from("#"),
+        Cell::from(""),
+        Cell::from("Title"),
+        Cell::from("Authors"),
+        Cell::from("Year"),
+    ])
+    .style(
+        Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD),
+    );
+
+    let rows: Vec<Row<'_>> = papers
+        .iter()
+        .enumerate()
+        .map(|(i, p)| {
+            let authors = format_authors(&p.authors);
+            let year = p.year.map_or_else(|| "—".to_string(), |y| y.to_string());
+            let (dl_symbol, dl_color) = download_cell(p, downloading);
+
+            Row::new(vec![
+                Cell::from((i + 1).to_string()),
+                Cell::from(dl_symbol).style(Style::default().fg(dl_color)),
+                Cell::from(truncate(&p.title, 60)),
+                Cell::from(truncate(&authors, 30)),
+                Cell::from(year),
+            ])
+        })
+        .collect();
+
+    let widths = [
+        Constraint::Length(5),
+        Constraint::Length(2),
+        Constraint::Min(30),
+        Constraint::Length(32),
+        Constraint::Length(6),
+    ];
+
+    let table = Table::new(rows, widths)
+        .header(header)
+        .block(Block::default().title(title).borders(Borders::ALL))
+        .row_highlight_style(
+            Style::default()
+                .bg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
+        );
+
+    let mut state = TableState::default();
+    state.select(Some(selected));
+    frame.render_stateful_widget(table, area, &mut state);
+}
+
+/// Mirror of the Papers-tab download-state column so the Queue feels
+/// consistent. Copied-not-shared for now; a future refactor can lift
+/// this into `views/util` if a third view ever needs it.
+fn download_cell(
+    paper: &Paper,
+    downloading: &HashSet<String>,
+) -> (&'static str, ratatui::style::Color) {
+    if downloading.contains(paper.id.as_str()) {
+        return ("↻", Color::Yellow);
+    }
+    match paper.download_status {
+        Some(DownloadStatus::Downloaded) => ("✓", Color::Green),
+        Some(DownloadStatus::Paywall) => ("⊘", Color::Yellow),
+        Some(DownloadStatus::Failed) => ("✗", Color::Red),
+        None => (" ", Color::DarkGray),
+    }
+}
+
+fn format_authors(authors: &[String]) -> String {
+    match authors.len() {
+        0 => "Unknown".to_string(),
+        1 => authors[0].clone(),
+        2 => format!("{}, {}", authors[0], authors[1]),
+        _ => format!("{}, {} et al.", authors[0], authors[1]),
+    }
+}

--- a/tests/vhs/queue-tab.tape
+++ b/tests/vhs/queue-tab.tape
@@ -1,0 +1,74 @@
+# VHS tape: Queue tab aggregates starred papers across searches (#48).
+#
+# Seeds 3 papers in separate searches, stars 2, switches to the new
+# Queue tab, confirms the aggregator shows only the starred pair.
+
+Output "tests/vhs/snapshots/queue-tab/run.gif"
+
+Set Shell "bash"
+Set FontSize 14
+Set Width 1400
+Set Height 800
+Set Padding 10
+Set TypingSpeed 40ms
+
+Hide
+Type `export PATH="$PWD/target/release:$HOME/.cargo/bin:$PATH"`
+Enter
+Type `export PS1="$ "`
+Enter
+Type `export SCITADEL_DB=$(mktemp -d)/scitadel.db`
+Enter
+Type "scitadel init --yes --email demo@example.org --sources arxiv --db $SCITADEL_DB"
+Enter
+Sleep 1s
+
+# Seed 3 papers with distinct titles.
+Type `sqlite3 $SCITADEL_DB "INSERT INTO papers (id, title, authors, year, created_at, updated_at) VALUES ('p-a', 'Attention Is All You Need', '[\"Vaswani, A.\"]', 2017, datetime('now'), datetime('now'));"`
+Enter
+Sleep 200ms
+Type `sqlite3 $SCITADEL_DB "INSERT INTO papers (id, title, authors, year, created_at, updated_at) VALUES ('p-b', 'Deep Residual Learning', '[\"He, K.\"]', 2015, datetime('now'), datetime('now'));"`
+Enter
+Sleep 200ms
+Type `sqlite3 $SCITADEL_DB "INSERT INTO papers (id, title, authors, year, created_at, updated_at) VALUES ('p-c', 'GPT-3 Language Models', '[\"Brown, T.\"]', 2020, datetime('now'), datetime('now'));"`
+Enter
+Sleep 200ms
+
+# Star p-a and p-c, leave p-b unstarred. Reader defaults to $USER.
+Type `sqlite3 $SCITADEL_DB "INSERT INTO paper_state (paper_id, reader, starred, to_read, updated_at) VALUES ('p-a', '$USER', 1, 0, datetime('now', '-2 minutes'));"`
+Enter
+Sleep 100ms
+Type `sqlite3 $SCITADEL_DB "INSERT INTO paper_state (paper_id, reader, starred, to_read, updated_at) VALUES ('p-c', '$USER', 1, 0, datetime('now'));"`
+Enter
+Sleep 200ms
+
+Type "clear"
+Enter
+Show
+
+Type "scitadel tui"
+Enter
+Sleep 2500ms
+
+# Tab → Papers → Questions → Queue. The Queue tab lives after the
+# existing 3; cycle forward three times.
+Tab
+Sleep 600ms
+Tab
+Sleep 600ms
+Tab
+Sleep 1500ms
+Screenshot "tests/vhs/snapshots/queue-tab/01-queue-tab-open.png"
+
+# j to move the cursor down one row (p-c → p-a).
+Type "j"
+Sleep 500ms
+Screenshot "tests/vhs/snapshots/queue-tab/02-second-paper-selected.png"
+
+# s to unstar the focused paper (p-a). List should shrink to 1 entry.
+Type "s"
+Sleep 1000ms
+Screenshot "tests/vhs/snapshots/queue-tab/03-after-unstar.png"
+
+Type "q"
+Sleep 300ms


### PR DESCRIPTION
## Summary

Scope-reduced per the 0.6.0 spike:
- Drops \`to_read\` flag (researcher reviewer: "will rot within a week")
- Drops filter toggles (maintenance reviewer: filter + selection-index desync is an unforced error)
- Reuses 100% of \`paper_state\` + star MCP tools (#120). Zero new tables.

New 4th tab \`Queue\` cycled by Tab from Questions. \`j/k\` navigate, \`Enter\` opens PaperDetail, \`s\` unstars and list shrinks live. Sorted most-recently-starred-first.

## Test plan

- [x] 2 new unit tests for \`starred_ids_ordered\` (ordering + unstar removes)
- [x] VHS tape \`queue-tab.tape\` — 3 distinct snapshots (tab opened / cursor moved / after-unstar shrinks to 1)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean

Closes #48.