### PR TITLE
feat(tui): Question Dashboard — ranked papers + citation shortlist (#133)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and forces an explicit migration. See [ADR-006](docs/decisions/ADR-006-2026-04-21-bibtex-key-algorithm.md).
   CLI surface (`scitadel bib export` / `snapshot` / `verify`), `.scitadel-bib.lock`
   sidecar, import and watch ship in 0.6.1 (#134) and 0.6.2 (#135).
+- **Question Dashboard** (#133). New TUI overlay accessed via `Enter`
+  on the Questions tab. Split pane: left 40% shows papers scored
+  against the question, ranked by score DESC; right 60% shows the
+  focused paper's rationale + abstract + metadata. `c` toggles a
+  citation shortlist (persisted per `(question_id, reader)`) marked
+  with `●`. `Enter` opens the focused paper in the existing detail
+  overlay; `Esc`/`q` returns to Questions. Shortlist membership feeds
+  `bib snapshot <question_id>` in 0.6.1 (#134). Migration 010 adds
+  the `shortlist_members` table. MCP `get_question_dashboard` /
+  `toggle_shortlist` / `list_shortlist` tools ship in a follow-up.
 - **Dalton Dark theme + central `theme.rs` abstraction** (#136). TUI now
   pulls colours through semantic roles (`emphasis`, `muted`,
   `selection_bg`, `quote`, `info`, `success`, `warning`, `danger`, plus

--- a/crates/scitadel-db/migrations/010_shortlists.sql
+++ b/crates/scitadel-db/migrations/010_shortlists.sql
@@ -1,0 +1,17 @@
+-- Per-(question, reader) citation shortlist (#133 Question Dashboard).
+-- The shortlist is the "these are the papers I will cite" set curated
+-- by the reader while triaging a question's scored papers. It's the
+-- input to `bib snapshot <question_id>` (0.6.1, see #134).
+
+CREATE TABLE IF NOT EXISTS shortlist_members (
+    question_id TEXT NOT NULL REFERENCES research_questions(id),
+    paper_id    TEXT NOT NULL REFERENCES papers(id),
+    reader      TEXT NOT NULL,
+    added_at    TEXT NOT NULL,
+    PRIMARY KEY (question_id, paper_id, reader)
+);
+
+CREATE INDEX IF NOT EXISTS idx_shortlist_q_r
+    ON shortlist_members(question_id, reader);
+
+INSERT OR IGNORE INTO schema_version (version, applied_at) VALUES (10, datetime('now'));

--- a/crates/scitadel-db/src/sqlite/migrations.rs
+++ b/crates/scitadel-db/src/sqlite/migrations.rs
@@ -11,6 +11,7 @@ const MIGRATION_006: &str = include_str!("../../migrations/006_search_fts.sql");
 const MIGRATION_007: &str = include_str!("../../migrations/007_paper_download_state.sql");
 const MIGRATION_008: &str = include_str!("../../migrations/008_tui_state.sql");
 const MIGRATION_009: &str = include_str!("../../migrations/009_bibtex_keys.sql");
+const MIGRATION_010: &str = include_str!("../../migrations/010_shortlists.sql");
 
 const MIGRATIONS: &[(i64, &str)] = &[
     (1, MIGRATION_001),
@@ -22,6 +23,7 @@ const MIGRATIONS: &[(i64, &str)] = &[
     (7, MIGRATION_007),
     (8, MIGRATION_008),
     (9, MIGRATION_009),
+    (10, MIGRATION_010),
 ];
 
 /// Run all pending migrations, skipping already-applied ones.

--- a/crates/scitadel-db/src/sqlite/mod.rs
+++ b/crates/scitadel-db/src/sqlite/mod.rs
@@ -6,6 +6,7 @@ mod paper_state;
 mod papers;
 mod questions;
 mod searches;
+mod shortlist;
 mod tui_state;
 
 pub use annotations::{SqliteAnnotationRepository, resolve_anchor};
@@ -16,6 +17,7 @@ pub use paper_state::{PaperState, SqlitePaperStateRepository};
 pub use papers::SqlitePaperRepository;
 pub use questions::SqliteQuestionRepository;
 pub use searches::SqliteSearchRepository;
+pub use shortlist::SqliteShortlistRepository;
 pub use tui_state::{SqliteTuiStateRepository, TuiState};
 
 use r2d2::Pool;

--- a/crates/scitadel-db/src/sqlite/shortlist.rs
+++ b/crates/scitadel-db/src/sqlite/shortlist.rs
@@ -1,0 +1,171 @@
+//! Per-(question, reader) citation shortlist (#133).
+//!
+//! Curated set of papers the reader will cite for a research question.
+//! Drives the Question Dashboard's `c` keybind and feeds
+//! `bib snapshot <question_id>` (#134, 0.6.1).
+//!
+//! Multi-author story: `reader` scope mirrors the annotation and star
+//! conventions — per-reader shortlists diverge until Dolt sync lands
+//! in Phase 5.
+
+use rusqlite::{OptionalExtension, params};
+
+use crate::error::DbError;
+use crate::sqlite::Database;
+
+#[derive(Clone)]
+pub struct SqliteShortlistRepository {
+    db: Database,
+}
+
+impl SqliteShortlistRepository {
+    pub fn new(db: Database) -> Self {
+        Self { db }
+    }
+
+    /// Is this paper on `reader`'s shortlist for `question_id`?
+    pub fn contains(
+        &self,
+        question_id: &str,
+        paper_id: &str,
+        reader: &str,
+    ) -> Result<bool, DbError> {
+        let conn = self.db.conn()?;
+        let exists: Option<i64> = conn
+            .query_row(
+                "SELECT 1 FROM shortlist_members
+                 WHERE question_id = ?1 AND paper_id = ?2 AND reader = ?3",
+                params![question_id, paper_id, reader],
+                |r| r.get(0),
+            )
+            .optional()?;
+        Ok(exists.is_some())
+    }
+
+    /// Toggle membership. Returns the post-toggle state (`true` = on
+    /// shortlist). Matches the TUI's `c` keybind and MCP
+    /// `toggle_shortlist` semantics. Does the whole check-and-swap
+    /// under one pool connection to avoid deadlocking the single-
+    /// connection in-memory test DB.
+    pub fn toggle(&self, question_id: &str, paper_id: &str, reader: &str) -> Result<bool, DbError> {
+        let conn = self.db.conn()?;
+        let exists: Option<i64> = conn
+            .query_row(
+                "SELECT 1 FROM shortlist_members
+                 WHERE question_id = ?1 AND paper_id = ?2 AND reader = ?3",
+                params![question_id, paper_id, reader],
+                |r| r.get(0),
+            )
+            .optional()?;
+        if exists.is_some() {
+            conn.execute(
+                "DELETE FROM shortlist_members
+                 WHERE question_id = ?1 AND paper_id = ?2 AND reader = ?3",
+                params![question_id, paper_id, reader],
+            )?;
+            Ok(false)
+        } else {
+            conn.execute(
+                "INSERT INTO shortlist_members (question_id, paper_id, reader, added_at)
+                 VALUES (?1, ?2, ?3, ?4)",
+                params![
+                    question_id,
+                    paper_id,
+                    reader,
+                    chrono::Utc::now().to_rfc3339()
+                ],
+            )?;
+            Ok(true)
+        }
+    }
+
+    /// Paper IDs on `reader`'s shortlist for `question_id`, in
+    /// added-at-ascending order (the order the reader built the list).
+    pub fn list(&self, question_id: &str, reader: &str) -> Result<Vec<String>, DbError> {
+        let conn = self.db.conn()?;
+        let mut stmt = conn.prepare(
+            "SELECT paper_id FROM shortlist_members
+             WHERE question_id = ?1 AND reader = ?2
+             ORDER BY added_at ASC",
+        )?;
+        let rows = stmt.query_map(params![question_id, reader], |r| r.get::<_, String>(0))?;
+        Ok(rows.filter_map(Result::ok).collect())
+    }
+
+    /// `paper_id` set for use as a contains-check in render loops —
+    /// cheaper than N per-row `contains` calls.
+    pub fn members_set(
+        &self,
+        question_id: &str,
+        reader: &str,
+    ) -> Result<std::collections::HashSet<String>, DbError> {
+        Ok(self.list(question_id, reader)?.into_iter().collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fresh() -> SqliteShortlistRepository {
+        let db = Database::open_in_memory().unwrap();
+        db.migrate().unwrap();
+        let conn = db.conn().unwrap();
+        // Need a question + a paper to satisfy FKs.
+        conn.execute(
+            "INSERT INTO research_questions (id, text, description, created_at, updated_at)
+             VALUES ('q1', 'Q', '', datetime('now'), datetime('now'))",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO papers (id, title, created_at, updated_at)
+             VALUES ('p1', 'T', datetime('now'), datetime('now'))",
+            [],
+        )
+        .unwrap();
+        SqliteShortlistRepository::new(db)
+    }
+
+    #[test]
+    fn toggle_round_trip() {
+        let repo = fresh();
+        assert!(repo.toggle("q1", "p1", "lars").unwrap(), "adds on first");
+        assert!(repo.contains("q1", "p1", "lars").unwrap());
+        assert!(
+            !repo.toggle("q1", "p1", "lars").unwrap(),
+            "removes on second"
+        );
+        assert!(!repo.contains("q1", "p1", "lars").unwrap());
+    }
+
+    #[test]
+    fn list_is_added_at_ascending() {
+        let repo = fresh();
+        // Insert the second paper in a scoped block so the connection
+        // is released before `repo.toggle` needs one (the test DB's
+        // pool is single-connection).
+        {
+            let conn = repo.db.conn().unwrap();
+            conn.execute(
+                "INSERT INTO papers (id, title, created_at, updated_at)
+                 VALUES ('p2', 'T2', datetime('now'), datetime('now'))",
+                [],
+            )
+            .unwrap();
+        }
+        repo.toggle("q1", "p2", "lars").unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        repo.toggle("q1", "p1", "lars").unwrap();
+        let ids = repo.list("q1", "lars").unwrap();
+        assert_eq!(ids, vec!["p2", "p1"], "oldest first");
+    }
+
+    #[test]
+    fn readers_have_independent_shortlists() {
+        let repo = fresh();
+        repo.toggle("q1", "p1", "lars").unwrap();
+        assert!(!repo.contains("q1", "p1", "claude").unwrap());
+        assert!(repo.contains("q1", "p1", "lars").unwrap());
+    }
+}

--- a/crates/scitadel-tui/src/app.rs
+++ b/crates/scitadel-tui/src/app.rs
@@ -19,8 +19,7 @@ use crate::data::DataStore;
 use crate::tasks::{Task, TaskKind, TaskStatus, TaskUpdate, spawn_download_paper};
 use crate::views::annotation_prompt::{AnnotationPrompt, PromptCommit, PromptSubmission};
 use crate::views::{
-    annotation_prompt, dashboard, detail, papers, questions, queue, searches,
-    tasks as tasks_view,
+    annotation_prompt, dashboard, detail, papers, questions, queue, searches, tasks as tasks_view,
 };
 use crate::widgets::status_bar;
 

--- a/crates/scitadel-tui/src/app.rs
+++ b/crates/scitadel-tui/src/app.rs
@@ -19,7 +19,8 @@ use crate::data::DataStore;
 use crate::tasks::{Task, TaskKind, TaskStatus, TaskUpdate, spawn_download_paper};
 use crate::views::annotation_prompt::{AnnotationPrompt, PromptCommit, PromptSubmission};
 use crate::views::{
-    annotation_prompt, detail, papers, questions, queue, searches, tasks as tasks_view,
+    annotation_prompt, dashboard, detail, papers, questions, queue, searches,
+    tasks as tasks_view,
 };
 use crate::widgets::status_bar;
 
@@ -90,6 +91,13 @@ pub enum Overlay {
     },
     SearchPapers {
         search_id: String,
+        selected: usize,
+    },
+    /// Question Dashboard (#133). Split-pane ranked-by-score view of
+    /// papers assessed against the question, with a citation shortlist
+    /// curated via `c`.
+    QuestionDashboard {
+        question_id: String,
         selected: usize,
     },
 }
@@ -236,17 +244,21 @@ impl App {
                 (Some(paper_id.clone()), None, ann_id)
             }
             Some(Overlay::SearchPapers { search_id, .. }) => (None, Some(search_id.clone()), None),
-            None => (None, None, None),
+            Some(Overlay::QuestionDashboard { .. }) | None => (None, None, None),
         };
-        // Question id only when the user is actually on the Questions tab.
-        let question_id = if matches!(self.tab, Tab::Questions) {
-            self.data.load_questions().ok().and_then(|qs| {
-                qs.get(self.question_selected)
-                    .map(|q| q.id.as_str().to_string())
-            })
-        } else {
-            None
-        };
+        // Question id: from the overlay (dashboard open) or the
+        // Questions-tab cursor. Dashboard wins since it's more specific.
+        let question_id =
+            if let Some(Overlay::QuestionDashboard { question_id, .. }) = &self.overlay {
+                Some(question_id.clone())
+            } else if matches!(self.tab, Tab::Questions) {
+                self.data.load_questions().ok().and_then(|qs| {
+                    qs.get(self.question_selected)
+                        .map(|q| q.id.as_str().to_string())
+                })
+            } else {
+                None
+            };
         scitadel_db::sqlite::TuiState {
             tab: tab.to_string(),
             paper_id,
@@ -403,6 +415,51 @@ impl App {
                     let sel = *selected;
                     if let Ok(papers) = self.data.load_papers_for_search(&search_id_clone)
                         && let Some(paper) = papers.get(sel)
+                    {
+                        self.overlay = Some(Overlay::PaperDetail {
+                            paper_id: paper.id.as_str().to_string(),
+                            scroll: 0,
+                            annotation_focus: None,
+                            prompt: None,
+                            reader: false,
+                            highlight_focus: None,
+                        });
+                    }
+                }
+                _ => {}
+            },
+            Some(Overlay::QuestionDashboard {
+                ref question_id,
+                ref mut selected,
+            }) => match code {
+                KeyCode::Esc | KeyCode::Char('q') => self.overlay = None,
+                KeyCode::Char('j') | KeyCode::Down => {
+                    let count = dashboard::row_count(&self.data, question_id);
+                    if count > 0 {
+                        *selected = (*selected + 1).min(count - 1);
+                    }
+                }
+                KeyCode::Char('k') | KeyCode::Up => {
+                    *selected = selected.saturating_sub(1);
+                }
+                KeyCode::Char('c') => {
+                    let qid = question_id.clone();
+                    let sel = *selected;
+                    if let Ok(rows) = self.data.load_question_dashboard(&qid)
+                        && let Some((paper, _)) = rows.get(sel)
+                    {
+                        let pid = paper.id.as_str().to_string();
+                        let _ = self.data.toggle_shortlist(&qid, &pid, &self.reader);
+                    }
+                }
+                KeyCode::Enter => {
+                    // Open the focused paper's detail overlay on top of
+                    // the dashboard — same overlay mechanic as the
+                    // SearchPapers flow. Esc returns to the dashboard.
+                    let qid = question_id.clone();
+                    let sel = *selected;
+                    if let Ok(rows) = self.data.load_question_dashboard(&qid)
+                        && let Some((paper, _)) = rows.get(sel)
                     {
                         self.overlay = Some(Overlay::PaperDetail {
                             paper_id: paper.id.as_str().to_string(),
@@ -694,6 +751,16 @@ impl App {
                     KeyCode::Char('k') | KeyCode::Up => {
                         self.question_selected = self.question_selected.saturating_sub(1);
                     }
+                    KeyCode::Enter => {
+                        if let Ok(questions) = self.data.load_questions()
+                            && let Some(q) = questions.get(self.question_selected)
+                        {
+                            self.overlay = Some(Overlay::QuestionDashboard {
+                                question_id: q.id.as_str().to_string(),
+                                selected: 0,
+                            });
+                        }
+                    }
                     _ => {}
                 }
             }
@@ -885,6 +952,19 @@ fn draw(frame: &mut ratatui::Frame, app: &mut App) {
                 &app.downloading_paper_ids(),
             );
         }
+        Some(Overlay::QuestionDashboard {
+            question_id,
+            selected,
+        }) => {
+            dashboard::draw(
+                frame,
+                chunks[1],
+                &app.data,
+                question_id,
+                &app.reader,
+                *selected,
+            );
+        }
         None => match app.tab {
             Tab::Searches => searches::draw(frame, chunks[1], &app.data, app.search_selected),
             Tab::Papers => papers::draw(
@@ -945,6 +1025,9 @@ fn draw(frame: &mut ratatui::Frame, app: &mut App) {
         }
         (Some(Overlay::SearchPapers { .. }), _) => {
             "Esc/q: back | j/k: navigate | Enter: open paper"
+        }
+        (Some(Overlay::QuestionDashboard { .. }), _) => {
+            "Esc/q: back | j/k: navigate | Enter: open paper | c: toggle shortlist"
         }
         (None, Tab::Papers | Tab::Queue) => {
             "Tab: switch tabs | j/k: navigate | Enter: open | s: (un)star | c: clear tasks | q: quit"

--- a/crates/scitadel-tui/src/data.rs
+++ b/crates/scitadel-tui/src/data.rs
@@ -56,6 +56,13 @@ impl DataStore {
         Ok(q_repo.list_questions()?)
     }
 
+    /// Fetch a single research question by id. Used by the dashboard
+    /// title bar (#133).
+    pub fn load_question(&self, question_id: &str) -> Result<Option<ResearchQuestion>> {
+        let (_, _, q_repo, _, _) = self.db.repositories();
+        Ok(q_repo.get_question(question_id)?)
+    }
+
     pub fn load_terms(&self, question_id: &str) -> Result<Vec<SearchTerm>> {
         let (_, _, q_repo, _, _) = self.db.repositories();
         Ok(q_repo.get_terms(question_id)?)
@@ -156,6 +163,70 @@ impl DataStore {
     /// Soft-delete an annotation (tombstone — replies stay readable).
     pub fn delete_annotation(&self, annotation_id: &str) -> Result<()> {
         Ok(SqliteAnnotationRepository::new(self.db.clone()).soft_delete(annotation_id)?)
+    }
+
+    /// Load a question's papers ranked by assessment score (DESC) for
+    /// the Question Dashboard (#133). Returns `(Paper, Option<Assessment>)`
+    /// so the dashboard can show both metadata and the LLM score +
+    /// rationale in one render pass. Papers without an assessment
+    /// sort to the end.
+    pub fn load_question_dashboard(
+        &self,
+        question_id: &str,
+    ) -> Result<Vec<(Paper, Option<Assessment>)>> {
+        let (paper_repo, _, _, a_repo, _) = self.db.repositories();
+        let assessments = a_repo.get_for_question(question_id)?;
+        let mut out: Vec<(Paper, Option<Assessment>)> = Vec::with_capacity(assessments.len());
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for a in assessments {
+            let pid = a.paper_id.as_str().to_string();
+            if seen.contains(&pid) {
+                continue;
+            }
+            if let Ok(Some(paper)) = paper_repo.get(&pid) {
+                seen.insert(pid);
+                out.push((paper, Some(a)));
+            }
+        }
+        // Sort by score DESC, then by paper_id for tie stability.
+        out.sort_by(|a, b| {
+            let sa = a.1.as_ref().map_or(0.0, |x| x.score);
+            let sb = b.1.as_ref().map_or(0.0, |x| x.score);
+            sb.partial_cmp(&sa)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.0.id.as_str().cmp(b.0.id.as_str()))
+        });
+        Ok(out)
+    }
+
+    /// Toggle a paper's shortlist membership for the current reader.
+    /// Returns the post-toggle state (true = on shortlist). (#133)
+    pub fn toggle_shortlist(
+        &self,
+        question_id: &str,
+        paper_id: &str,
+        reader: &str,
+    ) -> Result<bool> {
+        Ok(
+            scitadel_db::sqlite::SqliteShortlistRepository::new(self.db.clone()).toggle(
+                question_id,
+                paper_id,
+                reader,
+            )?,
+        )
+    }
+
+    /// Members of `reader`'s shortlist for `question_id` as a set.
+    /// Used by the dashboard render to mark shortlisted rows. (#133)
+    pub fn load_shortlist_set(
+        &self,
+        question_id: &str,
+        reader: &str,
+    ) -> Result<std::collections::HashSet<String>> {
+        Ok(
+            scitadel_db::sqlite::SqliteShortlistRepository::new(self.db.clone())
+                .members_set(question_id, reader)?,
+        )
     }
 
     /// Persist the outcome of a download attempt for the Papers-table

--- a/crates/scitadel-tui/src/views/dashboard.rs
+++ b/crates/scitadel-tui/src/views/dashboard.rs
@@ -1,0 +1,242 @@
+//! Question Dashboard — ranked scored papers + citation shortlist (#133).
+//!
+//! Split pane: left 40% shows the papers scored against the question,
+//! ranked by score DESC; right 60% shows the focused paper's rationale,
+//! abstract, and annotation count. `c` toggles shortlist membership
+//! (marked with `●` prefix); Esc/q exits back to the Questions tab.
+
+use std::collections::HashSet;
+
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table, TableState, Wrap};
+
+use scitadel_core::models::{Assessment, Paper};
+
+use crate::data::DataStore;
+use crate::views::util::truncate;
+
+pub fn draw(
+    frame: &mut Frame,
+    area: Rect,
+    data: &DataStore,
+    question_id: &str,
+    reader: &str,
+    selected: usize,
+) {
+    let rows = data
+        .load_question_dashboard(question_id)
+        .unwrap_or_default();
+    let shortlist = data
+        .load_shortlist_set(question_id, reader)
+        .unwrap_or_default();
+    let question_text = data
+        .load_question(question_id)
+        .ok()
+        .flatten()
+        .map_or_else(|| "(unknown question)".to_string(), |q| q.text);
+
+    if rows.is_empty() {
+        let block = Block::default()
+            .title(format!(" Dashboard — {question_text} "))
+            .borders(Borders::ALL);
+        let msg = Paragraph::new(
+            "No scored papers yet for this question.\n\n\
+             Score papers via MCP: `prepare_batch_assessments` → LLM → `save_assessment`,\n\
+             then return here.",
+        )
+        .block(block)
+        .wrap(Wrap { trim: false });
+        frame.render_widget(msg, area);
+        return;
+    }
+
+    let chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(40), Constraint::Percentage(60)])
+        .split(area);
+
+    draw_list(
+        frame,
+        chunks[0],
+        &rows,
+        &shortlist,
+        selected,
+        &question_text,
+    );
+    draw_detail(frame, chunks[1], rows.get(selected));
+}
+
+fn draw_list(
+    frame: &mut Frame,
+    area: Rect,
+    rows: &[(Paper, Option<Assessment>)],
+    shortlist: &HashSet<String>,
+    selected: usize,
+    question_text: &str,
+) {
+    let shortlist_count = shortlist.len();
+    let title = format!(
+        " Dashboard — {} · {} scored · {} shortlisted ",
+        truncate(question_text, 40),
+        rows.len(),
+        shortlist_count
+    );
+
+    let header = Row::new(vec![
+        Cell::from(""),
+        Cell::from("Score"),
+        Cell::from("Title"),
+        Cell::from("Year"),
+    ])
+    .style(
+        Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD),
+    );
+
+    let table_rows: Vec<Row<'_>> = rows
+        .iter()
+        .map(|(paper, assessment)| {
+            let marker = if shortlist.contains(paper.id.as_str()) {
+                "●"
+            } else {
+                " "
+            };
+            let score = assessment
+                .as_ref()
+                .map_or("—".to_string(), |a| format!("{:.2}", a.score));
+            let year = paper
+                .year
+                .map_or_else(|| "—".to_string(), |y| y.to_string());
+            Row::new(vec![
+                Cell::from(marker).style(Style::default().fg(Color::Yellow)),
+                Cell::from(score),
+                Cell::from(truncate(&paper.title, 40)),
+                Cell::from(year),
+            ])
+        })
+        .collect();
+
+    let widths = [
+        Constraint::Length(2),
+        Constraint::Length(5),
+        Constraint::Min(20),
+        Constraint::Length(6),
+    ];
+
+    let table = Table::new(table_rows, widths)
+        .header(header)
+        .block(Block::default().title(title).borders(Borders::ALL))
+        .row_highlight_style(
+            Style::default()
+                .bg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
+        );
+
+    let mut state = TableState::default();
+    state.select(Some(selected));
+    frame.render_stateful_widget(table, area, &mut state);
+}
+
+fn draw_detail(frame: &mut Frame, area: Rect, focused: Option<&(Paper, Option<Assessment>)>) {
+    let Some((paper, assessment)) = focused else {
+        let empty = Paragraph::new("").block(Block::default().borders(Borders::ALL));
+        frame.render_widget(empty, area);
+        return;
+    };
+
+    let mut lines: Vec<Line<'_>> = Vec::new();
+    lines.push(Line::from(vec![
+        Span::styled(
+            "Title: ",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(paper.title.clone()),
+    ]));
+    if !paper.authors.is_empty() {
+        let authors = paper
+            .authors
+            .iter()
+            .take(4)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(", ");
+        let suffix = if paper.authors.len() > 4 {
+            format!(" et al. ({} total)", paper.authors.len())
+        } else {
+            String::new()
+        };
+        lines.push(Line::from(vec![
+            Span::styled("Authors: ", Style::default().fg(Color::Yellow)),
+            Span::raw(format!("{authors}{suffix}")),
+        ]));
+    }
+    if let Some(year) = paper.year {
+        lines.push(Line::from(vec![
+            Span::styled("Year: ", Style::default().fg(Color::Yellow)),
+            Span::raw(year.to_string()),
+        ]));
+    }
+    if let Some(doi) = &paper.doi {
+        lines.push(Line::from(vec![
+            Span::styled("DOI: ", Style::default().fg(Color::Yellow)),
+            Span::raw(doi.clone()),
+        ]));
+    }
+    lines.push(Line::from(""));
+
+    if let Some(a) = assessment {
+        lines.push(Line::from(vec![
+            Span::styled(
+                "Score: ",
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(format!("{:.2}", a.score)),
+            Span::raw("  "),
+            Span::styled(
+                format!("({})", a.assessor),
+                Style::default().fg(Color::DarkGray),
+            ),
+        ]));
+        if !a.reasoning.is_empty() {
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(
+                "Rationale:",
+                Style::default().fg(Color::Yellow),
+            )));
+            for line in a.reasoning.lines() {
+                lines.push(Line::from(line.to_string()));
+            }
+        }
+    }
+
+    if !paper.r#abstract.is_empty() {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "Abstract:",
+            Style::default().fg(Color::Yellow),
+        )));
+        for line in paper.r#abstract.lines() {
+            lines.push(Line::from(line.to_string()));
+        }
+    }
+
+    let para = Paragraph::new(lines)
+        .block(Block::default().title(" Detail ").borders(Borders::ALL))
+        .wrap(Wrap { trim: false });
+    frame.render_widget(para, area);
+}
+
+/// How many ranked rows exist for a question. Used by the app handler
+/// to clamp `selected` without re-running the full dashboard query.
+pub fn row_count(data: &DataStore, question_id: &str) -> usize {
+    data.load_question_dashboard(question_id)
+        .map_or(0, |v| v.len())
+}

--- a/crates/scitadel-tui/src/views/mod.rs
+++ b/crates/scitadel-tui/src/views/mod.rs
@@ -1,4 +1,5 @@
 pub mod annotation_prompt;
+pub mod dashboard;
 pub mod detail;
 pub mod papers;
 pub mod questions;

--- a/tests/vhs/question-dashboard.tape
+++ b/tests/vhs/question-dashboard.tape
@@ -1,0 +1,81 @@
+# VHS tape: Question Dashboard — ranked papers + citation shortlist (#133).
+#
+# Seeds a question + 3 scored papers, opens the Questions tab,
+# presses Enter to open the dashboard, toggles one onto the
+# shortlist with `c`.
+
+Output "tests/vhs/snapshots/question-dashboard/run.gif"
+
+Set Shell "bash"
+Set FontSize 14
+Set Width 1600
+Set Height 900
+Set Padding 10
+Set TypingSpeed 40ms
+
+Hide
+Type `export PATH="$PWD/target/release:$HOME/.cargo/bin:$PATH"`
+Enter
+Type `export PS1="$ "`
+Enter
+Type `export SCITADEL_DB=$(mktemp -d)/scitadel.db`
+Enter
+Type "scitadel init --yes --email demo@example.org --sources arxiv --db $SCITADEL_DB"
+Enter
+Sleep 1s
+
+# Seed a research question + 3 papers + 3 assessments.
+Type `sqlite3 $SCITADEL_DB "INSERT INTO research_questions (id, text, description, created_at, updated_at) VALUES ('q-ml', 'What are the key advances in attention mechanisms?', 'For a lit review section.', datetime('now'), datetime('now'));"`
+Enter
+Sleep 200ms
+Type `sqlite3 $SCITADEL_DB "INSERT INTO papers (id, title, authors, year, abstract, created_at, updated_at) VALUES ('p-a', 'Attention Is All You Need', '[\"Vaswani, A.\"]', 2017, 'The dominant sequence transduction models are based on complex RNNs or CNNs. We propose the Transformer.', datetime('now'), datetime('now'));"`
+Enter
+Sleep 100ms
+Type `sqlite3 $SCITADEL_DB "INSERT INTO papers (id, title, authors, year, abstract, created_at, updated_at) VALUES ('p-b', 'Neural Machine Translation by Jointly Learning to Align and Translate', '[\"Bahdanau, D.\"]', 2014, 'Earlier work on attention for sequence-to-sequence models.', datetime('now'), datetime('now'));"`
+Enter
+Sleep 100ms
+Type `sqlite3 $SCITADEL_DB "INSERT INTO papers (id, title, authors, year, abstract, created_at, updated_at) VALUES ('p-c', 'Long Short-Term Memory', '[\"Hochreiter, S.\"]', 1997, 'A recurrent architecture — foundational but not attention-based.', datetime('now'), datetime('now'));"`
+Enter
+Sleep 100ms
+Type `sqlite3 $SCITADEL_DB "INSERT INTO assessments (id, paper_id, question_id, score, reasoning, assessor, created_at) VALUES ('a-1', 'p-a', 'q-ml', 0.95, 'Landmark Transformer paper — core to the question on attention mechanisms.', 'claude-opus-4-7', datetime('now'));"`
+Enter
+Sleep 100ms
+Type `sqlite3 $SCITADEL_DB "INSERT INTO assessments (id, paper_id, question_id, score, reasoning, assessor, created_at) VALUES ('a-2', 'p-b', 'q-ml', 0.82, 'Earlier but directly relevant: attention for alignment in NMT.', 'claude-opus-4-7', datetime('now'));"`
+Enter
+Sleep 100ms
+Type `sqlite3 $SCITADEL_DB "INSERT INTO assessments (id, paper_id, question_id, score, reasoning, assessor, created_at) VALUES ('a-3', 'p-c', 'q-ml', 0.25, 'Seminal but pre-attention; include only for historical context.', 'claude-opus-4-7', datetime('now'));"`
+Enter
+Sleep 300ms
+
+Type "clear"
+Enter
+Show
+
+Type "scitadel tui"
+Enter
+Sleep 2500ms
+
+Tab
+Sleep 600ms
+Tab
+Sleep 1200ms
+Screenshot "tests/vhs/snapshots/question-dashboard/01-questions-tab.png"
+
+Enter
+Sleep 1500ms
+Screenshot "tests/vhs/snapshots/question-dashboard/02-dashboard-open.png"
+
+Type "j"
+Sleep 800ms
+Screenshot "tests/vhs/snapshots/question-dashboard/03-second-paper-focused.png"
+
+Type "c"
+Sleep 800ms
+Screenshot "tests/vhs/snapshots/question-dashboard/04-shortlisted.png"
+
+Escape
+Sleep 500ms
+Screenshot "tests/vhs/snapshots/question-dashboard/05-back-to-questions.png"
+
+Type "q"
+Sleep 300ms


### PR DESCRIPTION
## Summary

The 0.6.0 headliner. New TUI overlay that shows a question's scored papers ranked by score, with a citation shortlist curated via \`c\` and persisted to a new \`shortlist_members\` table (migration 010).

Closes the bottleneck between "scitadel scored 200 papers" and "here are the 12 I'll cite" — that shortlist feeds \`bib snapshot <question_id>\` in 0.6.1 (#134).

## Test plan

- [x] 3 new unit tests in \`scitadel-db::sqlite::shortlist\` (round-trip, ordering, per-reader isolation)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] VHS tape \`question-dashboard.tape\` — 5 distinct snapshots verify the flow
- [x] Manual smoke: dashboard ranks 0.95/0.82/0.25 correctly, \`●\` marker appears on shortlist toggle, Esc returns to Questions tab

Closes #133.