### PR TITLE
feat(bib): --strategy interactive + PromptResolver hook

### DIFF
--- a/crates/scitadel-cli/src/commands.rs
+++ b/crates/scitadel-cli/src/commands.rs
@@ -747,7 +747,9 @@ pub fn bib_import(
     use scitadel_mcp::bib_import::{ImportOptions, import_bibtex_file};
 
     let strategy = MergeStrategy::parse(strategy).ok_or_else(|| {
-        anyhow::anyhow!("unknown --strategy: {strategy}; valid: reject, db-wins, bib-wins, merge")
+        anyhow::anyhow!(
+            "unknown --strategy: {strategy}; valid: reject, db-wins, bib-wins, merge, interactive"
+        )
     })?;
     let reader =
         reader.unwrap_or_else(|| std::env::var("USER").unwrap_or_else(|_| "import".into()));
@@ -761,6 +763,12 @@ pub fn bib_import(
         strategy,
         reader,
         lenient: true,
+        // CLI does not yet wire stdin prompts; #161's TUI/CLI
+        // prompt-surface is out of scope. Without a resolver,
+        // `--strategy interactive` degrades to the same per-row
+        // failure path as `--strategy merge` for ambiguous-alias
+        // rows. The trait is now in place for follow-ups.
+        prompt_resolver: None,
     };
     let report = import_bibtex_file(path, &options, &papers, &aliases, &annotations)
         .with_context(|| format!("import {}", path.display()))?;

--- a/crates/scitadel-cli/src/main.rs
+++ b/crates/scitadel-cli/src/main.rs
@@ -159,7 +159,7 @@ enum BibCommands {
     Import {
         /// Path to the .bib file (Zotero / Mendeley export)
         path: PathBuf,
-        /// Merge strategy: reject | db-wins | bib-wins | merge
+        /// Merge strategy: reject | db-wins | bib-wins | merge | interactive
         #[arg(long, default_value = "merge")]
         strategy: String,
         /// Identity attached to imported annotations (`note=` field).

--- a/crates/scitadel-export/src/import/merge.rs
+++ b/crates/scitadel-export/src/import/merge.rs
@@ -16,8 +16,11 @@
 //!   `keywords=`, `file=`) are left to step-4 side-effect plumbing.
 //!   The Paper row itself stays unchanged under Merge — the value
 //!   the strategy adds is in the side effects, not the columns.
-//!
-//! Note: `interactive` mode is P1 polish per the issue — not in iter 2.
+//! - [`MergeStrategy::Interactive`] — same row-level semantics as
+//!   `Merge` (DB wins on owned fields). The strategy is a flag that
+//!   enables prompt-driven resolution at orchestrator-level steps the
+//!   pure resolver doesn't see (e.g. ambiguous-alias disambiguation
+//!   in `scitadel-mcp::bib_import`). See #161.
 
 use scitadel_core::models::Paper;
 
@@ -29,6 +32,10 @@ pub enum MergeStrategy {
     DbWins,
     BibWins,
     Merge,
+    /// Same row-level semantics as `Merge`, but signals to the
+    /// orchestrator that a `PromptResolver` may be consulted on
+    /// ambiguous decisions (e.g. ambiguous-alias). See #161.
+    Interactive,
 }
 
 impl MergeStrategy {
@@ -41,6 +48,7 @@ impl MergeStrategy {
             "db-wins" => Some(Self::DbWins),
             "bib-wins" => Some(Self::BibWins),
             "merge" => Some(Self::Merge),
+            "interactive" => Some(Self::Interactive),
             _ => None,
         }
     }
@@ -51,6 +59,7 @@ impl MergeStrategy {
             Self::DbWins => "db-wins",
             Self::BibWins => "bib-wins",
             Self::Merge => "merge",
+            Self::Interactive => "interactive",
         }
     }
 }
@@ -99,11 +108,13 @@ pub fn resolve(db_paper: Option<Paper>, bib: &BibEntry, strategy: MergeStrategy)
             from_bib: vec![],
             kept_from_db: vec![],
         },
