### PR TITLE
refactor(bib): wrap import per-row writes in a single transaction (#157)

### DIFF
--- a/crates/scitadel-db/src/sqlite/annotations.rs
+++ b/crates/scitadel-db/src/sqlite/annotations.rs
@@ -31,6 +31,20 @@ impl SqliteAnnotationRepository {
     /// `Annotation` (see `Annotation::new_root` / `new_reply`).
     pub fn create(&self, annotation: &Annotation) -> Result<(), DbError> {
         let conn = self.db.conn()?;
+        Self::insert_via(&conn, annotation)
+    }
+
+    /// Transactional sibling of [`Self::create`] (#157). Used by the
+    /// bib-import orchestrator so paper-save + alias-record + annotation-
+    /// create commit (or roll back) as a single unit per row.
+    pub fn create_in_tx(
+        tx: &rusqlite::Transaction<'_>,
+        annotation: &Annotation,
+    ) -> Result<(), DbError> {
+        Self::insert_via(tx, annotation)
+    }
+
+    fn insert_via(conn: &rusqlite::Connection, annotation: &Annotation) -> Result<(), DbError> {
         conn.execute(
             "INSERT INTO annotations
                 (id, parent_id, paper_id, question_id,

--- a/crates/scitadel-db/src/sqlite/mod.rs
+++ b/crates/scitadel-db/src/sqlite/mod.rs
@@ -11,6 +11,7 @@ mod shortlist;
 mod tui_state;
 
 pub use annotations::{SqliteAnnotationRepository, resolve_anchor};
+
 pub use assessments::SqliteAssessmentRepository;
 pub use citations::SqliteCitationRepository;
 pub use migrations::run_migrations;
@@ -18,6 +19,10 @@ pub use paper_aliases::{SOURCE_BIBTEX_IMPORT, SOURCE_REKEY, SqlitePaperAliasRepo
 pub use paper_state::{PaperState, SqlitePaperStateRepository};
 pub use papers::SqlitePaperRepository;
 pub use questions::SqliteQuestionRepository;
+/// Re-export of `rusqlite::Transaction` so downstream crates (e.g.
+/// `scitadel-mcp`'s bib-import orchestrator in #157) can drive multi-
+/// repo transactions without taking a direct rusqlite dependency.
+pub use rusqlite::Transaction as SqliteTransaction;
 pub use searches::SqliteSearchRepository;
 pub use shortlist::SqliteShortlistRepository;
 pub use tui_state::{SqliteTuiStateRepository, TuiState};

--- a/crates/scitadel-db/src/sqlite/paper_aliases.rs
+++ b/crates/scitadel-db/src/sqlite/paper_aliases.rs
@@ -41,6 +41,23 @@ impl SqlitePaperAliasRepository {
         Ok(rows > 0)
     }
 
+    /// Transactional sibling of [`Self::record`] (#157). Used by the
+    /// bib-import orchestrator so paper-save + alias-record + annotation-
+    /// create commit (or roll back) as a single unit per row.
+    pub fn record_in_tx(
+        tx: &rusqlite::Transaction<'_>,
+        paper_id: &str,
+        alias: &str,
+        source: &str,
+    ) -> Result<bool, DbError> {
+        let rows = tx.execute(
+            "INSERT OR IGNORE INTO paper_aliases (paper_id, alias, source, created_at)
+             VALUES (?1, ?2, ?3, ?4)",
+            params![paper_id, alias, source, chrono::Utc::now().to_rfc3339()],
+        )?;
+        Ok(rows > 0)
+    }
+
     /// Look up a paper by alias. When two papers share an alias (legal —
     /// two different imports may collide on citekey) this returns the
     /// earliest-created row so the lookup is deterministic. Secondary

--- a/crates/scitadel-db/src/sqlite/papers.rs
+++ b/crates/scitadel-db/src/sqlite/papers.rs
@@ -41,6 +41,14 @@ impl SqlitePaperRepository {
         Self { db }
     }
 
+    /// Borrow the underlying `Database` so callers (e.g. the bib-import
+    /// orchestrator in #157) can drive a multi-repo transaction over a
+    /// single pooled connection. Read-only access — repos remain the
+    /// canonical write surface.
+    pub fn db(&self) -> &Database {
+        &self.db
+    }
+
     /// If a paper with the same DOI already exists, return a clone with the existing ID
     /// so the upsert merges into the existing row instead of violating the DOI unique index.
     fn resolve_doi_conflict(
@@ -115,6 +123,21 @@ impl SqlitePaperRepository {
     /// the seed in `Database::backfill_bibtex_keys`.
     pub fn taken_bibtex_keys(&self) -> Result<std::collections::HashSet<String>, CoreError> {
         let conn = self.db.conn()?;
+        Self::taken_bibtex_keys_inner(&conn)
+    }
+
+    /// Transactional sibling of [`Self::taken_bibtex_keys`] (#157). Runs
+    /// the snapshot inside an in-flight transaction so the bib-import
+    /// orchestrator's per-row tx sees its own pending writes.
+    pub fn taken_bibtex_keys_in_tx(
+        tx: &rusqlite::Transaction<'_>,
+    ) -> Result<std::collections::HashSet<String>, CoreError> {
+        Self::taken_bibtex_keys_inner(tx)
+    }
+
+    fn taken_bibtex_keys_inner(
+        conn: &rusqlite::Connection,
+    ) -> Result<std::collections::HashSet<String>, CoreError> {
         let keys = conn
             .prepare("SELECT bibtex_key FROM papers WHERE bibtex_key IS NOT NULL")
             .map_err(DbError::Sqlite)?
@@ -123,6 +146,59 @@ impl SqlitePaperRepository {
             .filter_map(Result::ok)
             .collect();
         Ok(keys)
+    }
+
+    /// Transactional sibling of [`PaperRepository::save`] (#157). Same
+    /// upsert + DOI-conflict-retry logic, but runs against the caller's
+    /// transaction so a multi-step import operation can roll back as a
+    /// unit on partial failure.
+    pub fn save_in_tx(tx: &rusqlite::Transaction<'_>, paper: &Paper) -> Result<(), CoreError> {
+        let paper = Self::resolve_doi_conflict_tx(tx, paper)?;
+        let p = Self::paper_params(&paper);
+        let params: Vec<&dyn rusqlite::types::ToSql> = p.iter().map(|b| b.as_ref()).collect();
+        match tx.execute(UPSERT_SQL, params.as_slice()) {
+            Ok(_) => Ok(()),
+            Err(rusqlite::Error::SqliteFailure(err, _))
+                if err.code == rusqlite::ErrorCode::ConstraintViolation =>
+            {
+                if let Some(doi) = &paper.doi {
+                    let existing_id: Option<String> = tx
+                        .query_row(
+                            "SELECT id FROM papers WHERE doi = ?1",
+                            params![doi],
+                            |row| row.get(0),
+                        )
+                        .optional()
+                        .map_err(DbError::Sqlite)?;
+                    if let Some(eid) = existing_id {
+                        let mut retry = paper.clone();
+                        retry.id = PaperId::from(eid);
+                        let p2 = Self::paper_params(&retry);
+                        let params2: Vec<&dyn rusqlite::types::ToSql> =
+                            p2.iter().map(|b| b.as_ref()).collect();
+                        tx.execute(UPSERT_SQL, params2.as_slice())
+                            .map_err(DbError::Sqlite)?;
+                    }
+                }
+                Ok(())
+            }
+            Err(e) => Err(DbError::Sqlite(e).into()),
+        }
+    }
+
+    /// Transactional sibling of
+    /// [`PaperRepository::update_bibtex_key`] (#157).
+    pub fn update_bibtex_key_in_tx(
+        tx: &rusqlite::Transaction<'_>,
+        paper_id: &str,
+        key: &str,
+    ) -> Result<(), CoreError> {
+        tx.execute(
+            "UPDATE papers SET bibtex_key = ?1 WHERE id = ?2",
+            params![key, paper_id],
+        )
+        .map_err(DbError::Sqlite)?;
+        Ok(())
     }
 
     /// Lookup-by-id helpers used by the bib-import matcher (#134).

--- a/crates/scitadel-mcp/src/bib_import.rs
+++ b/crates/scitadel-mcp/src/bib_import.rs
@@ -17,6 +17,11 @@
 //! 2. Record the imported citekey on `paper_aliases`.
 //! 3. Save the unanchored annotation built from `note=` (if any).
 //!
+//! All three writes are wrapped in a single per-row SQLite transaction
+//! (#157) so a mid-row failure can never strand an orphaned `papers`
+//! row without its alias — the next re-import would otherwise miss
+//! the orphan via the alias step and either DOI-merge or duplicate it.
+//!
 //! Failures on a single row are logged and counted but never abort
 //! the run — a 5000-paper Zotero dump must survive a couple bad
 //! entries.
@@ -26,8 +31,10 @@ use std::path::Path;
 use scitadel_core::bibtex_key::assign_keys;
 use scitadel_core::error::CoreError;
 use scitadel_core::ports::PaperRepository;
+use scitadel_db::error::DbError;
 use scitadel_db::sqlite::{
     SqliteAnnotationRepository, SqlitePaperAliasRepository, SqlitePaperRepository,
+    SqliteTransaction,
 };
 use scitadel_export::import::{
     BibEntry, MatchOutcome, MergeAction, MergeStrategy, PaperLookup, SideEffects,
@@ -134,8 +141,14 @@ pub fn import_bibtex_str(
     let lookup = SqliteBibLookup { papers, aliases };
     let mut report = ImportReport::default();
 
+    // `annotations` is unused below — the per-row tx grabs a connection
+    // from `papers.db()` and calls `SqliteAnnotationRepository::create_in_tx`
+    // statically. Kept on the outer signature so callers (CLI, MCP) don't
+    // need to change construction order (#157).
+    let _ = annotations;
+
     for entry in entries {
-        match import_one(&entry, options, &lookup, papers, aliases, annotations) {
+        match import_one(&entry, options, &lookup, papers) {
             Ok(row) => report.rows.push(row),
             Err(e) if options.lenient => {
                 tracing::warn!(citekey = %entry.citekey, error = %e, "import row failed; continuing");
@@ -159,23 +172,24 @@ pub fn import_bibtex_file(
     import_bibtex_str(&src, options, papers, aliases, annotations)
 }
 
-/// Assign and persist a stable `bibtex_key` for a newly-saved paper.
-/// Snapshots the existing key set, runs the #132 algorithm with the
-/// paper's title/authors/year, and writes the result back. Idempotent
-/// only if the paper already has a key (the algorithm's collision
-/// disambiguator may pick a different suffix on re-run when the
-/// `taken` set differs).
-fn assign_and_persist_bibtex_key(
-    papers: &SqlitePaperRepository,
+/// Assign and persist a stable `bibtex_key` for a newly-saved paper
+/// inside an in-flight transaction. Snapshots the existing key set
+/// (within the tx, so it sees the row we just upserted), runs the
+/// #132 algorithm with the paper's title/authors/year, and writes
+/// the result back. Tx-only sibling of the original
+/// `assign_and_persist_bibtex_key` — pulled inline now that the
+/// orchestrator owns the transaction (#157).
+fn assign_and_persist_bibtex_key_in_tx(
+    tx: &SqliteTransaction<'_>,
     paper: &scitadel_core::models::Paper,
 ) -> Result<(), CoreError> {
     if paper.bibtex_key.is_some() {
         return Ok(());
     }
-    let mut taken = papers.taken_bibtex_keys()?;
+    let mut taken = SqlitePaperRepository::taken_bibtex_keys_in_tx(tx)?;
     let assigned = assign_keys(std::slice::from_ref(paper), &mut taken);
     if let Some(key) = assigned.into_iter().next() {
-        papers.update_bibtex_key(paper.id.as_str(), &key)?;
+        SqlitePaperRepository::update_bibtex_key_in_tx(tx, paper.id.as_str(), &key)?;
     }
     Ok(())
 }
@@ -185,10 +199,9 @@ fn import_one(
     options: &ImportOptions,
     lookup: &SqliteBibLookup<'_>,
     papers: &SqlitePaperRepository,
-    aliases: &SqlitePaperAliasRepository,
-    annotations: &SqliteAnnotationRepository,
 ) -> Result<ImportRow, CoreError> {
-    // 1. Match cascade.
+    // 1. Match cascade. Read-only; runs against committed state, so
+    //    no need to be inside the per-row transaction.
     let outcome = match_entry(entry, lookup)?;
     let matched_id = match outcome {
         MatchOutcome::Matched(id, _) => Some(id),
@@ -231,30 +244,35 @@ fn import_one(
     };
     let merge = resolve_merge(db_paper, entry, options.strategy);
 
-    // 3. Persist the paper. Created/Updated write the row; Created
-    //    additionally needs an explicit bibtex_key assignment because
-    //    `SqlitePaperRepository::save` does not write the column —
-    //    skipping this leaves new papers keyless until the next
-    //    `migrate` run and silently degrades subsequent imports'
-    //    BibtexKey cascade step.
+    // 3+4. Persistence — wrapped in a single transaction (#157) so
+    //      paper-save / bibtex-key-assignment / alias-record /
+    //      annotation-create commit (or roll back) atomically. Without
+    //      this, a mid-row failure (e.g. transient SQLite error during
+    //      a 5000-paper Zotero import) could leave an orphaned papers
+    //      row with no alias — invisible to the next re-import's alias
+    //      step, defeating the whole point of recording the citekey.
+    let mut conn = papers.db().conn().map_err(CoreError::from)?;
+    let tx = conn
+        .transaction()
+        .map_err(DbError::from)
+        .map_err(CoreError::from)?;
+
     let persisted_id = match merge.action {
         MergeAction::Rejected => None,
         _ => match merge.paper.as_ref() {
             None => None,
             Some(p) => {
                 if matches!(merge.action, MergeAction::Created | MergeAction::Updated) {
-                    papers.save(p)?;
+                    SqlitePaperRepository::save_in_tx(&tx, p)?;
                 }
                 if merge.action == MergeAction::Created {
-                    assign_and_persist_bibtex_key(papers, p)?;
+                    assign_and_persist_bibtex_key_in_tx(&tx, p)?;
                 }
                 Some(p.id.as_str().to_string())
             }
         },
     };
 
-    // 4. Side effects (alias / annotation / verbose-log items) — only
-    //    when we have a paper to attach them to.
     let (annotation_created, dropped_keywords, dropped_file) = if let Some(pid) = &persisted_id {
         let SideEffects {
             alias,
@@ -263,12 +281,11 @@ fn import_one(
             dropped_file,
         } = compute_side_effects(pid, &options.reader, entry, merge.action);
         if let Some(a) = alias {
-            aliases
-                .record(&a.paper_id, &a.alias, a.source)
+            SqlitePaperAliasRepository::record_in_tx(&tx, &a.paper_id, &a.alias, a.source)
                 .map_err(CoreError::from)?;
         }
         let created = if let Some(annot) = annotation {
-            annotations.create(&annot)?;
+            SqliteAnnotationRepository::create_in_tx(&tx, &annot).map_err(CoreError::from)?;
             true
         } else {
             false
@@ -277,6 +294,10 @@ fn import_one(
     } else {
         (false, vec![], None)
     };
+
+    tx.commit()
+        .map_err(DbError::from)
+        .map_err(CoreError::from)?;
 
     Ok(ImportRow {
         citekey: entry.citekey.clone(),
@@ -618,6 +639,67 @@ mod tests {
             aliases.lookup_all("smith2024").unwrap().len(),
             aliases_before
         );
+    }
+
+    /// Per-row tx invariant (#157): paper-save + alias-record + annotation-
+    /// create must commit (or roll back) atomically. Without this, a
+    /// transient failure on the alias write after a successful paper
+    /// save would leave an orphan papers row that the next re-import
+    /// can't see via the alias step — silently DOI-merging or
+    /// duplicating instead of resolving to the orphan.
+    ///
+    /// Drive the primitive directly: open the orchestrator's tx, save
+    /// a paper, then trigger an FK violation (alias → bogus paper_id)
+    /// and drop the tx without committing. Assert papers row count is
+    /// zero after rollback.
+    #[test]
+    fn per_row_tx_rolls_back_when_alias_record_fails() {
+        let (papers, aliases, _annotations) = fresh();
+        let mut p = Paper::new("Will Be Rolled Back");
+        p.year = Some(2026);
+
+        let papers_before = papers.list_all(100, 0).unwrap().len();
+        assert_eq!(papers_before, 0);
+
+        // Mirror what `import_one` does: grab one connection, open a
+        // single tx, save the paper inside it, then attempt an alias
+        // record that violates the FK (paper_aliases.paper_id REFERENCES
+        // papers(id)). The error must propagate and — critically —
+        // dropping `tx` without `commit()` must roll back the paper save.
+        let mut conn = papers.db().conn().unwrap();
+        let tx = conn.transaction().unwrap();
+        SqlitePaperRepository::save_in_tx(&tx, &p).unwrap();
+        // Inside the tx, the paper IS visible to subsequent queries.
+        let mid_count: i64 = tx
+            .query_row("SELECT COUNT(*) FROM papers", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(
+            mid_count, 1,
+            "paper must be visible inside its own tx before commit"
+        );
+        // Force the failure: alias points at a non-existent paper.
+        let err = SqlitePaperAliasRepository::record_in_tx(
+            &tx,
+            "no-such-paper-id",
+            "ghostkey",
+            "bibtex-import",
+        );
+        assert!(err.is_err(), "FK violation must surface as Err");
+        // Drop without commit → rollback.
+        drop(tx);
+        drop(conn);
+
+        // The canary: papers count is back to zero. Without per-row tx
+        // wrapping (#134 PR-A behavior), the paper would persist as an
+        // orphan and the subsequent re-import wouldn't know about it.
+        let papers_after = papers.list_all(100, 0).unwrap().len();
+        assert_eq!(
+            papers_after, 0,
+            "paper save must roll back when a later step in the same row's tx fails; \
+             got {papers_after} orphan(s)"
+        );
+        // And no alias was recorded either.
+        assert!(aliases.lookup("ghostkey").unwrap().is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Wrap the three per-row writes in `import_one` (paper save, alias record, annotation create) in a single SQLite transaction so a mid-row failure rolls back atomically rather than leaving an orphan papers row.
- Add `_in_tx` sibling methods on the three repos plus a `db()` accessor and `SqliteTransaction` re-export from `scitadel-db`, so the orchestrator can drive multi-repo writes over one pooled connection without taking a direct rusqlite dep.
- Add adversarial test `per_row_tx_rolls_back_when_alias_record_fails` driving the primitive directly: open the tx, save a paper, force an FK violation on alias-record, drop the tx without committing, and assert papers count stays zero.

## Test plan

- [x] `just lint` (cargo fmt --check + clippy --workspace --tests -D warnings) clean
- [x] `cargo test --workspace --exclude scitadel-tui` — all suites green; new test `per_row_tx_rolls_back_when_alias_record_fails` passes alongside the existing 8 in `bib_import::tests`
- [x] Round-trip + ambiguous-alias regression tests still pass under the new tx wrapping
- [ ] Reviewer sanity check: 5000-paper Zotero import (manual) — transactions are normally faster, not slower, for batch writes; no expected regression

Closes #157.