### PR TITLE
fix(db): unicode-aware title+year matching (#159)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ reqwest = { version = "0.12", features = ["json"] }
 quick-xml = { version = "0.37", features = ["serialize"] }
 
 # SQLite
-rusqlite = { version = "0.32", features = ["bundled", "serde_json"] }
+rusqlite = { version = "0.32", features = ["bundled", "functions", "serde_json"] }
 r2d2 = "0.8"
 r2d2_sqlite = "0.25"
 

--- a/crates/scitadel-db/src/sqlite/mod.rs
+++ b/crates/scitadel-db/src/sqlite/mod.rs
@@ -24,9 +24,27 @@ pub use tui_state::{SqliteTuiStateRepository, TuiState};
 
 use r2d2::Pool;
 use r2d2_sqlite::SqliteConnectionManager;
+use rusqlite::functions::FunctionFlags;
 use std::path::Path;
 
 use crate::error::DbError;
+
+/// Register `unicode_lower(text)` — a Unicode-aware lowercase scalar
+/// function for SQL queries. SQLite's built-in `LOWER()` is ASCII-only
+/// (`Ü` stays `Ü`), so case-insensitive title comparisons miss
+/// non-ASCII case variants. Registered on every connection at init
+/// time so any pooled handle can use it. (#159)
+fn register_unicode_lower(conn: &rusqlite::Connection) -> rusqlite::Result<()> {
+    conn.create_scalar_function(
+        "unicode_lower",
+        1,
+        FunctionFlags::SQLITE_UTF8 | FunctionFlags::SQLITE_DETERMINISTIC,
+        |ctx| {
+            let s = ctx.get::<Option<String>>(0)?;
+            Ok(s.map(|v| v.to_lowercase()))
+        },
+    )
+}
 
 /// Parse an RFC3339 timestamp string, falling back to now on parse errors.
 pub(crate) fn parse_rfc3339_or_now(s: &str) -> chrono::DateTime<chrono::Utc> {
@@ -60,6 +78,7 @@ impl Database {
                      PRAGMA foreign_keys=ON;
                      PRAGMA busy_timeout=5000;",
             )?;
+            register_unicode_lower(conn)?;
             Ok(())
         });
 
@@ -75,6 +94,7 @@ impl Database {
                 "PRAGMA journal_mode=WAL;
                      PRAGMA foreign_keys=ON;",
             )?;
+            register_unicode_lower(conn)?;
             Ok(())
         });
 

--- a/crates/scitadel-db/src/sqlite/papers.rs
+++ b/crates/scitadel-db/src/sqlite/papers.rs
@@ -181,28 +181,32 @@ impl SqlitePaperRepository {
     }
 
     /// Case-insensitive title match, optionally constrained by year.