-        // DbWins and Merge leave the Paper row identical — Merge
-        // adds value via side effects (annotations from `note=`,
-        // tags from `keywords=`) wired in step 4, not by mutating
-        // owned columns. Collapsed to one arm to keep clippy happy.
-        MergeStrategy::DbWins | MergeStrategy::Merge => MergeOutcome {
+        // DbWins, Merge, and Interactive leave the Paper row identical
+        // — Merge adds value via side effects (annotations from
+        // `note=`, tags from `keywords=`) wired in step 4, not by
+        // mutating owned columns. Interactive is just Merge with a
+        // prompt hook the orchestrator may consult upstream. Collapsed
+        // to one arm to keep clippy happy.
+        MergeStrategy::DbWins | MergeStrategy::Merge | MergeStrategy::Interactive => MergeOutcome {
             paper: Some(db),
             action: MergeAction::Unchanged,
             from_bib: vec![],
@@ -297,7 +308,7 @@ mod tests {
 
     #[test]
     fn parse_strategy_round_trip() {
-        for s in ["reject", "db-wins", "bib-wins", "merge"] {
+        for s in ["reject", "db-wins", "bib-wins", "merge", "interactive"] {
             let parsed = MergeStrategy::parse(s).unwrap();
             assert_eq!(parsed.as_str(), s);
         }

--- a/crates/scitadel-mcp/src/bib_import.rs
+++ b/crates/scitadel-mcp/src/bib_import.rs
@@ -27,6 +27,7 @@
 //! entries.
 
 use std::path::Path;
+use std::sync::Arc;
 
 use scitadel_core::bibtex_key::assign_keys;
 use scitadel_core::error::CoreError;
@@ -104,8 +105,34 @@ impl PaperLookup for SqliteBibLookup<'_> {
     }
 }
 
+/// Hook for orchestrator-level prompts during a bib import (#161).
+///
+/// The pure resolver in `scitadel-export` cannot prompt — it has no
+/// stdio, no UI, no async story. Instead, the import orchestrator
+/// calls a `PromptResolver` impl when it hits a decision the strategy
+/// alone can't settle (today: `MatchOutcome::AmbiguousAlias` under
+/// `MergeStrategy::Interactive`).
+///
+/// Returning `None` means "user declined / skip this row"; the
+/// orchestrator then falls back to the default failure path
+/// (`CoreError::Validation`, recorded in `report.failed`). This keeps
+/// the default-strategy regression in `ambiguous_alias_is_a_per_row_failure_not_a_silent_create`
+/// passing: a `None`-returning resolver and a non-Interactive
+/// strategy are observationally identical from the row's perspective.
+///
+/// TUI integration (paper-detail prompt overlay shape) is a follow-up;
+/// see the annotation-prompt plumbing in
+/// `crates/scitadel-tui/src/views/annotation_prompt.rs`.
+pub trait PromptResolver: Send + Sync {
+    /// Choose one paper id from the candidate set when an alias
+    /// resolves to multiple papers and title+year can't disambiguate.
+    /// Implementations may render the candidates however they like
+    /// (CLI numbered list, TUI overlay, MCP elicitation).
+    fn resolve_ambiguous_alias(&self, citekey: &str, candidate_ids: &[String]) -> Option<String>;
+}
+
 /// Configuration for one import run.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct ImportOptions {
     pub strategy: MergeStrategy,
     /// Identity attached to created annotations (`Annotation.author`).
@@ -113,6 +140,28 @@ pub struct ImportOptions {
     /// Continue past per-row errors (logging them) rather than aborting.
     /// True is the default — see issue #134 P1 `--lenient` flag.
     pub lenient: bool,
+    /// Optional prompt hook consulted when `strategy` is
+    /// `Interactive`. `None` (the default) preserves the legacy
+    /// failure path: ambiguous-alias rows surface as `report.failed`
+    /// entries, which is the contract the #160 regression test pins.
+    pub prompt_resolver: Option<Arc<dyn PromptResolver>>,
+}
+
+impl std::fmt::Debug for ImportOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ImportOptions")
+            .field("strategy", &self.strategy)
+            .field("reader", &self.reader)
+            .field("lenient", &self.lenient)
+            .field(
+                "prompt_resolver",
+                &self
+                    .prompt_resolver
+                    .as_ref()
+                    .map(|_| "<dyn PromptResolver>"),
+            )
+            .finish()
+    }
 }
 
 impl Default for ImportOptions {
@@ -121,6 +170,7 @@ impl Default for ImportOptions {
             strategy: MergeStrategy::Merge,
             reader: "import".to_string(),
             lenient: true,
+            prompt_resolver: None,
         }
     }
 }
