### PR TITLE
feat(mcp): pdftotext -layout fallback for scientific PDFs (#145)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Layout-aware PDF text extraction** (#145). `read_paper` now prefers
+  `pdftotext -layout -nopgbrk` (poppler) when on PATH, falling back to
+  the existing `pdf-extract` crate when not. Two-column scientific
+  papers come out in correct reading order instead of left/right
+  interleaved; the response envelope includes an `Extractor:` line so
+  downstream agents can tell which tier produced the text. No new
+  mandatory dependency — pdftotext is already common via Homebrew /
+  poppler-utils, and absence of it is transparent.
+- **`O` keybind in TUI Detail overlay** (#144). Spawns the OS default
+  viewer (`open` / `xdg-open` / `cmd /c start`) on `paper.local_path`
+  for figure/math/table-heavy PDFs that don't survive plain-text
+  extraction. Failures (no local file, exec error) surface in the
+  task panel as a Failed row. Status bar now: `D: download | O: open
+  externally | R: reader | n: new | J: focus`.
 - **Stable BibTeX citation keys + deterministic export** (#132). Migration 009
   adds `papers.bibtex_key TEXT UNIQUE`. Algorithm lives in
   `scitadel-core::bibtex_key` (Better-BibTeX-style `{lastname}{year}{firstword}`,

--- a/crates/scitadel-mcp/src/extract.rs
+++ b/crates/scitadel-mcp/src/extract.rs
@@ -1,0 +1,126 @@
+//! PDF text extraction with a layout-aware fallback (#145).
+//!
+//! Why two tiers: `pdf-extract` is pure-Rust and ships in every build,
+//! but it mangles two-column scientific layouts (left/right interleave),
+//! drops ligatures, and breaks formula-heavy passages. Poppler's
+//! `pdftotext -layout` produces materially better text on those exact
+//! papers — and most macOS / Linux scientific workstations already have
+//! it via `brew install poppler` / the distro `poppler-utils` package.
+//!
+//! We probe `pdftotext` once per process and cache the result. If
+//! present, we shell out to it; if not, we fall back to `pdf-extract`.
+//! No new mandatory dependency, transparent improvement when available.
+
+use std::path::Path;
+use std::sync::OnceLock;
+
+/// Identifies which extractor produced the text. Surfaced in the MCP
+/// `read_paper` response so a downstream agent can tell whether it's
+/// reading layout-preserved poppler output or naive flow text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PdfExtractor {
+    /// `pdftotext -layout` from poppler-utils. Preserves columns +
+    /// reading order; recommended for 2-column scientific PDFs.
+    Pdftotext,
+    /// Pure-Rust `pdf-extract` crate. Always available; lossier on
+    /// multi-column layouts.
+    PdfExtractCrate,
+}
+
+impl PdfExtractor {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Pdftotext => "pdftotext",
+            Self::PdfExtractCrate => "pdf-extract",
+        }
+    }
+}
+
+/// Extract text from a PDF, preferring `pdftotext -layout` when
+/// available. Returns the text and which extractor produced it. Runs
+/// in `spawn_blocking` to keep the async runtime free.
+pub async fn extract_pdf_text(path: &Path) -> Result<(String, PdfExtractor), String> {
+    let path = path.to_path_buf();
+    tokio::task::spawn_blocking(move || extract_pdf_text_sync(&path))
+        .await
+        .map_err(|e| format!("pdf extract task failed: {e}"))?
+}
+
+/// Synchronous extraction core. Tier 1: `pdftotext -layout -nopgbrk
+/// <pdf> -`. Tier 2: `pdf_extract::extract_text`. Never panics — every
+/// failure returns a string so the MCP envelope can surface it.
+fn extract_pdf_text_sync(path: &Path) -> Result<(String, PdfExtractor), String> {
+    if pdftotext_available() {
+        match run_pdftotext(path) {
+            Ok(text) => return Ok((text, PdfExtractor::Pdftotext)),
+            Err(e) => {
+                // Don't fail the whole call — a malformed PDF that
+                // breaks pdftotext might still parse with pdf-extract,
+                // and either way a degraded extract beats no text.
+                tracing::warn!(
+                    error = %e,
+                    "pdftotext failed; falling back to pdf-extract"
+                );
+            }
+        }
+    }
+    let text = pdf_extract::extract_text(path).map_err(|e| format!("pdf extract failed: {e}"))?;
+    Ok((text, PdfExtractor::PdfExtractCrate))
+}
+
+/// Cached PATH probe for `pdftotext`. The answer doesn't change over
+/// the process lifetime, so we walk `$PATH` once and cache the result.
+fn pdftotext_available() -> bool {
+    static CACHED: OnceLock<bool> = OnceLock::new();
+    *CACHED.get_or_init(|| {
+        std::env::var_os("PATH").is_some_and(|paths| {
+            std::env::split_paths(&paths).any(|dir| dir.join("pdftotext").is_file())
+        })
+    })
+}
+
+/// Shell out to `pdftotext -layout -nopgbrk <pdf> -`. `-layout`
+/// preserves column geometry (the whole point of using poppler);
+/// `-nopgbrk` strips form-feed page separators that confuse downstream
+/// readers. `-` writes to stdout so we never touch a temp file.
+fn run_pdftotext(path: &Path) -> Result<String, String> {
+    let output = std::process::Command::new("pdftotext")
+        .arg("-layout")
+        .arg("-nopgbrk")
+        .arg(path)
+        .arg("-")
+        .output()
+        .map_err(|e| format!("pdftotext spawn failed: {e}"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "pdftotext exited {}: {}",
+            output.status,
+            stderr.trim()
+        ));
+    }
+    String::from_utf8(output.stdout).map_err(|e| format!("pdftotext stdout was not UTF-8: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extractor_names_are_stable() {
+        // The strings end up in API responses and logs — pinning them
+        // means renaming the enum variant doesn't silently change the
+        // wire format.
+        assert_eq!(PdfExtractor::Pdftotext.as_str(), "pdftotext");
+        assert_eq!(PdfExtractor::PdfExtractCrate.as_str(), "pdf-extract");
+    }
+
+    #[test]
+    fn pdftotext_probe_is_cached_and_idempotent() {
+        // Two calls should agree (and cheaply — the cache is the point).
+        let a = pdftotext_available();
+        let b = pdftotext_available();
+        assert_eq!(a, b);
+    }
+}

--- a/crates/scitadel-mcp/src/lib.rs
+++ b/crates/scitadel-mcp/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod extract;
 #[allow(clippy::unused_self, clippy::needless_pass_by_value)]
 pub mod server;
 pub mod tools;

--- a/crates/scitadel-mcp/src/tools.rs
+++ b/crates/scitadel-mcp/src/tools.rs
@@ -565,20 +565,22 @@ pub async fn read_paper_tool(paper_id: &str, max_chars: Option<usize>) -> Result
     let mut text: Option<String> = paper.full_text.clone();
     let mut path: Option<std::path::PathBuf> = None;
 
+    let mut extractor: Option<&'static str> = None;
     if text.is_none() {
         let p = scitadel_adapters::download::find_cached_file(&paper, &config.papers_dir())
             .ok_or_else(|| "paper not downloaded yet. Call download_paper first.".to_string())?;
         let extracted = match p.extension().and_then(|e| e.to_str()) {
             Some("pdf") => {
-                let path_clone = p.clone();
-                tokio::task::spawn_blocking(move || pdf_extract::extract_text(&path_clone))
-                    .await
-                    .map_err(|e| format!("pdf extract task failed: {e}"))?
-                    .map_err(|e| format!("pdf extract failed: {e}"))?
+                // Layout-aware pdftotext when available, else
+                // pdf-extract — see crate::extract for rationale (#145).
+                let (body, used) = crate::extract::extract_pdf_text(&p).await?;
+                extractor = Some(used.as_str());
+                body
             }
             Some("html") => {
                 let bytes = tokio::fs::read(&p).await.map_err(|e| e.to_string())?;
                 let html = String::from_utf8_lossy(&bytes);
+                extractor = Some("html2text");
                 html_to_text(&html)
             }
             other => return Err(format!("unsupported file type: {other:?}")),
@@ -610,8 +612,9 @@ pub async fn read_paper_tool(paper_id: &str, max_chars: Option<usize>) -> Result
         text
     };
 
+    let extractor_line = extractor.map_or_else(String::new, |e| format!("Extractor: {e}\n"));
     Ok(format!(
-        "Paper: {}\nPath: {}\n\n{}",
+        "Paper: {}\nPath: {}\n{extractor_line}\n{}",
         paper.title, path_display, truncated
     ))
 }


### PR DESCRIPTION
## Summary
- New `crates/scitadel-mcp/src/extract.rs`: two-tier extractor — `pdftotext -layout -nopgbrk` first, `pdf-extract` fallback
- `read_paper` envelope adds `Extractor: pdftotext|pdf-extract|html2text` so agents can tell layout-preserved output from naive flow text
- PATH probe cached via `OnceLock` (paid once per process)
- pdftotext failure falls through to pdf-extract — degraded extract beats no text

Closes #145.

## Why
`pdf-extract` mangles two-column scientific PDFs: text comes out left/right interleaved, ligatures break, math falls apart. Most macOS / Linux scientific workstations already have `pdftotext` via Homebrew or poppler-utils. Using it when present gets users readable text on the papers they actually want to read.

## Test plan
- [ ] `cargo test -p scitadel-mcp` — 15 lib tests pass
- [ ] Manually: open a 2-column paper via `read_paper` with poppler installed → output reads top-to-bottom in column order
- [ ] Manually: same on a clean machine without pdftotext → still works (falls through to pdf-extract)

## Out of scope (for follow-ups)
- Per-page extraction so reader can show "page N of M"
- Persisting `extractor` alongside `full_text` to enable re-extract on upgrade
- pdfium-render as a third tier