### PR TITLE
feat(tui): O keybind to open downloaded paper in OS viewer (#144)

### DIFF
--- a/crates/scitadel-tui/src/app.rs
+++ b/crates/scitadel-tui/src/app.rs
@@ -281,9 +281,12 @@ impl App {
                         .iter()
                         .find(|t| t.id == id)
                         .map(|t| match &t.kind {
-                            TaskKind::Download { paper_id, .. } => paper_id.clone(),
+                            TaskKind::Download { paper_id, .. } => (paper_id.clone(), true),
+                            TaskKind::OpenExternal { paper_id, .. } => (paper_id.clone(), false),
                         });
-                    if let Some(pid) = paper_id {
+                    if let Some((pid, persist)) = paper_id
+                        && persist
+                    {
                         self.persist_download_outcome(&pid, &status);
                     }
                     if let Some(t) = self.tasks.iter_mut().find(|t| t.id == id) {
@@ -314,9 +317,9 @@ impl App {
         self.tasks
             .iter()
             .filter(|t| matches!(t.status, TaskStatus::Queued | TaskStatus::Running))
-            .map(|t| {
-                let TaskKind::Download { paper_id, .. } = &t.kind;
-                paper_id.clone()
+            .filter_map(|t| match &t.kind {
+                TaskKind::Download { paper_id, .. } => Some(paper_id.clone()),
+                TaskKind::OpenExternal { .. } => None,
             })
             .collect()
     }
@@ -576,7 +579,53 @@ impl App {
                 *reader = true;
                 *highlight_focus = if count > 0 { Some(0) } else { None };
             }
+            KeyCode::Char('O') => {
+                // #144: open the locally downloaded file in the OS
+                // default viewer. PDFs that are unreadable as plain
+                // text (figures, math, tables) are the main motivator —
+                // R is for the in-TUI reader, O escapes to the real one.
+                let pid = paper_id.clone();
+                self.open_paper_externally(&pid);
+            }
             _ => {}
+        }
+    }
+
+    /// Spawn the OS default viewer for the paper's local file. Surfaces
+    /// errors (no local file, exec failure) via a transient task panel
+    /// row — success is implicit because the user sees the viewer pop up.
+    fn open_paper_externally(&self, paper_id: &str) {
+        let Ok(Some(paper)) = self.data.load_paper(paper_id) else {
+            return;
+        };
+        let path = paper.local_path.as_ref().map(std::path::PathBuf::from);
+        if let Some(p) = path {
+            crate::tasks::spawn_open_external(self.task_tx.clone(), &paper, p);
+        } else {
+            // Synthesize a Failed task so the user sees feedback rather
+            // than a silent no-op when they haven't downloaded yet.
+            let id = uuid::Uuid::new_v4();
+            let ref_id = paper
+                .doi
+                .clone()
+                .filter(|s| !s.is_empty())
+                .or_else(|| paper.arxiv_id.clone().filter(|s| !s.is_empty()))
+                .unwrap_or_else(|| paper.id.as_str().chars().take(8).collect());
+            let task = crate::tasks::Task {
+                id,
+                kind: TaskKind::OpenExternal {
+                    paper_id: paper.id.as_str().to_string(),
+                    ref_id,
+                    title: paper.title.clone(),
+                },
+                status: TaskStatus::Queued,
+                terminal_at: None,
+            };
+            let _ = self.task_tx.send(crate::tasks::TaskUpdate::New(task));
+            let _ = self.task_tx.send(crate::tasks::TaskUpdate::Status {
+                id,
+                status: TaskStatus::Failed("no local file — press D to download first".to_string()),
+            });
         }
     }
 
@@ -938,7 +987,7 @@ fn draw(frame: &mut ratatui::Frame, app: &mut App) {
                         "Esc: leave focus | j/k: navigate | n: new | e: edit | r: reply | d: delete"
                     }
                     (None, None) => {
-                        "Esc/q: back | j/k: scroll | d/u: page | D: download | n: new | J: focus | R: reader"
+                        "Esc/q: back | j/k: scroll | d/u: page | D: download | O: open externally | R: reader | n: new | J: focus"
                     }
                 }
             }

--- a/crates/scitadel-tui/src/tasks.rs
+++ b/crates/scitadel-tui/src/tasks.rs
@@ -34,6 +34,15 @@ pub enum TaskKind {
         ref_id: String,
         title: String,
     },
+    /// Spawn the OS file viewer for an already-downloaded paper (#144).
+    /// Fire-and-forget: success surfaces as the viewer opening, so this
+    /// task only sticks around long enough to flash the failure message
+    /// when no local file exists or the spawn errored.
+    OpenExternal {
+        paper_id: String,
+        ref_id: String,
+        title: String,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -105,6 +114,67 @@ pub fn synthesize_offline_failure(tx: UnboundedSender<TaskUpdate>, paper: &Paper
         ),
     });
     id
+}
+
+/// Spawn the OS default viewer for `path` and return a task tracking the
+/// outcome (#144). Success is implicit (the viewer pops up), so we
+/// transition to `Done` immediately with a synthetic path/access on the
+/// task — only failures (no opener on PATH, exec errored) actually need
+/// a visible row. `paper` provides the ref_id/title for the panel.
+pub fn spawn_open_external(tx: UnboundedSender<TaskUpdate>, paper: &Paper, path: PathBuf) -> Uuid {
+    let id = Uuid::new_v4();
+    let ref_id = paper
+        .doi
+        .clone()
+        .filter(|s| !s.is_empty())
+        .or_else(|| paper.arxiv_id.clone().filter(|s| !s.is_empty()))
+        .or_else(|| paper.openalex_id.clone().filter(|s| !s.is_empty()))
+        .unwrap_or_else(|| paper.id.as_str().chars().take(8).collect());
+    let task = Task {
+        id,
+        kind: TaskKind::OpenExternal {
+            paper_id: paper.id.as_str().to_string(),
+            ref_id,
+            title: paper.title.clone(),
+        },
+        status: TaskStatus::Queued,
+        terminal_at: None,
+    };
+    let _ = tx.send(TaskUpdate::New(task));
+
+    let status = match open_with_system_viewer(&path) {
+        Ok(()) => TaskStatus::Done {
+            path,
+            format: DownloadFormat::Pdf,
+            access: AccessStatus::FullText,
+            publisher_url: None,
+        },
+        Err(e) => TaskStatus::Failed(e),
+    };
+    let _ = tx.send(TaskUpdate::Status { id, status });
+    id
+}
+
+/// Cross-platform "open this file with the OS default app". Returns a
+/// human-readable error string so failures can land in the task panel.
+fn open_with_system_viewer(path: &std::path::Path) -> Result<(), String> {
+    if !path.exists() {
+        return Err(format!("file not found: {}", path.display()));
+    }
+    #[cfg(target_os = "macos")]
+    let mut cmd = std::process::Command::new("open");
+    #[cfg(target_os = "linux")]
+    let mut cmd = std::process::Command::new("xdg-open");
+    #[cfg(target_os = "windows")]
+    let mut cmd = {
+        let mut c = std::process::Command::new("cmd");
+        c.args(["/C", "start", ""]);
+        c
+    };
+    cmd.arg(path);
+    cmd.spawn()
+        .map(|_| ())
+        .map_err(|e| format!("failed to launch viewer: {e}"))
 }
 
 /// Spawn a download for a full `Paper` (uses all available identifiers).