@@ -215,25 +265,42 @@ fn import_one(
             // Equally, picking one of the candidates risks merging
             // the user's bib metadata into the wrong row.
             //
-            // Bubble up as a Validation error; the lenient-mode
-            // handler in `import_bibtex_str` records it in
-            // `report.failed` so the user sees exactly which entries
-            // need manual resolution (typically: `bib rekey` one
-            // of the candidates so its alias no longer collides).
-            // See #160. Interactive resolution lands with #161.
-            let preview: Vec<String> = ids.iter().take(3).cloned().collect();
-            let suffix = if ids.len() > preview.len() {
-                format!(" (+{} more)", ids.len() - preview.len())
+            // #161: under `--strategy interactive` AND a configured
+            // `PromptResolver`, ask the resolver which candidate the
+            // user wants. A `Some(id)` answer threads the row back
+            // onto the Matched path (the alias gets re-recorded as a
+            // side effect, but the user has explicitly endorsed the
+            // collision target). `None` (or no resolver, or a
+            // non-interactive strategy) preserves the #160 contract:
+            // bubble up as `Validation`, lenient-mode records it in
+            // `report.failed`, the default-strategy regression test
+            // keeps passing.
+            let resolver_pick = if matches!(options.strategy, MergeStrategy::Interactive) {
+                options
+                    .prompt_resolver
+                    .as_ref()
+                    .and_then(|r| r.resolve_ambiguous_alias(&entry.citekey, &ids))
             } else {
-                String::new()
+                None
             };
-            return Err(CoreError::Validation(format!(
-                "ambiguous alias '{}' matches {} papers [{}]{}; resolve via `scitadel bib rekey` on one of them, or use --strategy interactive once it lands (#161)",
-                entry.citekey,
-                ids.len(),
-                preview.join(", "),
-                suffix,
-            )));
+            match resolver_pick {
+                Some(picked) if ids.iter().any(|c| c == &picked) => Some(picked),
+                _ => {
+                    let preview: Vec<String> = ids.iter().take(3).cloned().collect();
+                    let suffix = if ids.len() > preview.len() {
+                        format!(" (+{} more)", ids.len() - preview.len())
+                    } else {
+                        String::new()
+                    };
+                    return Err(CoreError::Validation(format!(
+                        "ambiguous alias '{}' matches {} papers [{}]{}; resolve via `scitadel bib rekey` on one of them, or run with --strategy interactive and a prompt resolver (#161)",
+                        entry.citekey,
+                        ids.len(),
+                        preview.join(", "),
+                        suffix,
+                    )));
+                }
+            }
         }
     };
 
@@ -336,6 +403,7 @@ mod tests {
             strategy: MergeStrategy::Merge,
             reader: reader.into(),
             lenient: true,
+            prompt_resolver: None,
         }
     }
 
@@ -700,6 +768,111 @@ mod tests {
         );
         // And no alias was recorded either.
         assert!(aliases.lookup("ghostkey").unwrap().is_none());
+    }
+
+    /// #161: under `MergeStrategy::Interactive` with a `PromptResolver`
+    /// that returns one of the candidate ids, the row threads through
+    /// the Matched path. The picked paper's row stays unchanged
+    /// (Interactive == Merge semantics on owned columns), but the
+    /// citekey gets recorded as an alias on the chosen paper so the
+    /// next import resolves cleanly.
+    #[test]
+    fn interactive_strategy_with_resolver_picks_a_candidate() {
+        struct FixedPick {
+            picked: String,
+        }
+        impl PromptResolver for FixedPick {
+            fn resolve_ambiguous_alias(
+                &self,
+                _citekey: &str,
+                candidate_ids: &[String],
+            ) -> Option<String> {
+                // Sanity: resolver only ever sees the candidate set
+                // the matcher actually surfaced.
+                assert!(candidate_ids.contains(&self.picked));
+                Some(self.picked.clone())
+            }
+        }
+
+        let (papers, aliases, annotations) = fresh();
+        let mut p1 = Paper::new("First Paper");
+        p1.year = Some(2024);
+        let mut p2 = Paper::new("Second Paper");
+        p2.year = Some(2024);
+        papers.save(&p1).unwrap();
+        papers.save(&p2).unwrap();
+        aliases
+            .record(p1.id.as_str(), "smith2024", "bibtex-import")
+            .unwrap();
+        aliases
+            .record(p2.id.as_str(), "smith2024", "bibtex-import")
+            .unwrap();
+
+        let resolver = Arc::new(FixedPick {
+            picked: p2.id.as_str().to_string(),
+        });
+        let options = ImportOptions {
+            strategy: MergeStrategy::Interactive,
+            reader: "lars".into(),
+            lenient: true,
+            prompt_resolver: Some(resolver),
+        };
+
+        let src = r"
+@article{smith2024,
+    title = {Some Other Title Entirely},
+    year = {1999}
+}";
+        let report = import_bibtex_str(src, &options, &papers, &aliases, &annotations).unwrap();
+
+        assert!(
+            report.failed.is_empty(),
+            "interactive resolver chose a candidate; failure list should be empty: {:?}",
+            report.failed
+        );
+        assert_eq!(report.rows.len(), 1);
+        let row = &report.rows[0];
+        assert_eq!(row.citekey, "smith2024");
+        assert_eq!(row.action, MergeAction::Unchanged);
+        assert_eq!(row.paper_id.as_deref(), Some(p2.id.as_str()));
+    }
+
+    /// #161: `MergeStrategy::Interactive` without a resolver must
+    /// behave identically to the default failure path. Belt-and-braces
+    /// against accidentally enabling silent-create behavior just by
+    /// flipping the strategy.
+    #[test]
+    fn interactive_strategy_without_resolver_falls_back_to_validation_failure() {
+        let (papers, aliases, annotations) = fresh();
+        let mut p1 = Paper::new("First Paper");
+        p1.year = Some(2024);
+        let mut p2 = Paper::new("Second Paper");
+        p2.year = Some(2024);
+        papers.save(&p1).unwrap();
+        papers.save(&p2).unwrap();
+        aliases
+            .record(p1.id.as_str(), "smith2024", "bibtex-import")
+            .unwrap();
+        aliases
+            .record(p2.id.as_str(), "smith2024", "bibtex-import")
+            .unwrap();
+
+        let options = ImportOptions {
+            strategy: MergeStrategy::Interactive,
+            reader: "lars".into(),
+            lenient: true,
+            prompt_resolver: None,
+        };
+
+        let src = r"
+@article{smith2024,
+    title = {Some Other Title Entirely},
+    year = {1999}
+}";
+        let report = import_bibtex_str(src, &options, &papers, &aliases, &annotations).unwrap();
+        assert!(report.rows.is_empty());
+        assert_eq!(report.failed.len(), 1);
+        assert!(report.failed[0].1.contains("ambiguous alias"));
     }
 
     #[test]

