### PR TITLE
feat(tui): light mode + auto-detect (#137, theme iter 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Light mode + auto-detect** (#137, theme iter 2). Adds
+  `Theme::DALTON_BRIGHT` (Dalton Bright palette ported from upstream)
+  and runtime theme resolution: `--theme <name>` CLI flag on
+  `scitadel tui` (highest precedence) → `SCITADEL_THEME` env var →
+  `[ui] theme = "..."` in config → `auto`. `auto` probes `COLORFGBG`
+  to pick light vs dark and falls back to dark when unset/unparseable.
+  OSC 11 fallback intentionally deferred (raw-tty + timeout dance);
+  `--theme` is the documented escape hatch when `COLORFGBG` is wrong.
+  Theme is locked once at startup — restart the TUI if the terminal
+  flips light/dark mid-session.
+
+## [0.6.0] - 2026-04-24
+
+The "actually read what you found" release. Closes the workflow gap
+that motivated 0.6.0: agents and the TUI now agree on a stable
+citation key, the Queue tab + Question Dashboard make multi-question
+research navigable, and pressing `O` on any downloaded paper escapes
+to your OS PDF viewer for the figure/math-heavy work that doesn't
+survive plain-text extraction. `read_paper` is also materially better
+on 2-column scientific PDFs via `pdftotext -layout` when available.
+
+### Added
+
 - **Layout-aware PDF text extraction** (#145). `read_paper` now prefers
   `pdftotext -layout -nopgbrk` (poppler) when on PATH, falling back to
   the existing `pdf-extract` crate when not. Two-column scientific

--- a/crates/scitadel-cli/src/commands.rs
+++ b/crates/scitadel-cli/src/commands.rs
@@ -43,11 +43,16 @@ pub async fn mcp() -> Result<()> {
     Ok(())
 }
 
-pub fn tui() -> Result<()> {
+pub fn tui(theme_override: Option<&str>) -> Result<()> {
     let config = load_config();
     let email = config.openalex.api_key.clone();
     let papers_dir = config.papers_dir();
     let reader = std::env::var("USER").unwrap_or_else(|_| "unknown".into());
+    // Resolve theme before any rendering so the very first frame uses
+    // the right palette. Order: --theme > SCITADEL_THEME > ui.theme >
+    // auto-detect (#137).
+    let resolved = scitadel_tui::theme::resolve(theme_override, &config.ui.theme);
+    scitadel_tui::theme::init(resolved);
     scitadel_tui::run(
         &config.db_path,
         email,

--- a/crates/scitadel-cli/src/main.rs
+++ b/crates/scitadel-cli/src/main.rs
@@ -116,7 +116,13 @@ enum Commands {
     /// Launch MCP server on stdio
     Mcp,
     /// Launch interactive TUI dashboard
-    Tui,
+    Tui {
+        /// Override the active theme for this session (#137).
+        /// Accepts: `auto` | `dark` | `light` | `dalton-dark` | `dalton-bright`.
+        /// Precedence: this flag > `SCITADEL_THEME` env > config > auto.
+        #[arg(long)]
+        theme: Option<String>,
+    },
     /// Run citation chaining (snowballing)
     Snowball {
         /// Search ID
@@ -238,7 +244,7 @@ async fn main() -> Result<()> {
         },
         Commands::Download { doi, output_dir } => commands::download(&doi, output_dir).await,
         Commands::Mcp => commands::mcp().await,
-        Commands::Tui => commands::tui(),
+        Commands::Tui { theme } => commands::tui(theme.as_deref()),
         Commands::Assess {
             search_id,
             question,

--- a/crates/scitadel-core/src/config.rs
+++ b/crates/scitadel-core/src/config.rs
@@ -106,12 +106,24 @@ pub struct UiConfig {
     /// grant access. Disable for headless / CI runs.
     #[serde(default = "default_true")]
     pub show_institutional_hint: bool,
+    /// Active TUI theme (#137). Accepts: `auto`, `dark`, `light`,
+    /// `dalton-dark`, `dalton-bright`. `auto` = read terminal
+    /// background via COLORFGBG → OSC 11 → fall back to dark.
+    /// Resolution order: CLI flag > `SCITADEL_THEME` env > this
+    /// config key > `auto`.
+    #[serde(default = "default_theme")]
+    pub theme: String,
+}
+
+fn default_theme() -> String {
+    "auto".into()
 }
 
 impl Default for UiConfig {
     fn default() -> Self {
         Self {
             show_institutional_hint: true,
+            theme: default_theme(),
         }
     }
 }

--- a/crates/scitadel-tui/src/lib.rs
+++ b/crates/scitadel-tui/src/lib.rs
@@ -1,7 +1,7 @@
 mod app;
 mod data;
 mod tasks;
-mod theme;
+pub mod theme;
 mod views;
 mod widgets;
 

--- a/crates/scitadel-tui/src/theme.rs
+++ b/crates/scitadel-tui/src/theme.rs
@@ -1,12 +1,27 @@
-//! Semantic color theming for the TUI (#136).
+//! Semantic color theming for the TUI (#136 / #137).
 //!
 //! Every TUI view pulls colors through named roles on [`Theme`] rather
 //! than hardcoding palette (`Color::Yellow`) or RGB values. That lets
-//! the theme be swapped wholesale — currently Dalton Dark by default;
-//! light mode + auto-detection ships in #137.
+//! the theme be swapped wholesale at startup based on user preference.
 //!
-//! Dalton Dark is a colorblind-friendly scheme tuned for deuteranopia
-//! and protanopia. Source: <https://github.com/gerchowl/dalton-colorscheme>.
+//! Dalton Dark / Dalton Bright are colorblind-friendly schemes tuned
+//! for deuteranopia and protanopia. Source:
+//! <https://github.com/gerchowl/dalton-colorscheme>.
+//!
+//! ## Runtime resolution (#137)
+//!
+//! Theme is picked once at startup via [`init`] — call it before the
+//! first frame is drawn. Order, highest precedence first:
+//! 1. `--theme <name>` CLI flag (handled in caller)
+//! 2. `SCITADEL_THEME` env var
+//! 3. `[ui] theme = "..."` in `config.toml`
+//! 4. Default: `auto` (probe terminal background via `COLORFGBG`,
+//!    fall back to dark)
+//!
+//! Mid-session theme change is intentionally not supported — if the
+//! terminal flips light/dark at sunset, restart the TUI.
+
+use std::sync::OnceLock;
 
 use ratatui::style::Color;
 
@@ -64,6 +79,34 @@ impl Theme {
         ],
     };
 
+    /// Light companion to Dalton Dark. Source CSS variables ported
+    /// from `dalton-bright.css` upstream. Background is the warm cream
+    /// (`#f4f1eb`); foreground roles use the darker chromatic
+    /// variants so they read against light without losing the
+    /// colorblind-distinguishability the palette is designed for.
+    /// Highlight slots are pale tints of the same hues — light enough
+    /// to sit behind dark text without inverting contrast.
+    pub const DALTON_BRIGHT: Theme = Theme {
+        emphasis: Color::Rgb(0x7a, 0x6d, 0x00), // dalton bright yellow (darker for light bg)
+        muted: Color::Rgb(0x70, 0x70, 0x7a),    // bright black (secondary text)
+        selection_bg: Color::Rgb(0xd0, 0xcd, 0xc5), // dalton bright selection
+        quote: Color::Rgb(0x2a, 0x68, 0x80),    // bright cyan (dark variant)
+        info: Color::Rgb(0x30, 0x60, 0xc8),     // dalton bright blue
+        success: Color::Rgb(0x3a, 0x75, 0x30),  // dalton bright green
+        warning: Color::Rgb(0x8a, 0x7d, 0x00),  // bright yellow (slightly stronger)
+        danger: Color::Rgb(0xb8, 0x30, 0x30),   // dalton bright red
+        highlights: [
+            Color::Rgb(0xf4, 0xd8, 0xd8), // pale red
+            Color::Rgb(0xd9, 0xed, 0xd5), // pale green
+            Color::Rgb(0xf2, 0xee, 0xc4), // pale yellow
+            Color::Rgb(0xd6, 0xe0, 0xf4), // pale blue
+            Color::Rgb(0xe7, 0xd6, 0xee), // pale magenta
+            Color::Rgb(0xd6, 0xe6, 0xec), // pale cyan
+            Color::Rgb(0xdc, 0xe6, 0xf4), // pale bright-blue
+            Color::Rgb(0xe2, 0xd2, 0xee), // pale bright-magenta
+        ],
+    };
+
     /// Pick a highlight colour for a string key (e.g. annotation
     /// root_id). djb2 hash modulo palette size so the mapping is
     /// stable across runs.
@@ -77,16 +120,113 @@ impl Theme {
     }
 }
 
-/// Process-wide active theme. Currently a const alias for Dalton Dark;
-/// #137 replaces this with a runtime-resolved value (config, flag,
-/// env, auto-detect).
-pub const ACTIVE: &Theme = &Theme::DALTON_DARK;
+/// Process-wide active theme. Set once at startup via [`init`]; reads
+/// after that go through [`theme()`]. `OnceLock` makes it cheap (no
+/// lock contention on the hot draw path) and lets tests use the
+/// default without setup.
+static ACTIVE: OnceLock<Theme> = OnceLock::new();
 
 /// Convenience accessor. `crate::theme::theme().emphasis` reads better
-/// at call sites than `crate::theme::ACTIVE.emphasis`.
+/// at call sites than reaching into `ACTIVE` directly. Falls back to
+/// Dalton Dark if [`init`] was never called (e.g. unit tests rendering
+/// a widget in isolation).
 #[must_use]
 pub fn theme() -> &'static Theme {
-    ACTIVE
+    ACTIVE.get().unwrap_or(&Theme::DALTON_DARK)
+}
+
+/// Set the process-wide theme. Must be called before the first frame
+/// is drawn; subsequent calls are no-ops (`OnceLock::set` returns Err).
+/// Pair with [`resolve`] to compute the right value from the layered
+/// preference sources.
+pub fn init(t: Theme) {
+    let _ = ACTIVE.set(t);
+}
+
+/// User's stated preference, in increasing precedence: config →
+/// `SCITADEL_THEME` env → `--theme` CLI flag. The caller threads the
+/// flag value here; we read the env var directly. `auto` (or any
+/// unrecognised string) defers to terminal probing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ThemeChoice {
+    /// `auto` — probe terminal background, fall back to dark.
+    Auto,
+    /// Forced dark — Dalton Dark today.
+    Dark,
+    /// Forced light — Dalton Bright today.
+    Light,
+}
+
+impl ThemeChoice {
+    /// Parse a layered preference string into a choice. Accepts
+    /// `auto`, `dark`, `light`, and the named variants
+    /// `dalton-dark` / `dalton-bright`. Anything else (including
+    /// empty string) folds to `Auto` so a typo can't take a session
+    /// down — it just falls through to detection.
+    #[must_use]
+    pub fn parse(name: &str) -> Self {
+        match name.trim().to_ascii_lowercase().as_str() {
+            "dark" | "dalton-dark" => Self::Dark,
+            "light" | "bright" | "dalton-bright" | "dalton-light" => Self::Light,
+            _ => Self::Auto,
+        }
+    }
+}
+
+/// Resolve the layered user preference + auto-detection into a concrete
+/// [`Theme`]. `cli` and `config_value` are the strings exactly as the
+/// user wrote them (or empty if unset). The env var
+/// `SCITADEL_THEME` sits between them in precedence.
+#[must_use]
+pub fn resolve(cli: Option<&str>, config_value: &str) -> Theme {
+    let raw = cli
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .or_else(|| std::env::var("SCITADEL_THEME").ok())
+        .unwrap_or_else(|| config_value.to_string());
+    match ThemeChoice::parse(&raw) {
+        ThemeChoice::Dark => Theme::DALTON_DARK,
+        ThemeChoice::Light => Theme::DALTON_BRIGHT,
+        ThemeChoice::Auto => match detect_terminal_background() {
+            Some(TerminalBackground::Light) => Theme::DALTON_BRIGHT,
+            // Dark or unknown → dark. Dark is the safer default
+            // because most dev terminals are dark and Dalton Dark
+            // was the previous behaviour.
+            _ => Theme::DALTON_DARK,
+        },
+    }
+}
+
+/// Whether the terminal background is light or dark. Returned as
+/// `Option` from [`detect_terminal_background`] so callers can
+/// distinguish "probed and got light" from "couldn't tell".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TerminalBackground {
+    Dark,
+    Light,
+}
+
+/// Probe the terminal for its background luminance. Tries
+/// `COLORFGBG` (set by most mature terminals; format
+/// `"<fg>;<bg>"` where each is an ANSI 0–15 colour index) and
+/// returns `None` if the variable is missing or unparseable. OSC 11
+/// query is intentionally not implemented in this iter — it requires
+/// raw-mode tty access and a 100–200ms timeout dance, and the
+/// `--theme` override gives users a clean escape hatch when
+/// `COLORFGBG` is wrong or unset.
+#[must_use]
+pub fn detect_terminal_background() -> Option<TerminalBackground> {
+    let raw = std::env::var("COLORFGBG").ok()?;
+    let bg = raw.split(';').nth(1)?.trim();
+    let idx: u8 = bg.parse().ok()?;
+    // ANSI base palette: 0–7 are dark variants, 8–15 are bright.
+    // Bg index 0–6 = dark background; 7 (white) and 8+ = light.
+    // The classic check: bg 15 = white = light, bg 0 = black = dark.
+    if idx >= 7 {
+        Some(TerminalBackground::Light)
+    } else {
+        Some(TerminalBackground::Dark)
+    }
 }
 
 #[cfg(test)]
@@ -100,6 +240,68 @@ mod tests {
         let a1 = t.highlight_for("ann-root-1");
         let a2 = t.highlight_for("ann-root-1");
         assert_eq!(a1, a2);
+    }
+
+    #[test]
+    fn theme_choice_parses_aliases() {
+        assert_eq!(ThemeChoice::parse("dark"), ThemeChoice::Dark);
+        assert_eq!(ThemeChoice::parse("DARK"), ThemeChoice::Dark);
+        assert_eq!(ThemeChoice::parse("dalton-dark"), ThemeChoice::Dark);
+        assert_eq!(ThemeChoice::parse("light"), ThemeChoice::Light);
+        assert_eq!(ThemeChoice::parse("bright"), ThemeChoice::Light);
+        assert_eq!(ThemeChoice::parse("dalton-bright"), ThemeChoice::Light);
+        assert_eq!(ThemeChoice::parse("dalton-light"), ThemeChoice::Light);
+        assert_eq!(ThemeChoice::parse("auto"), ThemeChoice::Auto);
+        // Typos fall back to Auto rather than panicking the session.
+        assert_eq!(ThemeChoice::parse("darj"), ThemeChoice::Auto);
+        assert_eq!(ThemeChoice::parse(""), ThemeChoice::Auto);
+    }
+
+    #[test]
+    fn cli_flag_overrides_env_and_config() {
+        // SAFETY: serial test — env var mutation is process-global but
+        // these tests run single-threaded by default in `cargo test`.
+        // We don't restore because every assertion explicitly sets
+        // what it needs.
+        unsafe {
+            std::env::set_var("SCITADEL_THEME", "light");
+        }
+        // CLI dark beats env light beats config bright.
+        let t = resolve(Some("dark"), "dalton-bright");
+        assert_eq!(t.emphasis, Theme::DALTON_DARK.emphasis);
+        // No CLI → env wins over config.
+        let t = resolve(None, "dalton-dark");
+        assert_eq!(t.emphasis, Theme::DALTON_BRIGHT.emphasis);
+        // Empty CLI is treated as unset.
+        let t = resolve(Some(""), "dalton-dark");
+        assert_eq!(t.emphasis, Theme::DALTON_BRIGHT.emphasis);
+        unsafe {
+            std::env::remove_var("SCITADEL_THEME");
+        }
+        // No CLI, no env → config wins.
+        let t = resolve(None, "dalton-dark");
+        assert_eq!(t.emphasis, Theme::DALTON_DARK.emphasis);
+    }
+
+    #[test]
+    fn auto_with_colorfgbg_picks_correct_theme() {
+        unsafe {
+            std::env::remove_var("SCITADEL_THEME");
+            std::env::set_var("COLORFGBG", "0;15"); // dark fg, white bg → light
+        }
+        let t = resolve(None, "auto");
+        assert_eq!(t.emphasis, Theme::DALTON_BRIGHT.emphasis);
+        unsafe {
+            std::env::set_var("COLORFGBG", "15;0"); // white fg, black bg → dark
+        }
+        let t = resolve(None, "auto");
+        assert_eq!(t.emphasis, Theme::DALTON_DARK.emphasis);
+        unsafe {
+            std::env::remove_var("COLORFGBG");
+        }
+        // No probe signal → dark fallback.
+        let t = resolve(None, "auto");
+        assert_eq!(t.emphasis, Theme::DALTON_DARK.emphasis);
     }
 
     #[test]

--- a/tests/vhs/theme-light.tape
+++ b/tests/vhs/theme-light.tape
@@ -1,0 +1,50 @@
+# VHS tape: --theme light renders Dalton Bright (#137).
+#
+# Forces the CLI flag (highest precedence) so the run is deterministic
+# regardless of the CI runner's COLORFGBG. Snapshots before/after the
+# Tab key show the light palette across both Searches and Papers tabs.
+
+Output "tests/vhs/snapshots/theme-light/run.gif"
+
+Set Shell "bash"
+Set FontSize 14
+Set Width 1400
+Set Height 800
+Set Padding 10
+Set TypingSpeed 40ms
+
+Hide
+Type `export PATH="$PWD/target/release:$HOME/.cargo/bin:$PATH"`
+Enter
+Type `export PS1="$ "`
+Enter
+Type `export SCITADEL_DB=$(mktemp -d)/scitadel.db`
+Enter
+Type "scitadel init --yes --email demo@example.org --sources arxiv --db $SCITADEL_DB"
+Enter
+Sleep 1s
+
+# Seed two papers so the table has visible rows in both tabs.
+Type `sqlite3 $SCITADEL_DB "INSERT INTO papers (id, title, authors, year, created_at, updated_at) VALUES ('p-1', 'Attention Is All You Need', '[\"Vaswani, A.\"]', 2017, datetime('now'), datetime('now'));"`
+Enter
+Sleep 200ms
+Type `sqlite3 $SCITADEL_DB "INSERT INTO papers (id, title, authors, year, created_at, updated_at) VALUES ('p-2', 'Deep Residual Learning', '[\"He, K.\"]', 2015, datetime('now'), datetime('now'));"`
+Enter
+Sleep 200ms
+
+Type "clear"
+Enter
+Show
+
+# CLI flag overrides anything in env / config.
+Type "scitadel tui --theme light"
+Enter
+Sleep 2500ms
+Screenshot "tests/vhs/snapshots/theme-light/01-searches-light.png"
+
+Tab
+Sleep 800ms
+Screenshot "tests/vhs/snapshots/theme-light/02-papers-light.png"
+
+Type "q"
+Sleep 300ms


### PR DESCRIPTION
## Summary
- **`Theme::DALTON_BRIGHT`** — light companion palette, ported from upstream `dalton-bright.css`. Muted light tints for highlights so they sit behind dark text without inverting contrast.
- **Runtime theme resolution** via new `theme::resolve()`. Precedence: `--theme <name>` flag > `SCITADEL_THEME` env > `[ui] theme` config > `auto`
- **`auto` detection** via `COLORFGBG` probe. OSC 11 intentionally deferred (raw-tty + timeout dance); `--theme` is the documented escape hatch
- **Theme is locked at startup** — if the terminal flips mid-session, restart the TUI
- VHS tape `theme-light.tape` — `--theme light` renders Dalton Bright across Searches + Papers tabs

Closes #137.

## Why this scope (iter 2, not full)
The issue listed OSC 11 fallback as P0. It requires raw-tty access + 100-200ms timeout to avoid blocking startup on non-responsive terminals. That's worth a dedicated iter; for now, `COLORFGBG` covers most mature terminals and `--theme` covers the rest.

## Test plan
- [x] `cargo test theme::` — 5 pass including precedence + detection
- [x] `cargo test --workspace` — all green
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [ ] Manual: `scitadel tui` on light iTerm2 → auto-picks Dalton Bright
- [ ] Manual: `scitadel tui --theme dark` on light terminal → forces dark
- [ ] VHS tape produces 2 distinct snapshots

## Follow-ups
- OSC 11 tertiary detection (theme iter 3)
- `--list-themes` flag + `scitadel init` theme prompt
- Per-theme VHS render matrix