--- a/crates/scitadel-tui/src/views/tasks.rs
+++ b/crates/scitadel-tui/src/views/tasks.rs
@@ -36,17 +36,21 @@ fn render_row(task: &Task, show_institutional_hint: bool) -> ListItem<'_> {
         TaskStatus::Failed(_) => ("✗", t.danger),
     };
 
-    let (title, ref_id) = match &task.kind {
-        TaskKind::Download { title, ref_id, .. } => (truncate(title, 55), ref_id.as_str()),
+    let (title, ref_id, kind_label) = match &task.kind {
+        TaskKind::Download { title, ref_id, .. } => (truncate(title, 55), ref_id.as_str(), ""),
+        TaskKind::OpenExternal { title, ref_id, .. } => {
+            (truncate(title, 55), ref_id.as_str(), "open: ")
+        }
     };
 
-    let status_tail = status_tail_text(&task.status, show_institutional_hint);
+    let status_tail = status_tail_text(&task.status, show_institutional_hint, &task.kind);
 
     ListItem::new(Line::from(vec![
         Span::styled(
             format!("{icon} "),
             Style::default().fg(color).add_modifier(Modifier::BOLD),
         ),
+        Span::styled(kind_label, Style::default().fg(crate::theme::theme().muted)),
         Span::raw(title),
         Span::raw("  "),
         Span::styled(
@@ -60,7 +64,7 @@ fn render_row(task: &Task, show_institutional_hint: bool) -> ListItem<'_> {
     ]))
 }
 
-fn status_tail_text(status: &TaskStatus, show_institutional_hint: bool) -> String {
+fn status_tail_text(status: &TaskStatus, show_institutional_hint: bool, kind: &TaskKind) -> String {
     match status {
         TaskStatus::Queued => "queued".to_string(),
         TaskStatus::Running => "downloading…".to_string(),
@@ -70,10 +74,14 @@ fn status_tail_text(status: &TaskStatus, show_institutional_hint: bool) -> Strin
             path,
             publisher_url,
         } => {
+            // OpenExternal "Done" just means "viewer was launched" — the
+            // download metadata fields are placeholders, so don't print
+            // them as if they describe a real download.
+            if matches!(kind, TaskKind::OpenExternal { .. }) {
+                let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("file");
+                return format!("opened {name}");
+            }
             let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("saved");
-            // On paywall, tell the user where to get the live page — an
-            // institutional IP range will often grant access that the
-            // headless fetcher can't.
             if *access == AccessStatus::Paywall
                 && show_institutional_hint
                 && let Some(url) = publisher_url
@@ -97,6 +105,31 @@ mod tests {
 
     use super::*;
 
+    fn dl_kind() -> TaskKind {
+        TaskKind::Download {
+            paper_id: "p".into(),
+            ref_id: "ref".into(),
+            title: "title".into(),
+        }
+    }
+
+    #[test]
+    fn open_external_done_shows_opened_filename() {
+        let status = TaskStatus::Done {
+            path: PathBuf::from("/tmp/paper.pdf"),
+            format: DownloadFormat::Pdf,
+            access: AccessStatus::FullText,
+            publisher_url: None,
+        };
+        let kind = TaskKind::OpenExternal {
+            paper_id: "p".into(),
+            ref_id: "ref".into(),
+            title: "title".into(),
+        };
+        let text = status_tail_text(&status, true, &kind);
+        assert_eq!(text, "opened paper.pdf");
+    }
+
     #[test]
     fn paywall_with_hint_includes_url() {
         let status = TaskStatus::Done {
@@ -105,7 +138,7 @@ mod tests {
             access: AccessStatus::Paywall,
             publisher_url: Some("https://doi.org/10.1234/x".into()),
         };
-        let text = status_tail_text(&status, true);
+        let text = status_tail_text(&status, true, &dl_kind());
         assert!(text.contains("https://doi.org/10.1234/x"));
         assert!(text.contains("institutional IP may grant access"));
     }
@@ -118,7 +151,7 @@ mod tests {
             access: AccessStatus::Paywall,
             publisher_url: Some("https://doi.org/10.1234/x".into()),
         };
-        let text = status_tail_text(&status, false);
+        let text = status_tail_text(&status, false, &dl_kind());
         assert!(!text.contains("https://doi.org/10.1234/x"));
         assert!(text.contains("paywall"));
     }
@@ -131,7 +164,7 @@ mod tests {
             access: AccessStatus::FullText,
             publisher_url: Some("https://example.org".into()),
         };
-        let text = status_tail_text(&status, true);
+        let text = status_tail_text(&status, true, &dl_kind());
         assert!(!text.contains("institutional IP"));
     }
 }

--- a/tests/vhs/open-externally.tape
+++ b/tests/vhs/open-externally.tape
@@ -1,0 +1,61 @@
+# VHS tape: 'O' keybind opens local PDF in OS viewer (#144).
+#
+# We deliberately seed a paper WITHOUT a local_path so pressing O in
+# the Detail overlay surfaces the "no local file — press D to download
+# first" failure in the task panel. This is the only path safe to
+# render in CI; the success path would actually launch a viewer and
+# steal focus from the headless terminal session.
+
+Output "tests/vhs/snapshots/open-externally/run.gif"
+
+Set Shell "bash"
+Set FontSize 14
+Set Width 1400
+Set Height 800
+Set Padding 10
+Set TypingSpeed 40ms
+
+Hide
+Type `export PATH="$PWD/target/release:$HOME/.cargo/bin:$PATH"`
+Enter
+Type `export PS1="$ "`
+Enter
+Type `export SCITADEL_DB=$(mktemp -d)/scitadel.db`
+Enter
+Type "scitadel init --yes --email demo@example.org --sources arxiv --db $SCITADEL_DB"
+Enter
+Sleep 1s
+
+# Seed one paper. local_path is intentionally NULL so O surfaces the
+# "no local file" failure instead of launching a viewer.
+Type `sqlite3 $SCITADEL_DB "INSERT INTO papers (id, title, authors, year, created_at, updated_at) VALUES ('p-x', 'Attention Is All You Need', '[\"Vaswani, A.\"]', 2017, datetime('now'), datetime('now'));"`
+Enter
+Sleep 200ms
+
+Type "clear"
+Enter
+Show
+
+Type "scitadel tui"
+Enter
+Sleep 2500ms
+
+# Tab to Papers, open the row.
+Tab
+Sleep 500ms
+Sleep 500ms
+Screenshot "tests/vhs/snapshots/open-externally/01-papers-tab.png"
+
+Enter
+Sleep 1500ms
+Screenshot "tests/vhs/snapshots/open-externally/02-detail-open.png"
+
+# Press O — paper has no local file, so we expect a Failed task row.
+Type "O"
+Sleep 1500ms
+Screenshot "tests/vhs/snapshots/open-externally/03-no-local-file-failure.png"
+
+Type "q"
+Sleep 300ms
+Type "q"
+Sleep 300ms


### PR DESCRIPTION
## Summary
- Adds `O` in the Detail overlay → spawns `open` (macOS) / `xdg-open` (Linux) / `cmd /c start` (Windows) on `paper.local_path`
- Failure path surfaces in the existing task panel via a new `TaskKind::OpenExternal` (e.g. "no local file — press D to download first")
- Status bar updated: `D: download | O: open externally | R: reader | n: new | J: focus`
- VHS tape `open-externally.tape` covers the no-local-file failure flow (success path can't run headless)

Closes #144.

## Why
Without this, `R` (text reader) is the only way to read a downloaded PDF in the TUI, and PDFs heavy on figures/math/tables come out unreadable. `O` lets the user escape to their OS default viewer with one keystroke.

## Test plan
- [ ] `cargo test -p scitadel-tui` — 28 pass locally including new `open_external_done_shows_opened_filename`
- [ ] Manually: download a paper (`D`), then `O` opens it in Preview/zathura/etc.
- [ ] Manually: press `O` on an undownloaded paper → task panel shows red ✗ "no local file — press D to download first"
- [ ] VHS tape renders 3 distinct snapshots (papers tab → detail overlay → failure flash)