--- a/crates/scitadel-mcp/src/tools.rs
+++ b/crates/scitadel-mcp/src/tools.rs
@@ -1615,7 +1615,9 @@ pub fn import_bibtex_tool(
 
     let strategy = strategy.unwrap_or("merge");
     let strategy = MergeStrategy::parse(strategy).ok_or_else(|| {
-        format!("unknown strategy '{strategy}'; valid: reject, db-wins, bib-wins, merge")
+        format!(
+            "unknown strategy '{strategy}'; valid: reject, db-wins, bib-wins, merge, interactive"
+        )
     })?;
 
     let db = open_db()?;
@@ -1627,6 +1629,10 @@ pub fn import_bibtex_tool(
         strategy,
         reader: reader.to_string(),
         lenient: true,
+        // MCP-side prompt elicitation is a follow-up; without a
+        // resolver, `interactive` strategy degrades to the same
+        // per-row failure path as `merge` for ambiguous-alias rows.
+        prompt_resolver: None,
     };
     let report = import_bibtex_file(
         std::path::Path::new(path),


### PR DESCRIPTION
## Summary

- Adds `MergeStrategy::Interactive` (parses `--strategy interactive`) — same row-level semantics as `Merge` (DB wins on owned columns), but signals the orchestrator to consult a prompt hook when the matcher hits `MatchOutcome::AmbiguousAlias`.
- Defines `PromptResolver` trait in `scitadel-mcp::bib_import` with one method, `resolve_ambiguous_alias(citekey, candidate_ids) -> Option<String>`. `ImportOptions` carries an `Option<Arc<dyn PromptResolver>>`; default is `None`.
- Surgical edit to the `AmbiguousAlias` arm in `import_one`: under `Interactive` + a resolver returning a valid candidate, treat the row as Matched. Otherwise (any non-Interactive strategy, no resolver, or `None` answer) fall through to the existing `CoreError::Validation` path — preserving the #160 regression contract.
- TUI / CLI prompt surfaces are deliberately out of scope; this PR is the trait + plumbing point only. The annotation-prompt overlay in `crates/scitadel-tui/src/views/annotation_prompt.rs` is referenced as the follow-up template.

## Test plan

- [x] `ambiguous_alias_is_a_per_row_failure_not_a_silent_create` (regression for #160) keeps passing under default `Merge` strategy.
- [x] New `interactive_strategy_with_resolver_picks_a_candidate`: stub resolver picks p2 → row lands as `Unchanged`, `paper_id == p2`, `report.failed` empty.
- [x] New `interactive_strategy_without_resolver_falls_back_to_validation_failure`: belt-and-braces — flipping the strategy alone must NOT enable silent-create.
- [x] `cargo fmt --all -- --check` + `cargo clippy --workspace --tests -- -D warnings` clean.
- [x] `cargo test --workspace --exclude scitadel-tui` green (all crates).

Closes #161