### PR TITLE
feat(annotations): synthetic sentence_id for unanchored imported notes (#158)

### DIFF
--- a/crates/scitadel-core/src/models/annotation.rs
+++ b/crates/scitadel-core/src/models/annotation.rs
@@ -70,6 +70,40 @@ impl Anchor {
     pub fn is_orphan(&self) -> bool {
         matches!(self.status, AnchorStatus::Orphan)
     }
+
+    /// True when the anchor's only "selector" is a synthetic
+    /// import-marker `sentence_id` (no quote, no char_range, no
+    /// real sentence hash) — i.e. a `note=` from a `.bib` import
+    /// that has nothing to anchor against in the paper text yet.
+    /// The resolver short-circuits these so they don't trip the
+    /// orphan-warning UI flow (#158).
+    #[must_use]
+    pub fn is_imported_synthetic(&self) -> bool {
+        self.char_range.is_none()
+            && self.quote.is_none()
+            && self
+                .sentence_id
+                .as_deref()
+                .is_some_and(|s| s.starts_with(IMPORTED_SENTENCE_ID_PREFIX))
+    }
+}
+
+/// Marker prefix on a synthetic `sentence_id` produced by the
+/// `.bib` import path for unanchored `note={...}` entries (#158).
+/// Picked to be unambiguous: SHA1 hex (the real `sentence_id`
+/// output) cannot start with `bibtex-import:`.
+pub const IMPORTED_SENTENCE_ID_PREFIX: &str = "bibtex-import:";
+
+/// Build a synthetic `sentence_id` for an unanchored imported
+/// `note=`. Combines the source citekey with the SHA1 of the
+/// normalized note content so the same `(citekey, note)` pair
+/// always hashes to the same id. The result is a stable handle
+/// that the resolver recognizes as "imported, not yet anchored
+/// to paper text" rather than as a broken anchor.
+#[must_use]
+pub fn imported_sentence_id(citekey: &str, note: &str) -> String {
+    let content_hash = sentence_id(note);
+    format!("{IMPORTED_SENTENCE_ID_PREFIX}{citekey}:{content_hash}")
 }
 
 /// One annotation. May be a root (with an anchor) or a reply (parent_id set,
@@ -244,6 +278,48 @@ mod tests {
         assert!(!a.is_orphan());
         a.status = AnchorStatus::Orphan;
         assert!(a.is_orphan());
+    }
+
+    #[test]
+    fn imported_synthetic_id_has_marker_prefix() {
+        let id = imported_sentence_id("smith2024", "some note");
+        assert!(id.starts_with(IMPORTED_SENTENCE_ID_PREFIX));
+        assert!(id.contains("smith2024"));
+    }
+
+    #[test]
+    fn is_imported_synthetic_recognises_marker_anchor() {
+        let a = Anchor {
+            sentence_id: Some(imported_sentence_id("k", "n")),
+            ..Anchor::default()
+        };
+        assert!(a.is_imported_synthetic());
+    }
+
+    #[test]
+    fn is_imported_synthetic_rejects_real_sentence_id() {
+        let a = Anchor {
+            sentence_id: Some(sentence_id("a real sentence.")),
+            ..Anchor::default()
+        };
+        assert!(!a.is_imported_synthetic());
+    }
+
+    #[test]
+    fn is_imported_synthetic_rejects_anchor_with_quote_or_range() {
+        let with_quote = Anchor {
+            sentence_id: Some(imported_sentence_id("k", "n")),
+            quote: Some("hi".into()),
+            ..Anchor::default()
+        };
+        assert!(!with_quote.is_imported_synthetic());
+
+        let with_range = Anchor {
+            sentence_id: Some(imported_sentence_id("k", "n")),
+            char_range: Some((0, 2)),
+            ..Anchor::default()
+        };
+        assert!(!with_range.is_imported_synthetic());
     }
 
     #[test]

--- a/crates/scitadel-core/src/models/mod.rs
+++ b/crates/scitadel-core/src/models/mod.rs
@@ -7,7 +7,8 @@ mod question;
 mod search;
 
 pub use annotation::{
-    Anchor, AnchorStatus, Annotation, AnnotationRead, normalize_sentence, sentence_id,
+    Anchor, AnchorStatus, Annotation, AnnotationRead, IMPORTED_SENTENCE_ID_PREFIX,
+    imported_sentence_id, normalize_sentence, sentence_id,
 };
 pub use assessment::Assessment;
 pub use citation::{Citation, CitationDirection, SnowballRun};

--- a/crates/scitadel-db/src/sqlite/annotations.rs
+++ b/crates/scitadel-db/src/sqlite/annotations.rs
@@ -316,6 +316,18 @@ pub fn resolve_anchor_with_threshold(
     text: &str,
     fuzzy_threshold: f64,
 ) -> AnchorStatus {
+    // Short-circuit: `.bib`-imported `note=` annotations carry only
+    // a synthetic marker `sentence_id` (no quote / range), since they
+    // have nothing to anchor against in the paper text yet. Treat them
+    // as `Ok` instead of falling through to `Orphan`, so they don't
+    // trip the orphan-warning UI flow (#158). Real Orphan semantics
+    // still apply to anchors whose selectors *should* match paper text
+    // but failed to.
+    if anchor.is_imported_synthetic() {
+        anchor.status = AnchorStatus::Ok;
+        return AnchorStatus::Ok;
+    }
+
     // Step 1: position selector — bounds-checked.
     if let (Some((start, end)), Some(quote)) = (anchor.char_range, anchor.quote.as_ref())
         && let Some(slice) = char_slice(text, start, end)
@@ -695,6 +707,41 @@ mod tests {
             resolve_anchor(&mut a, "nothing to see"),
             AnchorStatus::Orphan
         );
+    }
+
+    /// #158: an unanchored `.bib` `note=` import carries only a
+    /// synthetic marker `sentence_id`. The resolver must short-circuit
+    /// to `Ok` rather than falling through to `Orphan` (which would
+    /// trip the orphan-warning UI flow).
+    #[test]
+    fn resolver_short_circuits_imported_synthetic_anchor_to_ok() {
+        let mut a = Anchor {
+            sentence_id: Some(scitadel_core::models::imported_sentence_id(
+                "smith2024",
+                "Reading note about methodology.",
+            )),
+            ..Anchor::default()
+        };
+        // Paper text deliberately contains nothing matching the
+        // synthetic id — the short-circuit must fire regardless.
+        let status = resolve_anchor(&mut a, "the body of the paper says many things.");
+        assert_eq!(status, AnchorStatus::Ok);
+        assert_eq!(a.status, AnchorStatus::Ok);
+        assert!(!a.is_orphan());
+    }
+
+    /// #158: an anchor with a `quote` that fails to resolve must still
+    /// flip to `Orphan` — the synthetic short-circuit only applies to
+    /// import-only anchors with no real selectors.
+    #[test]
+    fn resolver_still_orphans_real_anchors_that_fail() {
+        let mut a = Anchor {
+            quote: Some("missing quote".into()),
+            sentence_id: Some(scitadel_core::models::sentence_id("a real sentence.")),
+            ..Anchor::default()
+        };
+        let status = resolve_anchor(&mut a, "different text without the quote.");
+        assert_eq!(status, AnchorStatus::Orphan);
     }
 
     // ---- Read-receipt tests ----

--- a/crates/scitadel-export/src/import/side_effects.rs
+++ b/crates/scitadel-export/src/import/side_effects.rs
@@ -18,7 +18,7 @@
 //! (#134 step 1) so a future re-import resolves via the alias step
 //! of the match cascade.
 
-use scitadel_core::models::{Anchor, Annotation, PaperId};
+use scitadel_core::models::{Anchor, Annotation, PaperId, imported_sentence_id};
 
 use super::merge::MergeAction;
 use super::parse::BibEntry;
@@ -91,11 +91,20 @@ pub fn compute(paper_id: &str, reader: &str, bib: &BibEntry, action: MergeAction
 
     let (annotation, dropped_keywords) = match bib.note.as_deref() {
         Some(note) if !note.is_empty() => {
+            // Synthetic `sentence_id` so the resolver recognizes this
+            // as an unanchored import on first open instead of flipping
+            // it to `Orphan` (#158). Hash incorporates citekey + note
+            // content so the same `(citekey, note)` pair always
+            // produces the same id — re-import collapses to no-op.
+            let synthetic = Anchor {
+                sentence_id: Some(imported_sentence_id(&bib.citekey, note)),
+                ..Anchor::default()
+            };
             let mut a = Annotation::new_root(
                 PaperId::from(paper_id),
                 reader.to_string(),
                 note.to_string(),
-                Anchor::default(),
+                synthetic,
             );
             a.tags.clone_from(&bib.keywords);
             (Some(a), vec![])
@@ -169,11 +178,42 @@ mod tests {
         assert_eq!(a.note, "Read twice; methodology questionable");
         assert_eq!(a.paper_id.as_str(), "p-x");
         assert!(a.parent_id.is_none(), "root annotation");
-        assert_eq!(
-            a.anchor,
-            Anchor::default(),
-            "unanchored — no source text yet"
-        );
+        // No selectors against paper text — only the synthetic
+        // `sentence_id` marker the resolver uses to short-circuit (#158).
+        assert!(a.anchor.char_range.is_none());
+        assert!(a.anchor.quote.is_none());
+        assert!(a.anchor.prefix.is_none());
+        assert!(a.anchor.suffix.is_none());
+        assert!(a.anchor.is_imported_synthetic());
+    }
+
+    #[test]
+    fn imported_synthetic_sentence_id_is_stable_per_citekey_note() {
+        let mut b1 = bib("smith2024");
+        b1.note = Some("methodology questionable".into());
+        let mut b2 = bib("smith2024");
+        b2.note = Some("methodology questionable".into());
+        let mut b3 = bib("smith2024");
+        b3.note = Some("different note".into());
+        let mut b4 = bib("jones2024");
+        b4.note = Some("methodology questionable".into());
+
+        let a1 = compute("p", "lars", &b1, MergeAction::Updated)
+            .annotation
+            .unwrap();
+        let a2 = compute("p", "lars", &b2, MergeAction::Updated)
+            .annotation
+            .unwrap();
+        let a3 = compute("p", "lars", &b3, MergeAction::Updated)
+            .annotation
+            .unwrap();
+        let a4 = compute("p", "lars", &b4, MergeAction::Updated)
+            .annotation
+            .unwrap();
+
+        assert_eq!(a1.anchor.sentence_id, a2.anchor.sentence_id);
+        assert_ne!(a1.anchor.sentence_id, a3.anchor.sentence_id);
+        assert_ne!(a1.anchor.sentence_id, a4.anchor.sentence_id);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Per #134 PR-A, Zotero `note={...}` becomes an `Annotation` with `Anchor::default()` — every selector `None`. The resolver then flipped these to `Orphan` on first open, and the TUI annotation reader (#136) treated them as broken anchors. The user's reading notes were technically present but flagged as not-anchored-to-anything, which is loss-adjacent given #134's "merged without loss" promise.

This PR follows the issue's preferred approach: stamp the import path with a synthetic `sentence_id` of the form `bibtex-import:<citekey>:<sha1(note)>`. The resolver recognises the marker prefix, short-circuits to `Ok`, and skips the orphan fall-through. Status stays meaningful — `Orphan` continues to mean "selectors that should match paper text actually failed."

### Design choice

**Synthetic sentence_id** over the alternative `AnchorStatus::Imported` variant. Rationale:

- The issue title and proposal lead with synthetic-id.
- Zero touch on the `AnchorStatus` enum, the DB schema, or the TUI/MCP surfaces — only the import-time anchor builder and the resolver short-circuit.
- The synthetic id doubles as a deterministic content handle: same `(citekey, note)` always hashes to the same id, which keeps the existing `round_trip_export_then_import_touches_zero_rows` test honest.

### Touch points

- `scitadel-core/src/models/annotation.rs`: `IMPORTED_SENTENCE_ID_PREFIX`, `imported_sentence_id(citekey, note)`, `Anchor::is_imported_synthetic()`.
- `scitadel-export/src/import/side_effects.rs`: stamp the synthetic id when building a `note=` annotation.
- `scitadel-db/src/sqlite/annotations.rs`: short-circuit `resolve_anchor_with_threshold` for synthetic anchors.

## Test plan

- [x] `cargo test --workspace --exclude scitadel-tui` — all green
- [x] `just lint` (fmt + clippy -D warnings) — clean
- [x] New test: resolver short-circuits a synthetic anchor to `Ok` against arbitrary paper text
- [x] New test: resolver still flips real (quote-bearing) anchors to `Orphan` when their selectors fail
- [x] New test: `imported_sentence_id` is stable per `(citekey, note)` and varies on either input
- [x] New test: `is_imported_synthetic` requires absence of quote/range
- [x] Existing `round_trip_export_then_import_touches_zero_rows` still passes — re-import is no-op (acceptance criterion)

Closes #158