### PR TITLE
feat(bib): ambiguous alias is a per-row failure, not a silent create (#160)

### DIFF
--- a/crates/scitadel-mcp/src/bib_import.rs
+++ b/crates/scitadel-mcp/src/bib_import.rs
@@ -192,20 +192,36 @@ fn import_one(
     let outcome = match_entry(entry, lookup)?;
     let matched_id = match outcome {
         MatchOutcome::Matched(id, _) => Some(id),
-        MatchOutcome::AmbiguousAlias(ids) => {
-            // Surface as a warning; treat as no-match (create new
-            // paper) rather than silently picking. The caller can
-            // later add a `--strategy interactive` mode (P1) to
-            // prompt; today we err on the side of "new paper" so
-            // user data isn't silently merged into the wrong row.
-            tracing::warn!(
-                citekey = %entry.citekey,
-                candidates = ?ids,
-                "ambiguous alias — creating new paper instead of guessing"
-            );
-            None
-        }
         MatchOutcome::NoMatch => None,
+        MatchOutcome::AmbiguousAlias(ids) => {
+            // Both alias AND title+year ambiguous (the matcher
+            // already tried title+year before falling back to this
+            // arm). Refuse to act: silently creating a new paper
+            // here causes the SAME citekey to fork into yet another
+            // alias row, ratcheting the collision on every re-import.
+            // Equally, picking one of the candidates risks merging
+            // the user's bib metadata into the wrong row.
+            //
+            // Bubble up as a Validation error; the lenient-mode
+            // handler in `import_bibtex_str` records it in
+            // `report.failed` so the user sees exactly which entries
+            // need manual resolution (typically: `bib rekey` one
+            // of the candidates so its alias no longer collides).
+            // See #160. Interactive resolution lands with #161.
+            let preview: Vec<String> = ids.iter().take(3).cloned().collect();
+            let suffix = if ids.len() > preview.len() {
+                format!(" (+{} more)", ids.len() - preview.len())
+            } else {
+                String::new()
+            };
+            return Err(CoreError::Validation(format!(
+                "ambiguous alias '{}' matches {} papers [{}]{}; resolve via `scitadel bib rekey` on one of them, or use --strategy interactive once it lands (#161)",
+                entry.citekey,
+                ids.len(),
+                preview.join(", "),
+                suffix,
+            )));
+        }
     };
 
     // 2. Resolve via the strategy.
@@ -544,6 +560,64 @@ mod tests {
             .collect();
         let bib_b = export_bibtex(&saved2);
         assert_eq!(bib_a, bib_b, "round-trip export must be byte-identical");
+    }
+
+    /// Regression test for #160: ambiguous alias must not silently
+    /// create a new paper. Earlier behavior forked the citekey into
+    /// a third alias row, ratcheting the collision on every re-import.
+    /// New behavior: per-row Validation failure, surfaced in
+    /// `report.failed` with all candidate paper IDs.
+    #[test]
+    fn ambiguous_alias_is_a_per_row_failure_not_a_silent_create() {
+        let (papers, aliases, annotations) = fresh();
+
+        // Two papers that legitimately share a citekey "smith2024"
+        // (e.g. two distinct .bib files were both imported earlier
+        // with the same Zotero-assigned key).
+        let mut p1 = Paper::new("First Paper");
+        p1.year = Some(2024);
+        let mut p2 = Paper::new("Second Paper");
+        p2.year = Some(2024);
+        papers.save(&p1).unwrap();
+        papers.save(&p2).unwrap();
+        aliases
+            .record(p1.id.as_str(), "smith2024", "bibtex-import")
+            .unwrap();
+        aliases
+            .record(p2.id.as_str(), "smith2024", "bibtex-import")
+            .unwrap();
+
+        let papers_before = papers.list_all(100, 0).unwrap().len();
+        let aliases_before = aliases.lookup_all("smith2024").unwrap().len();
+
+        // A bib with the colliding citekey + a title that doesn't
+        // match either seeded paper — forces the matcher's title+year
+        // step to fail, so the cascade ends in AmbiguousAlias.
+        let src = r"
+@article{smith2024,
+    title = {Some Other Title Entirely},
+    year = {1999}
+}";
+        let report =
+            import_bibtex_str(src, &opts_merge("lars"), &papers, &aliases, &annotations).unwrap();
+
+        assert!(
+            report.rows.is_empty(),
+            "no row should land on success path; got {:?}",
+            report.rows
+        );
+        assert_eq!(report.failed.len(), 1);
+        let (citekey, msg) = &report.failed[0];
+        assert_eq!(citekey, "smith2024");
+        assert!(msg.contains("ambiguous alias"), "got: {msg}");
+        assert!(msg.contains("matches 2 papers"), "got: {msg}");
+
+        // The canary: papers + aliases counts unchanged.
+        assert_eq!(papers.list_all(100, 0).unwrap().len(), papers_before);
+        assert_eq!(
+            aliases.lookup_all("smith2024").unwrap().len(),
+            aliases_before
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #160.

## What changes

When `import_one` gets a `MatchOutcome::AmbiguousAlias` (alias resolves to >1 paper AND title+year can't disambiguate), the orchestrator now bubbles it up as a `CoreError::Validation` with all candidate paper IDs in the message. The existing lenient-mode catch in `import_bibtex_str` records this in `report.failed` without aborting the run.

## Why

Pre-fix behavior silently created a new paper with the colliding citekey. The new paper got an alias row under the same citekey → next import had even more papers sharing the alias → ratchet, forever.

The user-facing impact: every Zotero re-import quietly bloated the `paper_aliases` table; the user had no clear signal anything was wrong until they ran `verify` or the alias lookup table grew unmanageable.

## What it looks like now

```
$ scitadel bib import library.bib --reader $USER
  unchanged abcd1234  vaswani2017attention
  failed    —         smith2024 — ambiguous alias 'smith2024' matches 2 papers [a1b2c3d4, e5f6g7h8]; resolve via `scitadel bib rekey` on one of them, or use --strategy interactive once it lands (#161)
  ...
imported 19 entries: 0 created, 0 updated, 19 unchanged, 0 rejected, 1 failed
```

## Tests

New orchestrator-level regression test:
1. Seeds two papers, both aliased under `smith2024`
2. Imports a bib with `@article{smith2024, title = {Different}, year = {1999}}`
3. Asserts `report.rows` is empty, `report.failed` contains the citekey + 2-paper message
4. **Canary**: papers + paper_aliases counts unchanged across the import — the bug it's regression-testing was specifically that these counts grew

8 bib_import tests pass; clippy + fmt clean.

## Test plan

- [x] `cargo test -p scitadel-mcp --lib bib_import` — 8 pass
- [x] `cargo clippy --workspace --exclude scitadel-tui --tests -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] Reviewer: confirm error message text is helpful enough — names every candidate, points at `bib rekey`