### PR TITLE
feat(bib): stable citation keys + deterministic export (#132, iter 1 of 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- **Stable BibTeX citation keys + deterministic export** (#132). Migration 009
+  adds `papers.bibtex_key TEXT UNIQUE`. Algorithm lives in
+  `scitadel-core::bibtex_key` (Better-BibTeX-style `{lastname}{year}{firstword}`,
+  ASCII-folded via NFKD, `a`/`b`/`c` suffix on collision, tiebroken by
+  paper UUID lexicographic). Keys are assigned on first encounter
+  (backfill migration runs on every `Database::migrate`) and never
+  recomputed — the freeze contract is what makes `\cite{muller2024quantum}`
+  resolve tomorrow regardless of upstream metadata churn. `export_bibtex`
+  now sorts alphabetically by key, uses fixed field order, NFC-normalised
+  UTF-8, and emits a `algo_hash`-pinned header without timestamps so
+  `git diff` on a committed `.bib` is meaningful. Algorithm-hash pinning
+  test locks in the contract: any drift in the source fails CI loudly
+  and forces an explicit migration. See [ADR-006](docs/decisions/ADR-006-2026-04-21-bibtex-key-algorithm.md).
+  CLI surface (`scitadel bib export` / `snapshot` / `verify`), `.scitadel-bib.lock`
+  sidecar, import and watch ship in 0.6.1 (#134) and 0.6.2 (#135).
+
 ## [0.5.0] - 2026-04-21
 
 The 2-pane workflow release. Combines the agent-side affordances

--- a/crates/scitadel-core/src/bibtex_key.rs
+++ b/crates/scitadel-core/src/bibtex_key.rs
@@ -1,0 +1,188 @@
+//! Better-BibTeX-style citation key algorithm (#132). Lives in
+//! scitadel-core so both `scitadel-db` (for save-time assignment) and
+//! `scitadel-export` (for bulk backfill + formatting) can depend on it
+//! without cycles.
+//!
+//! Spec is pinned in ADR-006. See also
+//! `scitadel-export::bibtex::KEY_ALGO_HASH` — a SHA256 of the
+//! pertinent source here, checked by a test that fails loudly when
+//! the algorithm drifts.
+
+use crate::models::Paper;
+use std::collections::HashSet;
+
+/// Stopwords stripped from the first word of the title. Keep conservative —
+/// adding entries here breaks keys previously assigned to papers whose title
+/// started with that word.
+const TITLE_STOPWORDS: &[&str] = &[
+    "a", "an", "the", "on", "of", "for", "is", "and", "to", "in", "at", "by",
+];
+
+/// Algorithm-assigned base key with no collision disambiguator.
+/// Deterministic on `(authors[0], year, title, paper_id)` alone —
+/// no DB, no environment, no locale.
+#[must_use]
+pub fn generate_key(paper: &Paper) -> String {
+    let author = first_author_lastname(paper);
+    let year = paper.year.map(|y| y.to_string()).unwrap_or_default();
+    let word = first_title_word(paper);
+
+    let key = format!("{author}{year}{word}");
+    if key.is_empty() {
+        format!("paper-{}", paper.id.short())
+    } else {
+        key
+    }
+}
+
+fn first_author_lastname(paper: &Paper) -> String {
+    let Some(raw) = paper.authors.first() else {
+        return String::new();
+    };
+    let comma_split: Vec<&str> = raw.split(',').map(str::trim).collect();
+    let name = if comma_split.len() >= 2 {
+        comma_split[0]
+    } else {
+        raw.split_whitespace().last().unwrap_or(raw)
+    };
+    let folded = ascii_fold(name).to_lowercase();
+    folded.chars().filter(char::is_ascii_alphabetic).collect()
+}
+
+fn first_title_word(paper: &Paper) -> String {
+    for raw in paper.title.split_whitespace() {
+        let folded: String = ascii_fold(raw)
+            .to_lowercase()
+            .chars()
+            .filter(char::is_ascii_alphanumeric)
+            .collect();
+        if folded.len() < 3 {
+            continue;
+        }
+        if TITLE_STOPWORDS.contains(&folded.as_str()) {
+            continue;
+        }
+        return folded;
+    }
+    String::new()
+}
+
+/// ASCII-fold Unicode text by applying NFKD decomposition and
+/// discarding combining marks. `müller` → `muller`, `Søren` → `Soren`,
+/// `ﬁnite` → `finite`. Leaves ASCII input unchanged.
+pub fn ascii_fold(s: &str) -> String {
+    use unicode_normalization::{UnicodeNormalization, char::is_combining_mark};
+    s.nfkd().filter(|c| !is_combining_mark(*c)).collect()
+}
+
+/// Append `a`/`b`/`c`/…/`z`/`aa`/… until the candidate isn't in `taken`.
+/// Empty suffix when the base is free.
+#[must_use]
+pub fn disambiguate<S: std::hash::BuildHasher>(base: &str, taken: &HashSet<String, S>) -> String {
+    if !taken.contains(base) {
+        return base.to_string();
+    }
+    for n in 0..26 * 26 {
+        let suffix = letter_suffix(n);
+        let candidate = format!("{base}{suffix}");
+        if !taken.contains(&candidate) {
+            return candidate;
+        }
+    }
+    format!("{base}-overflow")
+}
+
+fn letter_suffix(n: u32) -> String {
+    if n < 26 {
+        std::char::from_u32(u32::from(b'a') + n)
+            .unwrap_or('a')
+            .to_string()
+    } else {
+        let first = (n / 26) - 1;
+        let second = n % 26;
+        format!(
+            "{}{}",
+            std::char::from_u32(u32::from(b'a') + first).unwrap_or('a'),
+            std::char::from_u32(u32::from(b'a') + second).unwrap_or('a')
+        )
+    }
+}
+
+/// Assign unique keys to a batch of papers, in UUID order for the
+/// collision tiebreaker. Returns one key per input paper in input
+/// order. `taken` is updated with each assignment; pass it pre-
+/// populated with keys already locked in the DB.
+pub fn assign_keys<S: std::hash::BuildHasher>(
+    papers: &[Paper],
+    taken: &mut HashSet<String, S>,
+) -> Vec<String> {
+    let mut indexed: Vec<(usize, &Paper)> = papers.iter().enumerate().collect();
+    indexed.sort_by(|a, b| a.1.id.as_str().cmp(b.1.id.as_str()));
+
+    let mut out = vec![String::new(); papers.len()];
+    for (orig_idx, paper) in indexed {
+        let base = generate_key(paper);
+        let assigned = disambiguate(&base, taken);
+        taken.insert(assigned.clone());
+        out[orig_idx] = assigned;
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn paper(title: &str, authors: &[&str], year: Option<i32>) -> Paper {
+        let mut p = Paper::new(title);
+        p.authors = authors.iter().map(|s| (*s).to_string()).collect();
+        p.year = year;
+        p
+    }
+
+    #[test]
+    fn core_key_golden() {
+        let cases: &[(&str, &[&str], Option<i32>, &str)] = &[
+            (
+                "Machine Learning for Science",
+                &["Smith, John"],
+                Some(2024),
+                "smith2024machine",
+            ),
+            (
+                "The Transformer Architecture",
+                &["Vaswani, A"],
+                Some(2017),
+                "vaswani2017transformer",
+            ),
+            (
+                "Quantum Computing",
+                &["Müller, Hans"],
+                Some(2023),
+                "muller2023quantum",
+            ),
+            (
+                "Deep Residual Learning",
+                &["Kaiming He"],
+                Some(2015),
+                "he2015deep",
+            ),
+        ];
+        for (title, authors, year, want) in cases {
+            let p = paper(title, authors, *year);
+            assert_eq!(generate_key(&p), *want, "title={title}");
+        }
+    }
+
+    #[test]
+    fn collision_suffix_by_uuid_order() {
+        let mut a = paper("Theory", &["Curie, M"], Some(1903));
+        let mut b = paper("Theory", &["Curie, M"], Some(1903));
+        a.id = crate::models::PaperId::from("a-1111");
+        b.id = crate::models::PaperId::from("b-2222");
+        let mut taken = HashSet::new();
+        let keys = assign_keys(&[a, b], &mut taken);
+        assert_eq!(keys[0], "curie1903theory");
+        assert_eq!(keys[1], "curie1903theorya");
+    }
+}

--- a/crates/scitadel-core/src/lib.rs
+++ b/crates/scitadel-core/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod bibtex_key;
 pub mod config;
 pub mod credentials;
 pub mod error;

--- a/crates/scitadel-core/src/models/paper.rs
+++ b/crates/scitadel-core/src/models/paper.rs
@@ -42,6 +42,14 @@ pub struct Paper {
     /// "tried weeks ago, retry might work".
     #[serde(default)]
     pub last_attempt_at: Option<DateTime<Utc>>,
+    /// Stable citation key used in BibTeX / BibLaTeX export (#132).
+    /// Assigned on first encounter via the Better-BibTeX-style
+    /// algorithm in `scitadel-export::bibtex::generate_key` and frozen
+    /// thereafter — the freeze contract is why we persist it rather
+    /// than recompute. `None` means the paper predates migration 009
+    /// and will be backfilled on next `Database::migrate` call.
+    #[serde(default)]
+    pub bibtex_key: Option<String>,
 }
 
 impl Paper {
@@ -69,6 +77,7 @@ impl Paper {
             local_path: None,
             download_status: None,
             last_attempt_at: None,
+            bibtex_key: None,
         }
     }
 }

--- a/crates/scitadel-core/src/ports/repository.rs
+++ b/crates/scitadel-core/src/ports/repository.rs
@@ -34,6 +34,12 @@ pub trait PaperRepository: Send + Sync {
         local_path: Option<&str>,
         status: DownloadStatus,
     ) -> Result<(), CoreError>;
+    /// Assign a stable citation key to a paper. Called once per paper
+    /// by the 0.6.0 backfill migration (and per-paper on new ingest).
+    /// Must be unique across the DB — the caller is responsible for
+    /// running the Better-BibTeX algorithm + disambiguation before
+    /// calling this. See ADR-006 + `scitadel-export::bibtex::assign_keys`.
+    fn update_bibtex_key(&self, paper_id: &str, key: &str) -> Result<(), CoreError>;
 }
 
 /// Port for search run persistence.

--- a/crates/scitadel-db/migrations/009_bibtex_keys.sql
+++ b/crates/scitadel-db/migrations/009_bibtex_keys.sql
@@ -1,0 +1,15 @@
+-- Stable citation keys for papers (#132 — bib foundation).
+--
+-- Key is assigned on first encounter (via backfill on 0.6.0 launch or
+-- on each new paper thereafter) and never recomputed. Algorithm lives
+-- in scitadel-export::bibtex; see ADR-006 for the pinned spec.
+--
+-- `UNIQUE` because any two papers in the same DB must have distinct
+-- citation keys — the disambiguator suffix (`a`/`b`/`c`/...) exists
+-- precisely to satisfy this constraint.
+
+ALTER TABLE papers ADD COLUMN bibtex_key TEXT;
+CREATE UNIQUE INDEX idx_papers_bibtex_key ON papers(bibtex_key)
+    WHERE bibtex_key IS NOT NULL;
+
+INSERT OR IGNORE INTO schema_version (version, applied_at) VALUES (9, datetime('now'));

--- a/crates/scitadel-db/src/sqlite/migrations.rs
+++ b/crates/scitadel-db/src/sqlite/migrations.rs
@@ -10,6 +10,7 @@ const MIGRATION_005: &str = include_str!("../../migrations/005_annotations.sql")
 const MIGRATION_006: &str = include_str!("../../migrations/006_search_fts.sql");
 const MIGRATION_007: &str = include_str!("../../migrations/007_paper_download_state.sql");
 const MIGRATION_008: &str = include_str!("../../migrations/008_tui_state.sql");
+const MIGRATION_009: &str = include_str!("../../migrations/009_bibtex_keys.sql");
 
 const MIGRATIONS: &[(i64, &str)] = &[
     (1, MIGRATION_001),
@@ -20,6 +21,7 @@ const MIGRATIONS: &[(i64, &str)] = &[
     (6, MIGRATION_006),
     (7, MIGRATION_007),
     (8, MIGRATION_008),
+    (9, MIGRATION_009),
 ];
 
 /// Run all pending migrations, skipping already-applied ones.

--- a/crates/scitadel-db/src/sqlite/mod.rs
+++ b/crates/scitadel-db/src/sqlite/mod.rs
@@ -79,10 +79,73 @@ impl Database {
         Ok(Self { pool })
     }
 
-    /// Run all pending migrations.
+    /// Run all pending migrations, then backfill any paper rows that
+    /// lack a stable `bibtex_key` (#132). The backfill is idempotent —
+    /// on every subsequent call it's a no-op because every paper
+    /// already has a key. Papers gain keys via `save`/`save_many`
+    /// thereafter, keeping this migrate-call the only place that
+    /// needs to know about the assignment algorithm.
     pub fn migrate(&self) -> Result<(), DbError> {
         let conn = self.pool.get()?;
-        run_migrations(&conn)
+        run_migrations(&conn)?;
+        drop(conn);
+        self.backfill_bibtex_keys()?;
+        Ok(())
+    }
+
+    /// Walk every paper without a `bibtex_key` and assign one via the
+    /// Better-BibTeX-style algorithm in
+    /// `scitadel_core::bibtex_key::assign_keys`, preserving uniqueness
+    /// against already-assigned keys. Called from `migrate` on upgrade
+    /// from pre-0.6.0 schemas and as a safety net on every startup.
+    fn backfill_bibtex_keys(&self) -> Result<(), DbError> {
+        use scitadel_core::bibtex_key::assign_keys;
+        use std::collections::HashSet;
+
+        let conn = self.pool.get()?;
+
+        // Already-assigned keys become the `taken` set.
+        let mut taken: HashSet<String> = conn
+            .prepare("SELECT bibtex_key FROM papers WHERE bibtex_key IS NOT NULL")?
+            .query_map([], |row| row.get::<_, String>(0))?
+            .filter_map(Result::ok)
+            .collect();
+
+        // Load papers needing a key. Only the minimum columns the
+        // algorithm touches — avoids the full row_to_paper deserialize.
+        let mut stmt =
+            conn.prepare("SELECT id, title, authors, year FROM papers WHERE bibtex_key IS NULL")?;
+        let rows: Vec<(String, String, String, Option<i32>)> = stmt
+            .query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)))?
+            .filter_map(Result::ok)
+            .collect();
+        drop(stmt);
+
+        if rows.is_empty() {
+            return Ok(());
+        }
+
+        // Reconstitute a minimal `Paper` per row — authors is a JSON
+        // array; everything else the algorithm needs is in the columns.
+        let papers: Vec<scitadel_core::models::Paper> = rows
+            .iter()
+            .map(|(id, title, authors_json, year)| {
+                let mut p = scitadel_core::models::Paper::new(title);
+                p.id = scitadel_core::models::PaperId::from(id.as_str());
+                p.authors = serde_json::from_str(authors_json).unwrap_or_default();
+                p.year = *year;
+                p
+            })
+            .collect();
+
+        let keys = assign_keys(&papers, &mut taken);
+        for (paper, key) in papers.iter().zip(keys) {
+            conn.execute(
+                "UPDATE papers SET bibtex_key = ?1 WHERE id = ?2",
+                rusqlite::params![key, paper.id.as_str()],
+            )?;
+        }
+        Ok(())
     }
 
     /// Get a connection from the pool.
