### PR TITLE
chore(tooling): cargo fmt pre-commit hook + just lint recipe (#156)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,6 +69,19 @@ repos:
         files: ^justfile(\..*)?$
         pass_filenames: false
 
+  # Rust formatting (fast — under 1s on a warm cache). Clippy is
+  # NOT a pre-commit hook because it's too slow for every commit;
+  # run `just lint` before push or `just verify` before opening a
+  # PR. See #156.
+  - repo: local
+    hooks:
+      - id: cargo-fmt
+        name: cargo fmt --check
+        entry: cargo fmt --all -- --check
+        language: system
+        files: \.rs$
+        pass_filenames: false
+
   # Typo Linting
   - repo: https://github.com/crate-ci/typos
     rev: 07d900b8fa1097806b8adb6391b0d3e0ac2fdea7  # v1.39.0

--- a/justfile.project
+++ b/justfile.project
@@ -22,12 +22,19 @@ info:
 # RUST
 # ===============================================================================
 
-# Format check + clippy + tests
+# Quick pre-push lint: format check + clippy on lib + tests. No
+# test execution — that's `just verify`. ~30s on a warm cache.
+# `--tests` is the bit that catches per-test clippy lints and
+# matches CI's Lint job exactly.
 [group('quality')]
-verify:
-    cargo fmt --check
-    cargo clippy --workspace -- -D warnings
-    cargo test --workspace
+lint:
+    cargo fmt --all -- --check
+    cargo clippy --workspace --tests -- -D warnings
+
+# Full pre-PR check: lint + tests. Mirrors what CI runs.
+[group('quality')]
+verify: lint
+    cargo test --workspace --exclude scitadel-tui
 
 # Dependency / license audit (requires cargo-deny)
 [group('quality')]


### PR DESCRIPTION
Closes #156.

## What

1. **Pre-commit:** `cargo fmt --check` now runs on every commit touching `*.rs`. Fast (<1s warm). Catches the exact gap that bit #134 PR-A.
2. **Just recipes:**
   - `just lint` (new): fmt --check + clippy --workspace **--tests** -- -D warnings. Mirrors CI's Lint job exactly. The existing `verify` was missing `--tests`, which let test-only clippy lints slip through.
   - `just verify` now depends on `lint` and adds workspace tests (excluding scitadel-tui). Pre-PR gate.

## What's NOT included (and why)

- **Clippy as a pre-commit hook**: too slow on every commit (~30s on warm cache for the full workspace, longer cold). Pushed to `just lint` so it's still a one-command check before push.
- **Pre-push hook**: would force-run `just verify` before every push. Considered, deferred — `just verify` is on the developer to remember; CI is the safety net. If the gap recurs, escalate.

## Test plan

- [x] `prek run cargo-fmt --all-files` → Passed
- [x] `cargo fmt --all -- --check` → exit 0 (no diff)
- [ ] Reviewer: edit a Rust file with `let  x = 1;` (extra space), `git commit` → hook rejects
- [ ] Reviewer: in nix devshell, `just lint` → green (~30s warm)