-    /// Year `None` means "any year". Title comparison uses `LOWER()`
-    /// like `find_by_title`; whitespace normalization is the caller's
-    /// responsibility (the matcher passes title verbatim today —
-    /// good enough for the issue's stated "exact match only" intent).
+    /// Year `None` means "any year". Title comparison uses
+    /// `unicode_lower()` (a Rust-side `to_lowercase` registered as a
+    /// SQL scalar function in `Database::open` — see #159) so case
+    /// folds work for non-ASCII characters like `Ü/ü`. Whitespace
+    /// normalization is the caller's responsibility (the matcher
+    /// passes title verbatim today — good enough for the issue's
+    /// stated "exact match only" intent).
     pub fn find_id_by_title_and_year(
         &self,
         title: &str,
         year: Option<i32>,
     ) -> Result<Option<String>, CoreError> {
         let conn = self.db.conn()?;
+        let lowered = title.to_lowercase();
         let id: Option<String> = match year {
             Some(y) => conn
                 .query_row(
-                    "SELECT id FROM papers WHERE LOWER(title) = LOWER(?1) AND year = ?2",
-                    params![title, y],
+                    "SELECT id FROM papers WHERE unicode_lower(title) = ?1 AND year = ?2",
+                    params![lowered, y],
                     |r| r.get(0),
                 )
                 .optional(),
             None => conn
                 .query_row(
-                    "SELECT id FROM papers WHERE LOWER(title) = LOWER(?1)",
-                    params![title],
+                    "SELECT id FROM papers WHERE unicode_lower(title) = ?1",
+                    params![lowered],
                     |r| r.get(0),
                 )
                 .optional(),
@@ -367,10 +371,10 @@ impl PaperRepository for SqlitePaperRepository {
     fn find_by_title(&self, title: &str) -> Result<Option<Paper>, CoreError> {
         let conn = self.db.conn()?;
         let mut stmt = conn
-            .prepare("SELECT * FROM papers WHERE LOWER(title) = LOWER(?1)")
+            .prepare("SELECT * FROM papers WHERE unicode_lower(title) = ?1")
             .map_err(DbError::Sqlite)?;
         let result = stmt
-            .query_row(params![title], row_to_paper)
+            .query_row(params![title.to_lowercase()], row_to_paper)
             .optional()
             .map_err(DbError::Sqlite)?;
         Ok(result)
@@ -659,5 +663,46 @@ mod tests {
         let failed = repo.get(paper.id.as_str()).unwrap().unwrap();
         assert!(failed.local_path.is_none());
         assert_eq!(failed.download_status, Some(DownloadStatus::Failed));
+    }
+
+    /// Regression for #159: SQLite's built-in `LOWER()` is ASCII-only,
+    /// so a re-import of a `.bib` whose title differs only by case on
+    /// a non-ASCII letter (`Ü` vs `ü`, `Ñ` vs `ñ`, `Ï` vs `ï`) used to
+    /// miss the title+year fallback and create a duplicate paper. The
+    /// `unicode_lower` SQL function registered at connection init lifts
+    /// this — both query and stored title are folded with Rust's
+    /// Unicode-aware `to_lowercase`.
+    #[test]
+    fn find_id_by_title_and_year_unicode_case_insensitive() {
+        let (_, repo) = setup();
+        let mut paper = Paper::new("Über die naïve Quantenfeldtheorie");
+        paper.year = Some(1925);
+        repo.save(&paper).unwrap();
+
+        // Same title, different case on the non-ASCII letters: must
+        // resolve to the existing paper, not miss.
+        let found = repo
+            .find_id_by_title_and_year("ÜBER DIE NAÏVE QUANTENFELDTHEORIE", Some(1925))
+            .unwrap();
+        assert_eq!(found.as_deref(), Some(paper.id.as_str()));
+
+        // Lowercased query against title-cased stored row also matches.
+        let found_lower = repo
+            .find_id_by_title_and_year("über die naïve quantenfeldtheorie", Some(1925))
+            .unwrap();
+        assert_eq!(found_lower.as_deref(), Some(paper.id.as_str()));
+
+        // Year mismatch still misses.
+        let none = repo
+            .find_id_by_title_and_year("über die naïve quantenfeldtheorie", Some(1926))
+            .unwrap();
+        assert!(none.is_none());
+
+        // `find_by_title` (no year) follows the same unicode-aware path.
+        let by_title = repo
+            .find_by_title("ÜBER DIE NAÏVE QUANTENFELDTHEORIE")
+            .unwrap()
+            .unwrap();
+        assert_eq!(by_title.id, paper.id);
     }
 }


### PR DESCRIPTION
## Summary

- `SqlitePaperRepository::find_id_by_title_and_year` (and `find_by_title`) used SQLite's built-in `LOWER()`, which is ASCII-only — so a re-import of a `.bib` whose title only differs in case on a non-ASCII letter (`Ü/ü`, `Ñ/ñ`, `Ï/ï`) missed the matcher's title+year step and quietly created a duplicate.
- Register a `unicode_lower(text)` SQL scalar function on every pooled connection at init time. It delegates to Rust's Unicode-aware `str::to_lowercase`. Both queries now do `WHERE unicode_lower(title) = ?1`, with the query-side title pre-lowered in Rust so the SQL is one deterministic equality.
- No schema migration, no new column — existing rows are matched correctly the next time the connection is opened.

## Decision: on-the-fly normalization, not a stored column

The issue listed two paths: (1) Rust-side normalize bundled with a denormalized lowercase column on save, or (2) the SQLite ICU extension. I went with the lightest variant of (1): **on-the-fly Rust normalization via a registered scalar function, no stored column, no migration**.

Rationale:
- Adding a column means a migration (#11), backfill on upgrade, and a write-path invariant (every `save`/`save_many`/`update_*` must keep the denormalized column in sync) — substantially more surface area than the bug warrants. The matcher's title+year step runs after BibtexKey + alias, so this path is rarely exercised in practice.
- The scalar function is registered once at connection init (already a `with_init` hook for PRAGMAs), works on existing data immediately, and keeps `Paper` model + schema unchanged.
- If a future profile shows this is hot, indexing a stored column is a strict superset and easy to add later.

## Test plan

- [x] `cargo test -p scitadel-db --lib sqlite::papers::tests::find_id_by_title_and_year_unicode_case_insensitive` — new regression test covering `Über`/`über` + `naïve`/`NAÏVE` round-trips for both `find_id_by_title_and_year` and `find_by_title`, plus a year-mismatch negative case.
- [x] `just lint` (cargo fmt + clippy --all-targets -D warnings) clean.
- [x] `cargo test --workspace --exclude scitadel-tui` all green (existing fixture round-trip + 280+ unit/integration tests).

Closes #159