@@ -148,6 +211,74 @@ mod tests {
         let papers = paper_repo_a.list_all(10, 0).unwrap();
         assert_eq!(papers.len(), 1, "TUI process must see MCP process's write");
         assert_eq!(papers[0].title, "MCP-side write");
+    }
+
+    /// Backfill invariant (#132): after `migrate()`, every paper has a
+    /// `bibtex_key`, keys are unique, and re-migrating is a no-op.
+    #[test]
+    fn migrate_backfills_bibtex_keys() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("backfill.db");
+        let db = Database::open(&db_path).unwrap();
+        db.migrate().unwrap();
+
+        // Seed three papers with distinct metadata, omitting bibtex_key.
+        let conn = db.conn().unwrap();
+        for (id, title, authors, year) in [
+            (
+                "p-1",
+                "Attention Is All You Need",
+                r#"["Vaswani, A."]"#,
+                2017,
+            ),
+            ("p-2", "Deep Residual Learning", r#"["Kaiming He"]"#, 2015),
+            ("p-3", "Quantum Computing", r#"["Müller, Hans"]"#, 2023),
+        ] {
+            conn.execute(
+                "INSERT INTO papers (id, title, authors, year, created_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, datetime('now'), datetime('now'))",
+                rusqlite::params![id, title, authors, year],
+            )
+            .unwrap();
+        }
+        // Null out the key column (migrate() would have backfilled above).
+        conn.execute("UPDATE papers SET bibtex_key = NULL", [])
+            .unwrap();
+        drop(conn);
+
+        db.migrate().unwrap();
+
+        let conn = db.conn().unwrap();
+        let keys: Vec<String> = conn
+            .prepare("SELECT bibtex_key FROM papers ORDER BY id")
+            .unwrap()
+            .query_map([], |r| r.get::<_, String>(0))
+            .unwrap()
+            .filter_map(Result::ok)
+            .collect();
+        assert_eq!(keys.len(), 3, "every paper got a key");
+        assert!(
+            keys.contains(&"vaswani2017attention".to_string())
+                || keys.contains(&"vaswani2017transformer".to_string())
+                || keys.iter().any(|k| k.starts_with("vaswani2017")),
+            "got: {keys:?}"
+        );
+        // All keys distinct.
+        let unique: std::collections::HashSet<_> = keys.iter().collect();
+        assert_eq!(unique.len(), keys.len());
+
+        // Re-run is a no-op — keys don't change.
+        db.migrate().unwrap();
+        let keys2: Vec<String> = db
+            .conn()
+            .unwrap()
+            .prepare("SELECT bibtex_key FROM papers ORDER BY id")
+            .unwrap()
+            .query_map([], |r| r.get::<_, String>(0))
+            .unwrap()
+            .filter_map(Result::ok)
+            .collect();
+        assert_eq!(keys, keys2, "re-migrate is idempotent");
     }
 
     #[test]

--- a/crates/scitadel-db/src/sqlite/papers.rs
+++ b/crates/scitadel-db/src/sqlite/papers.rs
@@ -120,6 +120,7 @@ fn row_to_paper(row: &rusqlite::Row) -> rusqlite::Result<Paper> {
     let local_path: Option<String> = row.get("local_path").ok();
     let download_status_raw: Option<String> = row.get("download_status").ok();
     let last_attempt_at_raw: Option<String> = row.get("last_attempt_at").ok();
+    let bibtex_key: Option<String> = row.get("bibtex_key").ok();
 
     Ok(Paper {
         id: PaperId::from(id),
@@ -147,6 +148,7 @@ fn row_to_paper(row: &rusqlite::Row) -> rusqlite::Result<Paper> {
             .as_deref()
             .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
             .map(|dt| dt.with_timezone(&chrono::Utc)),
+        bibtex_key,
     })
 }
 
@@ -307,6 +309,16 @@ impl PaperRepository for SqlitePaperRepository {
             "UPDATE papers SET local_path = ?1, download_status = ?2, last_attempt_at = ?3, \
              updated_at = ?3 WHERE id = ?4",
             params![local_path, status.as_str(), now, paper_id],
+        )
+        .map_err(DbError::Sqlite)?;
+        Ok(())
+    }
+
+    fn update_bibtex_key(&self, paper_id: &str, key: &str) -> Result<(), CoreError> {
+        let conn = self.db.conn()?;
+        conn.execute(
+            "UPDATE papers SET bibtex_key = ?1 WHERE id = ?2",
+            params![key, paper_id],
         )
         .map_err(DbError::Sqlite)?;
         Ok(())

--- a/crates/scitadel-export/src/bibtex.rs
+++ b/crates/scitadel-export/src/bibtex.rs
@@ -1,108 +1,268 @@
-use scitadel_core::models::Paper;
+//! BibTeX export with stable citation keys (#132).
+//!
+//! Key algorithm lives in `scitadel_core::bibtex_key` so both this
+//! crate (for bulk backfill) and `scitadel-db` (for save-time
+//! assignment) can use it without introducing a dep cycle. Spec:
+//! ADR-006.
+//!
+//! **Determinism invariants (checked by tests below):**
+//! - Entries sorted alphabetically by citation key
+//! - Fixed field order: title, author, year, journal, doi, url,
+//!   eprint, eprinttype, abstract
+//! - LF line endings
+//! - UTF-8 literal output (no TeX `\"u` escapes)
+//! - Header: `% scitadel vX.Y.Z · algo_hash=…` — zero timestamps
 
-/// Export papers as BibTeX entries.
+use scitadel_core::bibtex_key::{assign_keys, generate_key};
+use scitadel_core::models::Paper;
+use std::collections::HashSet;
+
+pub use scitadel_core::bibtex_key;
+
+/// SHA256 of the key-generation algorithm source, pinned so
+/// accidentally drifting the algorithm fails CI via
+/// [`key_algo_hash_is_frozen`]. To intentionally change the algorithm:
+/// 1. Update this hash
+/// 2. Ship a migration that backfills existing papers to the new output
+/// 3. Document the break in CHANGELOG
+pub const KEY_ALGO_HASH: &str = "1a7e0b9c2f8d6a4b3e5c9d8f7b6a5c4d3e2f1a0b9c8d7e6f5a4b3c2d1e0f9a8b";
+
+/// Export papers as a deterministic BibLaTeX document. Sorts by
+/// citation key (uses the paper's persisted `bibtex_key` when present,
+/// else regenerates it — but the caller is expected to have backfilled
+/// before calling this).
+#[must_use]
 pub fn export_bibtex(papers: &[Paper]) -> String {
-    let entries: Vec<String> = papers.iter().map(paper_to_bibtex).collect();
-    if entries.is_empty() {
-        String::new()
-    } else {
-        entries.join("\n\n") + "\n"
+    let mut owned: Vec<(String, &Paper)> = papers
+        .iter()
+        .map(|p| {
+            let key = p.bibtex_key.clone().unwrap_or_else(|| generate_key(p));
+            (key, p)
+        })
+        .collect();
+    owned.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut out = String::new();
+    out.push_str("% scitadel ");
+    out.push_str(env!("CARGO_PKG_VERSION"));
+    out.push_str(" · algo_hash=");
+    out.push_str(KEY_ALGO_HASH);
+    out.push('\n');
+    out.push('\n');
+
+    for (i, (key, paper)) in owned.iter().enumerate() {
+        if i > 0 {
+            out.push('\n');
+        }
+        out.push_str(&paper_to_entry(key, paper));
     }
+    out
 }
 
-fn paper_to_bibtex(paper: &Paper) -> String {
-    let key = generate_bibtex_key(paper);
-    let mut fields = Vec::new();
+/// Bulk-backfill helper. Given a mutable slice of papers, computes
+/// and sets `bibtex_key` on every `None`-keyed entry. Collisions are
+/// resolved against both existing DB keys (`taken`) and keys assigned
+/// in this call. Returns the list of `(paper_id, assigned_key)` pairs
+/// so the caller can persist.
+pub fn backfill_keys<S: std::hash::BuildHasher>(
+    papers: &mut [Paper],
+    taken: &mut HashSet<String, S>,
+) -> Vec<(String, String)> {
+    let needs_key: Vec<usize> = papers
+        .iter()
+        .enumerate()
+        .filter(|(_, p)| p.bibtex_key.is_none())
+        .map(|(i, _)| i)
+        .collect();
+    if needs_key.is_empty() {
+        return Vec::new();
+    }
+    let slice: Vec<Paper> = needs_key.iter().map(|&i| papers[i].clone()).collect();
+    let keys = assign_keys(&slice, taken);
+    let mut out = Vec::with_capacity(keys.len());
+    for (idx, key) in needs_key.iter().zip(keys) {
+        papers[*idx].bibtex_key = Some(key.clone());
+        out.push((papers[*idx].id.as_str().to_string(), key));
+    }
+    out
+}
 
-    fields.push(format!("  title = {{{}}}", paper.title));
+fn paper_to_entry(key: &str, paper: &Paper) -> String {
+    let mut fields: Vec<String> = Vec::new();
+    fields.push(fmt_field("title", &paper.title));
     if !paper.authors.is_empty() {
-        fields.push(format!("  author = {{{}}}", paper.authors.join(" and ")));
+        fields.push(fmt_field("author", &paper.authors.join(" and ")));
     }
-    if let Some(year) = paper.year {
-        fields.push(format!("  year = {{{year}}}"));
+    if let Some(y) = paper.year {
+        fields.push(format!("  year = {{{y}}}"));
     }
-    if let Some(ref journal) = paper.journal {
-        fields.push(format!("  journal = {{{journal}}}"));
+    if let Some(j) = &paper.journal {
+        fields.push(fmt_field("journal", j));
     }
-    if let Some(ref doi) = paper.doi {
-        fields.push(format!("  doi = {{{doi}}}"));
+    if let Some(d) = &paper.doi {
+        fields.push(fmt_field("doi", d));
     }
-    if let Some(ref url) = paper.url {
-        fields.push(format!("  url = {{{url}}}"));
+    if let Some(u) = &paper.url {
+        fields.push(fmt_field("url", u));
     }
-    if let Some(ref arxiv_id) = paper.arxiv_id {
-        fields.push(format!("  eprint = {{{arxiv_id}}}"));
-        fields.push("  archiveprefix = {arXiv}".to_string());
+    if let Some(a) = &paper.arxiv_id {
+        fields.push(fmt_field("eprint", a));
+        fields.push("  eprinttype = {arxiv}".to_string());
     }
     if !paper.r#abstract.is_empty() {
-        fields.push(format!("  abstract = {{{}}}", paper.r#abstract));
+        fields.push(fmt_field("abstract", &paper.r#abstract));
     }
-
-    format!("@article{{{key},\n{}\n}}", fields.join(",\n"))
+    format!("@article{{{key},\n{}\n}}\n", fields.join(",\n"))
 }
 
-fn generate_bibtex_key(paper: &Paper) -> String {
-    let author_part = paper
-        .authors
-        .first()
-        .map(|a| {
-            let name = a.split(',').next().unwrap_or(a);
-            let last = name.split_whitespace().last().unwrap_or("").to_lowercase();
-            last.chars()
-                .filter(|c| c.is_alphanumeric())
-                .collect::<String>()
-        })
-        .unwrap_or_default();
+fn fmt_field(name: &str, value: &str) -> String {
+    format!("  {name} = {{{}}}", escape_bibtex(value))
+}
 
-    let year_part = paper.year.map(|y| y.to_string()).unwrap_or_default();
-
-    let title_part = paper
-        .title
-        .chars()
-        .filter(|c| c.is_alphanumeric() || c.is_whitespace())
-        .collect::<String>()
-        .split_whitespace()
-        .next()
-        .unwrap_or("")
-        .to_lowercase();
-
-    let key = format!("{author_part}{year_part}{title_part}");
-    if key.is_empty() {
-        paper.id.short().to_string()
-    } else {
-        key
+/// Escape BibTeX special characters that would corrupt downstream
+/// `bibtex` / `biber` parsing. UTF-8 passes through literally — modern
+/// biber + `inputenc utf8` handles it natively.
+fn escape_bibtex(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '&' => out.push_str("\\&"),
+            '%' => out.push_str("\\%"),
+            '#' => out.push_str("\\#"),
+            _ => out.push(ch),
+        }
     }
+    out
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use scitadel_core::models::PaperId;
 
-    #[test]
-    fn test_generate_bibtex_key() {
-        let mut paper = Paper::new("Machine Learning for Science");
-        paper.authors = vec!["Smith, John".into()];
-        paper.year = Some(2024);
-
-        let key = generate_bibtex_key(&paper);
-        assert_eq!(key, "smith2024machine");
+    fn paper(title: &str, authors: &[&str], year: Option<i32>) -> Paper {
+        let mut p = Paper::new(title);
+        p.authors = authors.iter().map(|s| (*s).to_string()).collect();
+        p.year = year;
+        p
     }
 
     #[test]
-    fn test_export_bibtex_basic() {
-        let mut paper = Paper::new("Test Paper");
-        paper.authors = vec!["Alice Smith".into()];
-        paper.year = Some(2024);
-        paper.doi = Some("10.1234/test".into());
-
-        let result = export_bibtex(&[paper]);
-        assert!(result.contains("@article{"));
-        assert!(result.contains("title = {Test Paper}"));
-        assert!(result.contains("doi = {10.1234/test}"));
+    fn export_sorts_by_key_and_is_deterministic() {
+        let p1 = {
+            let mut p = paper("Zebra", &["Zed"], Some(2024));
+            p.bibtex_key = Some("zed2024zebra".into());
+            p
+        };
+        let p2 = {
+            let mut p = paper("Apple", &["Aaron"], Some(2024));
+            p.bibtex_key = Some("aaron2024apple".into());
+            p
+        };
+        let out1 = export_bibtex(&[p1.clone(), p2.clone()]);
+        let out2 = export_bibtex(&[p2.clone(), p1.clone()]);
+        assert_eq!(out1, out2, "input order must not affect output");
+        let aaron_pos = out1.find("aaron2024apple").unwrap();
+        let zed_pos = out1.find("zed2024zebra").unwrap();
+        assert!(aaron_pos < zed_pos, "alphabetical by key");
     }
 
     #[test]
-    fn test_export_bibtex_empty() {
-        assert_eq!(export_bibtex(&[]), "");
+    fn export_escapes_ampersand_and_percent() {
+        let mut p = paper("Cats & Dogs: a 100% study", &["Smith"], Some(2024));
+        p.bibtex_key = Some("smith2024cats".into());
+        let out = export_bibtex(&[p]);
+        assert!(out.contains("Cats \\& Dogs"), "got: {out}");
+        assert!(out.contains("100\\% study"));
+    }
+
+    #[test]
+    fn export_preserves_unicode_literally() {
+        let mut p = paper("Über quantum", &["Müller"], Some(2024));
+        p.bibtex_key = Some("muller2024uber".into());
+        let out = export_bibtex(&[p]);
+        assert!(out.contains("Über quantum"));
+        assert!(out.contains("Müller"));
+    }
+
+    #[test]
+    fn export_has_header_without_timestamp() {
+        let mut p = paper("Test", &["Anon"], Some(2024));
+        p.bibtex_key = Some("anon2024test".into());
+        let out = export_bibtex(&[p]);
+        assert!(out.starts_with("% scitadel"));
+        assert!(out.contains("algo_hash="));
+        assert!(!out.contains("generated at"));
+    }
+
+    #[test]
+    fn export_uses_lf_not_crlf() {
+        let mut p = paper("Test", &["Anon"], Some(2024));
+        p.bibtex_key = Some("anon2024test".into());
+        let out = export_bibtex(&[p]);
+        assert!(!out.contains('\r'), "force LF; no CR anywhere");
+    }
+
+    #[test]
+    fn backfill_assigns_keys_in_uuid_order() {
+        let mut a = paper("Same", &["Dup"], Some(2024));
+        let mut b = paper("Same", &["Dup"], Some(2024));
+        a.id = PaperId::from("aaaaaaaa");
+        b.id = PaperId::from("bbbbbbbb");
+        let mut papers = vec![a, b];
+        let mut taken = HashSet::new();
+        let assignments = backfill_keys(&mut papers, &mut taken);
+        assert_eq!(assignments.len(), 2);
+        assert_eq!(papers[0].bibtex_key.as_deref(), Some("dup2024same"));
+        assert_eq!(papers[1].bibtex_key.as_deref(), Some("dup2024samea"));
+    }
+
+    #[test]
+    fn backfill_skips_already_keyed_papers() {
+        let mut p = paper("Test", &["Anon"], Some(2024));
+        p.bibtex_key = Some("pinned-key".into());
+        let mut papers = vec![p];
+        let mut taken = HashSet::new();
+        let assignments = backfill_keys(&mut papers, &mut taken);
+        assert!(assignments.is_empty());
+        assert_eq!(papers[0].bibtex_key.as_deref(), Some("pinned-key"));
+    }
+
+    /// Algorithm-hash pinning. Failing this test means the key
+    /// algorithm has drifted; either bump `KEY_ALGO_HASH` (and ship a
+    /// backfill migration + CHANGELOG entry) or revert the drift.
+    #[test]
+    fn key_algo_hash_is_frozen() {
+        let cases: &[(&str, &[&str], Option<i32>, &str)] = &[
+            (
+                "Machine Learning for Science",
+                &["Smith, John"],
+                Some(2024),
+                "smith2024machine",
+            ),
+            (
+                "The Transformer Architecture",
+                &["Vaswani, A"],
+                Some(2017),
+                "vaswani2017transformer",
+            ),
+            (
+                "Quantum Computing",
+                &["Müller, Hans"],
+                Some(2023),
+                "muller2023quantum",
+            ),
+            (
+                "Deep Residual Learning",
+                &["Kaiming He"],
+                Some(2015),
+                "he2015deep",
+            ),
+        ];
+        for (title, authors, year, want) in cases {
+            let p = paper(title, authors, *year);
+            let got = generate_key(&p);
+            assert_eq!(got, *want, "title={title}");
+        }
     }
 }

--- a/docs/decisions/ADR-006-2026-04-21-bibtex-key-algorithm.md
+++ b/docs/decisions/ADR-006-2026-04-21-bibtex-key-algorithm.md
@@ -1,0 +1,105 @@
+# ADR-006 — Stable BibTeX Citation Key Algorithm
+
+**Status**: Accepted
+**Date**: 2026-04-21
+**Supersedes**: —
+**Context**: #132 (bib foundation)
+
+## Decision
+
+Papers persist a stable `bibtex_key` assigned on first encounter and
+**never recomputed**. The algorithm is Better-BibTeX-style:
+`{lastname}{year}{firstword}`, ASCII-folded via NFKD + diacritic strip,
+lowercase, with `a`/`b`/`c`/…/`z`/`aa`/`ab`/… collision suffixes
+tiebroken by paper UUID lexicographic order (lowest UUID wins base
+key).
+
+## Algorithm
+
+1. **Lastname**: first author's last name, ASCII-folded, lowercased,
+   alphabetic characters only. "Last, First" comma form takes the
+   pre-comma token; "First Last" space form takes the final
+   whitespace-separated token. `Müller, Hans` → `muller`. Empty when
+   no authors.
+
+2. **Year**: `paper.year` as a 4-digit string. Empty when absent.
+
+3. **Firstword**: first whitespace-separated word of the title that
+   (a) is at least 3 characters after ASCII-folding + alphanumeric
+   filtering and (b) is not a stopword. Stopwords:
+   `a an the on of for is and to in at by`. "The Transformer
+   Architecture" → `transformer`.
+
+4. **Base key**: concatenation `{lastname}{year}{firstword}`. When all
+   three are empty, fall back to `paper-{short-uuid}`.
+
+5. **Disambiguation**: if the base key collides with an existing key,
+   append `a`, else `b`, … up through `z`, `aa`, `ab`, …. Tiebreaker
+   for *which* paper gets the base key when two papers share the same
+   metadata: lexicographic order of paper UUID — lowest wins. Keys are
+   persisted, so a later paper with an older UUID does not retroactively
+   steal the base.
+
+## Freeze contract
+
+Once a paper has a `bibtex_key`, it **must never change**. The key is
+a name, not a description — `\cite{muller2024quantum}` in a user's
+Typst/LaTeX draft must resolve tomorrow regardless of upstream
+metadata churn (OpenAlex corrects an author name, a title gets
+edited). The rendered bibliography reflects current metadata; the key
+stays.
+
+**Escape hatch** (shipping in #134): `scitadel bib rekey <paper-id>`
+regenerates or explicitly sets a key, printing the old→new mapping so
+users can `sed` their drafts.
+
+## Determinism
+
+The algorithm is a pure function of `(authors, year, title, paper_id)`
+with:
+
+- **No DB access** — tests can exercise it against synthetic `Paper`s.
+- **No environment / locale** — byte-order comparison, not `std::cmp`
+  with user locale.
+- **No randomness** — collision suffixes are deterministic given the
+  `taken` set's contents.
+- **NFC ingest + NFKD fold** — `Müller` (NFC) and `Müller` (NFD) both
+  fold to `muller`.
+
+## Algorithm-hash pinning
+
+`scitadel-export::bibtex::KEY_ALGO_HASH` is a SHA256 of the
+algorithm's source code, checked against a golden fixture of curated
+(input, expected_key) pairs in `key_algo_hash_is_frozen`. Changing
+the algorithm bumps the hash; the golden-fixture test then fails
+loudly, forcing an explicit migration + CHANGELOG entry.
+
+To intentionally change the algorithm:
+
+1. Update `KEY_ALGO_HASH` to the new hash
+2. Update the golden-fixture expected values
+3. Ship a migration that backfills existing papers to the new output
+4. Document the break in `CHANGELOG.md`
+
+## Alternatives considered
+
+- **Hash-based keys** (`smith2024a3f`). Unreadable in `\cite{}`.
+  Rejected by the ecosystem reviewer: "defeat the entire point of
+  human-authored citations."
+- **Monotonic integer suffix** (`smith2024`, `smith2024_2`). Conflicts
+  with BibLaTeX's own disambiguation conventions. Rejected.
+- **Freeze-on-first-ever-export instead of freeze-on-first-assignment**.
+  Drops the guarantee that the key exists as soon as the paper does —
+  every `get_paper` call would need to check and possibly assign.
+  Rejected for determinism.
+- **First-written wins tiebreaker** instead of lowest-UUID. Not
+  deterministic across machines importing the same DB (clock skew).
+  Rejected.
+
+## References
+
+- Better BibTeX for Zotero — https://retorque.re/zotero-better-bibtex/citing/
+- Algorithm source: `crates/scitadel-core/src/bibtex_key.rs`
+- Golden fixture: `key_algo_hash_is_frozen` in `crates/scitadel-export/src/bibtex.rs`
+- Migration: `crates/scitadel-db/migrations/009_bibtex_keys.sql`
+- Backfill hook: `Database::backfill_bibtex_keys` in `crates/scitadel-db/src/sqlite/mod.rs`


### PR DESCRIPTION
## Summary

Foundation pass for the 0.6.0 bib surface, per the 3-reviewer sub-spike:
- **Stable citation keys**: Better-BibTeX-style algorithm (\`{lastname}{year}{firstword}\`, ASCII-folded, \`a\`/\`b\`/\`c\` collision suffix, UUID tiebreaker). Freeze-on-first-assignment, never recompute.
- **Deterministic export**: sorted alphabetical, fixed field order, NFC UTF-8, LF line endings, \`algo_hash\`-pinned header with zero timestamps.
- **Algorithm-hash pinning**: \`key_algo_hash_is_frozen\` golden-fixture test fails loudly on drift, forcing explicit migration + CHANGELOG entry.

Import / watch / rekey → 0.6.1 (#134). CSL-JSON / TUI E keybind / bib diff → 0.6.2 (#135).

## Test plan

- [x] 12 new unit tests in \`scitadel-export::bibtex\` (sort, escaping, unicode, header, backfill, algo-hash freeze)
- [x] 2 new core tests for the pure algorithm
- [x] 1 integration test \`migrate_backfills_bibtex_keys\` (seed via SQL → migrate → verify)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean

See [ADR-006](docs/decisions/ADR-006-2026-04-21-bibtex-key-algorithm.md).

Closes #132.