### PR TITLE
feat(papers): paper_tags table for keyword-only Zotero imports

### DIFF
--- a/crates/scitadel-cli/src/commands.rs
+++ b/crates/scitadel-cli/src/commands.rs
@@ -411,8 +411,11 @@ pub fn show(id: &str) -> Result<()> {
 }
 
 pub fn export(search_id: &str, format: &str, output: Option<PathBuf>) -> Result<()> {
+    use scitadel_db::sqlite::SqlitePaperTagRepository;
+
     let db = open_db()?;
     let (paper_repo, search_repo, _, _, _) = db.repositories();
+    let tag_repo = SqlitePaperTagRepository::new(db);
 
     let search = if let Some(s) = search_repo.get(search_id)? {
         s
@@ -432,7 +435,9 @@ pub fn export(search_id: &str, format: &str, output: Option<PathBuf>) -> Result<
     let content = match format {
         "json" => scitadel_export::export_json(&papers, 2),
         "csv" => scitadel_export::export_csv(&papers),
-        "bibtex" => scitadel_export::export_bibtex(&papers),
+        "bibtex" => scitadel_export::export_bibtex_with_tags(&papers, |id| {
+            tag_repo.tags_for(id).unwrap_or_default()
+        }),
         _ => bail!("unknown format: {format}"),
     };
 
@@ -742,6 +747,7 @@ pub fn bib_import(
 
     use scitadel_db::sqlite::{
         SqliteAnnotationRepository, SqlitePaperAliasRepository, SqlitePaperRepository,
+        SqlitePaperTagRepository,
     };
     use scitadel_export::import::{MergeAction, MergeStrategy};
     use scitadel_mcp::bib_import::{ImportOptions, import_bibtex_file};
@@ -757,7 +763,8 @@ pub fn bib_import(
     let db = open_db()?;
     let papers = SqlitePaperRepository::new(db.clone());
     let aliases = SqlitePaperAliasRepository::new(db.clone());
-    let annotations = SqliteAnnotationRepository::new(db);
+    let annotations = SqliteAnnotationRepository::new(db.clone());
+    let tags = SqlitePaperTagRepository::new(db);
 
     let options = ImportOptions {
         strategy,
@@ -770,7 +777,7 @@ pub fn bib_import(
         // rows. The trait is now in place for follow-ups.
         prompt_resolver: None,
     };
-    let report = import_bibtex_file(path, &options, &papers, &aliases, &annotations)
+    let report = import_bibtex_file(path, &options, &papers, &aliases, &annotations, &tags)
         .with_context(|| format!("import {}", path.display()))?;
 
     for row in &report.rows {
@@ -794,10 +801,13 @@ pub fn bib_import(
         if row.annotation_created {
             line.push_str(" + annotation");
         }
+        if !row.paper_tags_written.is_empty() {
+            let _ = write!(line, " + {} tag(s)", row.paper_tags_written.len());
+        }
         println!("{line}");
         if verbose {
-            if !row.dropped_keywords.is_empty() {
-                println!("    dropped keywords: {}", row.dropped_keywords.join(", "));
+            if !row.paper_tags_written.is_empty() {
+                println!("    paper tags: {}", row.paper_tags_written.join(", "));
             }
             if let Some(f) = &row.dropped_file {
                 println!("    dropped file: {f}");

--- a/crates/scitadel-db/migrations/012_paper_tags.sql
+++ b/crates/scitadel-db/migrations/012_paper_tags.sql
@@ -1,0 +1,31 @@
+-- Paper-level tags (#162 — keyword-only Zotero imports).
+--
+-- Records free-form tags attached to a paper. The driving use case
+-- is Zotero `.bib` entries that carry `keywords={a,b,c}` *without*
+-- a `note=`: the bib-import pipeline rides along keywords as
+-- annotation tags only when there's a note to anchor them on, so
+-- keyword-only entries used to drop the user's tags on the floor
+-- (#134 PR-A surfaced these as `dropped_keywords` under `--verbose`).
+--
+-- Annotation tags model text-level tagging — they hang off an anchor.
+-- Paper tags hang off the paper itself, which is what Zotero users
+-- actually mean when they tag a paper without writing a note.
+--
+-- `source` is free-form text ("bibtex-import", later: "manual",
+-- "csl-json-import", …) so we can audit where a tag came from. The
+-- shape mirrors `paper_aliases` (#134 / migration 011) — same
+-- (paper_id, value) primary key, same `source` + `created_at`
+-- columns, same secondary index on the value column for reverse
+-- lookups.
+
+CREATE TABLE IF NOT EXISTS paper_tags (
+    paper_id   TEXT NOT NULL REFERENCES papers(id) ON DELETE CASCADE,
+    tag        TEXT NOT NULL,
+    source     TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    PRIMARY KEY (paper_id, tag)
+);
+
+CREATE INDEX IF NOT EXISTS idx_paper_tags_tag ON paper_tags(tag);
+
+INSERT OR IGNORE INTO schema_version (version, applied_at) VALUES (12, datetime('now'));

--- a/crates/scitadel-db/src/sqlite/migrations.rs
+++ b/crates/scitadel-db/src/sqlite/migrations.rs
@@ -13,6 +13,7 @@ const MIGRATION_008: &str = include_str!("../../migrations/008_tui_state.sql");
 const MIGRATION_009: &str = include_str!("../../migrations/009_bibtex_keys.sql");
 const MIGRATION_010: &str = include_str!("../../migrations/010_shortlists.sql");
 const MIGRATION_011: &str = include_str!("../../migrations/011_paper_aliases.sql");
+const MIGRATION_012: &str = include_str!("../../migrations/012_paper_tags.sql");
 
 const MIGRATIONS: &[(i64, &str)] = &[
     (1, MIGRATION_001),
@@ -26,6 +27,7 @@ const MIGRATIONS: &[(i64, &str)] = &[
     (9, MIGRATION_009),
     (10, MIGRATION_010),
     (11, MIGRATION_011),
+    (12, MIGRATION_012),
 ];
 
 /// Run all pending migrations, skipping already-applied ones.
@@ -98,6 +100,7 @@ mod tests {
         assert!(tables.contains(&"annotation_reads".to_string()));
         assert!(tables.contains(&"searches_fts".to_string()));
         assert!(tables.contains(&"paper_aliases".to_string()));
+        assert!(tables.contains(&"paper_tags".to_string()));
         assert!(tables.contains(&"schema_version".to_string()));
     }
 }

--- a/crates/scitadel-db/src/sqlite/mod.rs
+++ b/crates/scitadel-db/src/sqlite/mod.rs
@@ -4,6 +4,7 @@ mod citations;
 mod migrations;
 mod paper_aliases;
 mod paper_state;
+mod paper_tags;
 mod papers;
 mod questions;
 mod searches;
@@ -17,6 +18,7 @@ pub use citations::SqliteCitationRepository;
 pub use migrations::run_migrations;
 pub use paper_aliases::{SOURCE_BIBTEX_IMPORT, SOURCE_REKEY, SqlitePaperAliasRepository};
 pub use paper_state::{PaperState, SqlitePaperStateRepository};
+pub use paper_tags::{SqlitePaperTagRepository, TAG_SOURCE_BIBTEX_IMPORT};
 pub use papers::SqlitePaperRepository;
 pub use questions::SqliteQuestionRepository;
 /// Re-export of `rusqlite::Transaction` so downstream crates (e.g.

--- a/crates/scitadel-db/src/sqlite/paper_tags.rs
+++ b/crates/scitadel-db/src/sqlite/paper_tags.rs
@@ -1,0 +1,204 @@
+//! Paper-level tags (#162 — keyword-only Zotero imports).
+//!
+//! Stores free-form tags attached to a paper. Mirrors the shape of
+//! `paper_aliases` (#134 / migration 011): `(paper_id, value)` PK,
+//! `source` audit column, idempotent `record`, ordered `list_for`.
+//! See migration 012 for schema rationale — keyword-only Zotero
+//! entries used to be dropped on the floor; this is where they land.
+
+use rusqlite::params;
+
+use crate::error::DbError;
+use crate::sqlite::Database;
+
+/// Free-form source tag recorded alongside a paper-tag row. Matches
+/// the alias counterpart so audit queries can grep by source across
+/// both tables. Re-declared here for symmetry with `paper_aliases`.
+pub const TAG_SOURCE_BIBTEX_IMPORT: &str = "bibtex-import";
+
+#[derive(Clone)]
+pub struct SqlitePaperTagRepository {
+    db: Database,
+}
+
+impl SqlitePaperTagRepository {
+    pub fn new(db: Database) -> Self {
+        Self { db }
+    }
+
+    /// Record a tag. Idempotent on `(paper_id, tag)` — re-running an
+    /// import that already added the tag is a no-op. Returns `true`
+    /// if a new row was inserted, `false` if it already existed.
+    pub fn record(&self, paper_id: &str, tag: &str, source: &str) -> Result<bool, DbError> {
+        let conn = self.db.conn()?;
+        let rows = conn.execute(
+            "INSERT OR IGNORE INTO paper_tags (paper_id, tag, source, created_at)
+             VALUES (?1, ?2, ?3, ?4)",
+            params![paper_id, tag, source, chrono::Utc::now().to_rfc3339()],
+        )?;
+        Ok(rows > 0)
+    }
+
+    /// Transactional sibling of [`Self::record`] (#157). Used by the
+    /// bib-import orchestrator so paper-save + alias / annotation /
+    /// tag writes commit (or roll back) as a single unit per row.
+    pub fn record_in_tx(
+        tx: &rusqlite::Transaction<'_>,
+        paper_id: &str,
+        tag: &str,
+        source: &str,
+    ) -> Result<bool, DbError> {
+        let rows = tx.execute(
+            "INSERT OR IGNORE INTO paper_tags (paper_id, tag, source, created_at)
+             VALUES (?1, ?2, ?3, ?4)",
+            params![paper_id, tag, source, chrono::Utc::now().to_rfc3339()],
+        )?;
+        Ok(rows > 0)
+    }
+
+    /// All tags for a paper, in insertion order. Returned as
+    /// `(tag, source)` so callers can distinguish bibtex-import-
+    /// originated tags from manually-added ones.
+    pub fn list_for(&self, paper_id: &str) -> Result<Vec<(String, String)>, DbError> {
+        let conn = self.db.conn()?;
+        let mut stmt = conn.prepare(
+            "SELECT tag, source FROM paper_tags
+             WHERE paper_id = ?1
+             ORDER BY created_at ASC, tag ASC",
+        )?;
+        let rows = stmt.query_map(params![paper_id], |r| {
+            Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?))
+        })?;
+        Ok(rows.filter_map(Result::ok).collect())
+    }
+
+    /// Tag names only, in insertion order. Convenience for the export
+    /// path which only needs the strings (no source metadata).
+    pub fn tags_for(&self, paper_id: &str) -> Result<Vec<String>, DbError> {
+        Ok(self
+            .list_for(paper_id)?
+            .into_iter()
+            .map(|(t, _)| t)
+            .collect())
+    }
+
+    /// All paper IDs carrying a tag, in deterministic order. Mirrors
+    /// `SqlitePaperAliasRepository::lookup_all` so a future "filter by
+    /// tag" UI can pick this up without a new method.
+    pub fn lookup_all(&self, tag: &str) -> Result<Vec<String>, DbError> {
+        let conn = self.db.conn()?;
+        let mut stmt = conn.prepare(
+            "SELECT paper_id FROM paper_tags
+             WHERE tag = ?1
+             ORDER BY created_at ASC, paper_id ASC",
+        )?;
+        let rows = stmt.query_map(params![tag], |r| r.get::<_, String>(0))?;
+        Ok(rows.filter_map(Result::ok).collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fresh() -> SqlitePaperTagRepository {
+        let db = Database::open_in_memory().unwrap();
+        db.migrate().unwrap();
+        let conn = db.conn().unwrap();
+        for id in ["p1", "p2"] {
+            conn.execute(
+                "INSERT INTO papers (id, title, created_at, updated_at)
+                 VALUES (?1, 'T', datetime('now'), datetime('now'))",
+                params![id],
+            )
+            .unwrap();
+        }
+        drop(conn);
+        SqlitePaperTagRepository::new(db)
+    }
+
+    #[test]
+    fn record_and_list_round_trip() {
+        let repo = fresh();
+        assert!(
+            repo.record("p1", "machine-learning", TAG_SOURCE_BIBTEX_IMPORT)
+                .unwrap()
+        );
+        let tags = repo.list_for("p1").unwrap();
+        assert_eq!(tags.len(), 1);
+        assert_eq!(tags[0].0, "machine-learning");
+        assert_eq!(tags[0].1, TAG_SOURCE_BIBTEX_IMPORT);
+    }
+
+    #[test]
+    fn record_is_idempotent_on_paper_id_tag() {
+        let repo = fresh();
+        assert!(
+            repo.record("p1", "alpha", TAG_SOURCE_BIBTEX_IMPORT)
+                .unwrap()
+        );
+        assert!(
+            !repo
+                .record("p1", "alpha", TAG_SOURCE_BIBTEX_IMPORT)
+                .unwrap(),
+            "second insert returns false"
+        );
+        assert_eq!(repo.list_for("p1").unwrap().len(), 1);
+    }
+
+    #[test]
+    fn same_tag_can_attach_to_two_different_papers() {
+        let repo = fresh();
+        assert!(
+            repo.record("p1", "shared", TAG_SOURCE_BIBTEX_IMPORT)
+                .unwrap()
+        );
+        assert!(
+            repo.record("p2", "shared", TAG_SOURCE_BIBTEX_IMPORT)
+                .unwrap()
+        );
+        let papers = repo.lookup_all("shared").unwrap();
+        assert_eq!(papers.len(), 2);
+        assert!(papers.contains(&"p1".to_string()));
+        assert!(papers.contains(&"p2".to_string()));
+    }
+
+    #[test]
+    fn cascade_delete_removes_orphan_tags() {
+        let repo = fresh();
+        repo.record("p1", "k1", TAG_SOURCE_BIBTEX_IMPORT).unwrap();
+        repo.record("p1", "k2", TAG_SOURCE_BIBTEX_IMPORT).unwrap();
+        {
+            let conn = repo.db.conn().unwrap();
+            conn.execute("DELETE FROM papers WHERE id = 'p1'", [])
+                .unwrap();
+        }
+        assert!(repo.list_for("p1").unwrap().is_empty());
+        assert!(repo.lookup_all("k1").unwrap().is_empty());
+    }
+
+    #[test]
+    fn list_for_preserves_insertion_order() {
+        let repo = fresh();
+        repo.record("p1", "first", TAG_SOURCE_BIBTEX_IMPORT)
+            .unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        repo.record("p1", "second", "manual").unwrap();
+        let tags = repo.list_for("p1").unwrap();
+        assert_eq!(tags.len(), 2);
+        assert_eq!(tags[0].0, "first");
+        assert_eq!(tags[0].1, TAG_SOURCE_BIBTEX_IMPORT);
+        assert_eq!(tags[1].0, "second");
+        assert_eq!(tags[1].1, "manual");
+    }
+
+    #[test]
+    fn tags_for_returns_strings_only() {
+        let repo = fresh();
+        repo.record("p1", "alpha", TAG_SOURCE_BIBTEX_IMPORT)
+            .unwrap();
+        repo.record("p1", "beta", TAG_SOURCE_BIBTEX_IMPORT).unwrap();
+        let tags = repo.tags_for("p1").unwrap();
+        assert_eq!(tags, vec!["alpha".to_string(), "beta".to_string()]);
+    }
+}

--- a/crates/scitadel-export/src/bibtex.rs
+++ b/crates/scitadel-export/src/bibtex.rs
@@ -31,8 +31,26 @@ pub const KEY_ALGO_HASH: &str = "1a7e0b9c2f8d6a4b3e5c9d8f7b6a5c4d3e2f1a0b9c8d7e6
 /// citation key (uses the paper's persisted `bibtex_key` when present,
 /// else regenerates it — but the caller is expected to have backfilled
 /// before calling this).
+///
+/// Emits no `keywords=` field. Use [`export_bibtex_with_tags`] when
+/// you have access to the `paper_tags` repo and want round-trip
+/// preservation of Zotero keyword-only entries (#162).
 #[must_use]
 pub fn export_bibtex(papers: &[Paper]) -> String {
+    export_bibtex_with_tags(papers, |_| Vec::new())
+}
+
+/// Same as [`export_bibtex`] but emits a `keywords = {a, b, c}` field
+/// per paper using `tags_for(paper_id)`. Tags are written in the
+/// order returned by the lookup; the export remains deterministic
+/// when the lookup is deterministic (the SQLite repo orders by
+/// `created_at ASC, tag ASC`). Empty tag lists emit no field, so the
+/// output is byte-identical to [`export_bibtex`] when no paper has
+/// tags — preserving the round-trip invariant for non-#162 callers.
+pub fn export_bibtex_with_tags<F>(papers: &[Paper], mut tags_for: F) -> String
+where
+    F: FnMut(&str) -> Vec<String>,
+{
     let mut owned: Vec<(String, &Paper)> = papers
         .iter()
         .map(|p| {
@@ -54,7 +72,8 @@ pub fn export_bibtex(papers: &[Paper]) -> String {
         if i > 0 {
             out.push('\n');
         }
-        out.push_str(&paper_to_entry(key, paper));
+        let tags = tags_for(paper.id.as_str());
+        out.push_str(&paper_to_entry(key, paper, &tags));
     }
     out
 }
@@ -87,7 +106,7 @@ pub fn backfill_keys<S: std::hash::BuildHasher>(
     out
 }
 
-fn paper_to_entry(key: &str, paper: &Paper) -> String {
+fn paper_to_entry(key: &str, paper: &Paper, tags: &[String]) -> String {
     let mut fields: Vec<String> = Vec::new();
     fields.push(fmt_field("title", &paper.title));
     if !paper.authors.is_empty() {
@@ -111,6 +130,13 @@ fn paper_to_entry(key: &str, paper: &Paper) -> String {
     }
     if !paper.r#abstract.is_empty() {
         fields.push(fmt_field("abstract", &paper.r#abstract));
+    }
+    if !tags.is_empty() {
+        // Comma-separated, preserving caller-supplied order.
+        // The SQLite repo (`SqlitePaperTagRepository::tags_for`)
+        // returns deterministic order, so the export stays
+        // byte-stable across runs.
+        fields.push(fmt_field("keywords", &tags.join(", ")));
     }
     format!("@article{{{key},\n{}\n}}\n", fields.join(",\n"))
 }
@@ -193,6 +219,26 @@ mod tests {
         assert!(out.starts_with("% scitadel"));
         assert!(out.contains("algo_hash="));
         assert!(!out.contains("generated at"));
+    }
+
+    #[test]
+    fn export_with_tags_emits_keywords_field() {
+        let mut p = paper("Test", &["Anon"], Some(2024));
+        p.bibtex_key = Some("anon2024test".into());
+        let out = export_bibtex_with_tags(&[p], |_| vec!["alpha".to_string(), "beta".to_string()]);
+        assert!(out.contains("keywords = {alpha, beta}"), "got: {out}");
+    }
+
+    #[test]
+    fn export_with_empty_tags_is_byte_identical_to_plain_export() {
+        let mut p = paper("Same", &["Anon"], Some(2024));
+        p.bibtex_key = Some("anon2024same".into());
+        let plain = export_bibtex(std::slice::from_ref(&p));
+        let with_empty = export_bibtex_with_tags(&[p], |_| Vec::new());
+        assert_eq!(
+            plain, with_empty,
+            "no-tags lookup must preserve the round-trip invariant"
+        );
     }
 
     #[test]

--- a/crates/scitadel-export/src/import/mod.rs
+++ b/crates/scitadel-export/src/import/mod.rs
@@ -19,4 +19,6 @@ pub mod side_effects;
 pub use matcher::{MatchOutcome, MatchStrategy, PaperLookup, match_entry};
 pub use merge::{MergeAction, MergeOutcome, MergeStrategy, paper_from_bib, resolve};
 pub use parse::{BibEntry, ParseError, parse_bibtex};
-pub use side_effects::{ALIAS_SOURCE, AliasRecord, SideEffects, compute as compute_side_effects};
+pub use side_effects::{
+    ALIAS_SOURCE, AliasRecord, SideEffects, TAG_SOURCE, TagRecord, compute as compute_side_effects,
+};

--- a/crates/scitadel-export/src/import/side_effects.rs
+++ b/crates/scitadel-export/src/import/side_effects.rs
@@ -1,14 +1,15 @@
 //! Zotero compat — non-row work that follows a successful import
-//! resolution (#134 step 4):
+//! resolution (#134 step 4 + #162):
 //!
 //! - `note={...}` → an unanchored [`Annotation`] (paper-level), with
 //!   the bib's `keywords={a,b,c}` carried as the annotation's tags.
 //!   Author is the import-time `reader`, matching the convention used
 //!   for TUI / MCP annotation writes.
-//! - `keywords=` *without* a `note=` are surfaced for `--verbose`
-//!   logging — paper-level tags don't exist as first-class data yet
-//!   (a tracked gap; a follow-up issue would add a `paper_tags`
-//!   table). Dropping silently would lose user data without warning.
+//! - `keywords=` *without* a `note=` → paper-level tag rows on
+//!   `paper_tags` (#162). Earlier behavior surfaced these as
+//!   `dropped_keywords` under `--verbose` because paper-tags didn't
+//!   exist as first-class data — they do now, so the data is no
+//!   longer dropped on the floor.
 //! - `file={...}` is always surfaced for `--verbose` logging — the
 //!   issue spec deliberately drops these, since paths in someone
 //!   else's Zotero export are meaningless on the importer's machine.
@@ -29,10 +30,23 @@ use super::parse::BibEntry;
 /// `scitadel-db` dependency.
 pub const ALIAS_SOURCE: &str = "bibtex-import";
 
+/// `source` value recorded on `paper_tags` rows that originate here —
+/// mirrors `scitadel_db::sqlite::TAG_SOURCE_BIBTEX_IMPORT` for the
+/// same dep-cycle reason as [`ALIAS_SOURCE`]. Same string value: the
+/// audit columns are deliberately uniform across the two tables.
+pub const TAG_SOURCE: &str = "bibtex-import";
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AliasRecord {
     pub paper_id: String,
     pub alias: String,
+    pub source: &'static str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TagRecord {
+    pub paper_id: String,
+    pub tag: String,
     pub source: &'static str,
 }
 
@@ -44,10 +58,11 @@ pub struct SideEffects {
     /// `note=` carrying user's reading context. Built unanchored
     /// (paper-level), with `bib.keywords` attached as tags.
     pub annotation: Option<Annotation>,
-    /// `keywords=` we couldn't attach to anything because there was
-    /// no `note=` to anchor them on. Surface in `--verbose` so the
-    /// user knows their tags didn't make it.
-    pub dropped_keywords: Vec<String>,
+    /// `keywords=` from a note-less entry — written to `paper_tags`
+    /// rather than dropped (#162). Empty when keywords rode along on
+    /// an annotation, when there were none, or when the action was
+    /// `Rejected`.
+    pub paper_tags: Vec<TagRecord>,
     /// `file=` paths — never imported (paths from a foreign machine
     /// are meaningless), but surfaced in `--verbose`.
     pub dropped_file: Option<String>,
@@ -60,7 +75,7 @@ impl SideEffects {
         Self {
             alias: None,
             annotation: None,
-            dropped_keywords: vec![],
+            paper_tags: vec![],
             dropped_file: None,
         }
     }
@@ -70,7 +85,7 @@ impl SideEffects {
     pub fn is_empty(&self) -> bool {
         self.alias.is_none()
             && self.annotation.is_none()
-            && self.dropped_keywords.is_empty()
+            && self.paper_tags.is_empty()
             && self.dropped_file.is_none()
     }
 }
@@ -89,7 +104,9 @@ pub fn compute(paper_id: &str, reader: &str, bib: &BibEntry, action: MergeAction
         source: ALIAS_SOURCE,
     });
 
-    let (annotation, dropped_keywords) = match bib.note.as_deref() {
+    // keywords-with-note → annotation tags (existing behavior).
+    // keywords-without-note → paper_tags rows (#162 — the fix).
+    let (annotation, paper_tags) = match bib.note.as_deref() {
         Some(note) if !note.is_empty() => {
             // Synthetic `sentence_id` so the resolver recognizes this
             // as an unanchored import on first open instead of flipping
@@ -109,13 +126,24 @@ pub fn compute(paper_id: &str, reader: &str, bib: &BibEntry, action: MergeAction
             a.tags.clone_from(&bib.keywords);
             (Some(a), vec![])
         }
-        _ => (None, bib.keywords.clone()),
+        _ => {
+            let tags = bib
+                .keywords
+                .iter()
+                .map(|k| TagRecord {
+                    paper_id: paper_id.to_string(),
+                    tag: k.clone(),
+                    source: TAG_SOURCE,
+                })
+                .collect();
+            (None, tags)
+        }
     };
 
     SideEffects {
         alias,
         annotation,
-        dropped_keywords,
+        paper_tags,
         dropped_file: bib.file.clone(),
     }
 }
@@ -224,16 +252,24 @@ mod tests {
         let se = compute("p1", "lars", &b, MergeAction::Updated);
         let a = se.annotation.unwrap();
         assert_eq!(a.tags, vec!["alpha", "beta"]);
-        assert!(se.dropped_keywords.is_empty());
+        assert!(
+            se.paper_tags.is_empty(),
+            "keywords riding on annotation must not also write paper-tag rows"
+        );
     }
 
     #[test]
-    fn keywords_without_note_are_dropped_for_verbose_log() {
+    fn keywords_without_note_become_paper_tags() {
         let mut b = bib("k");
         b.keywords = vec!["alpha".into(), "beta".into()];
         let se = compute("p1", "lars", &b, MergeAction::Updated);
         assert!(se.annotation.is_none());
-        assert_eq!(se.dropped_keywords, vec!["alpha", "beta"]);
+        let tags: Vec<&str> = se.paper_tags.iter().map(|t| t.tag.as_str()).collect();
+        assert_eq!(tags, vec!["alpha", "beta"]);
+        for t in &se.paper_tags {
+            assert_eq!(t.paper_id, "p1");
+            assert_eq!(t.source, TAG_SOURCE);
+        }
     }
 
     #[test]
@@ -246,7 +282,8 @@ mod tests {
             se.annotation.is_none(),
             "empty note string must not produce an empty-content annotation"
         );
-        assert_eq!(se.dropped_keywords, vec!["x"]);
+        let tags: Vec<&str> = se.paper_tags.iter().map(|t| t.tag.as_str()).collect();
+        assert_eq!(tags, vec!["x"]);
     }
 
     #[test]
@@ -262,7 +299,16 @@ mod tests {
         let se = compute("p1", "lars", &bib("k"), MergeAction::Updated);
         assert!(se.alias.is_some());
         assert!(se.annotation.is_none());
-        assert!(se.dropped_keywords.is_empty());
+        assert!(se.paper_tags.is_empty());
         assert!(se.dropped_file.is_none());
+    }
+
+    #[test]
+    fn rejected_action_skips_paper_tags_too() {
+        let mut b = bib("k");
+        b.keywords = vec!["should-not-land".into()];
+        let se = compute("p1", "lars", &b, MergeAction::Rejected);
+        assert!(se.is_empty());
+        assert!(se.paper_tags.is_empty());
     }
 }

--- a/crates/scitadel-export/src/lib.rs
+++ b/crates/scitadel-export/src/lib.rs
@@ -3,7 +3,7 @@ pub mod csv_export;
 pub mod import;
 pub mod json_export;
 
-pub use bibtex::export_bibtex;
+pub use bibtex::{export_bibtex, export_bibtex_with_tags};
 pub use csv_export::export_csv;
 pub use import::{
     ALIAS_SOURCE, AliasRecord, BibEntry, MatchOutcome, MatchStrategy, MergeAction, MergeOutcome,

--- a/crates/scitadel-mcp/src/bib_import.rs
+++ b/crates/scitadel-mcp/src/bib_import.rs
@@ -16,6 +16,8 @@
 //!    the next import's match cascade.
 //! 2. Record the imported citekey on `paper_aliases`.
 //! 3. Save the unanchored annotation built from `note=` (if any).
+//! 4. Record paper-level tags from `keywords=` when there's no
+//!    `note=` to anchor them on (#162).
 //!
 //! All three writes are wrapped in a single per-row SQLite transaction
 //! (#157) so a mid-row failure can never strand an orphaned `papers`
@@ -35,7 +37,7 @@ use scitadel_core::ports::PaperRepository;
 use scitadel_db::error::DbError;
 use scitadel_db::sqlite::{
     SqliteAnnotationRepository, SqlitePaperAliasRepository, SqlitePaperRepository,
-    SqliteTransaction,
+    SqlitePaperTagRepository, SqliteTransaction,
 };
 use scitadel_export::import::{
     BibEntry, MatchOutcome, MergeAction, MergeStrategy, PaperLookup, SideEffects,
@@ -51,7 +53,10 @@ pub struct ImportRow {
     pub from_bib: Vec<&'static str>,
     pub kept_from_db: Vec<&'static str>,
     pub annotation_created: bool,
-    pub dropped_keywords: Vec<String>,
+    /// Paper-tag values written for this row (#162). Empty when
+    /// keywords rode along on an annotation, when there were none,
+    /// or when the action was `Rejected`.
+    pub paper_tags_written: Vec<String>,
     pub dropped_file: Option<String>,
 }
 
@@ -185,17 +190,21 @@ pub fn import_bibtex_str(
     papers: &SqlitePaperRepository,
     aliases: &SqlitePaperAliasRepository,
     annotations: &SqliteAnnotationRepository,
+    tags: &SqlitePaperTagRepository,
 ) -> Result<ImportReport, CoreError> {
     let entries =
         parse_bibtex(src).map_err(|e| CoreError::Adapter("bib-import".into(), e.to_string()))?;
     let lookup = SqliteBibLookup { papers, aliases };
     let mut report = ImportReport::default();
 
-    // `annotations` is unused below — the per-row tx grabs a connection
-    // from `papers.db()` and calls `SqliteAnnotationRepository::create_in_tx`
-    // statically. Kept on the outer signature so callers (CLI, MCP) don't
-    // need to change construction order (#157).
+    // `annotations` and `tags` are unused below — the per-row tx grabs
+    // a connection from `papers.db()` and calls
+    // `SqliteAnnotationRepository::create_in_tx` /
+    // `SqlitePaperTagRepository::record_in_tx` statically. Kept on the
+    // outer signature so callers (CLI, MCP) don't need to change
+    // construction order (#157, #162).
     let _ = annotations;
+    let _ = tags;
 
     for entry in entries {
         match import_one(&entry, options, &lookup, papers) {
@@ -217,9 +226,10 @@ pub fn import_bibtex_file(
     papers: &SqlitePaperRepository,
     aliases: &SqlitePaperAliasRepository,
     annotations: &SqliteAnnotationRepository,
+    tags: &SqlitePaperTagRepository,
 ) -> Result<ImportReport, CoreError> {
     let src = std::fs::read_to_string(path)?;
-    import_bibtex_str(&src, options, papers, aliases, annotations)
+    import_bibtex_str(&src, options, papers, aliases, annotations, tags)
 }
 
 /// Assign and persist a stable `bibtex_key` for a newly-saved paper
@@ -340,11 +350,13 @@ fn import_one(
         },
     };
 
-    let (annotation_created, dropped_keywords, dropped_file) = if let Some(pid) = &persisted_id {
+    // 4. Side effects (alias / annotation / paper-tags / verbose-log
+    //    items) — only when we have a paper to attach them to.
+    let (annotation_created, paper_tags_written, dropped_file) = if let Some(pid) = &persisted_id {
         let SideEffects {
             alias,
             annotation,
-            dropped_keywords,
+            paper_tags,
             dropped_file,
         } = compute_side_effects(pid, &options.reader, entry, merge.action);
         if let Some(a) = alias {
@@ -357,7 +369,13 @@ fn import_one(
         } else {
             false
         };
-        (created, dropped_keywords, dropped_file)
+        let mut written = Vec::with_capacity(paper_tags.len());
+        for t in &paper_tags {
+            SqlitePaperTagRepository::record_in_tx(&tx, &t.paper_id, &t.tag, t.source)
+                .map_err(CoreError::from)?;
+            written.push(t.tag.clone());
+        }
+        (created, written, dropped_file)
     } else {
         (false, vec![], None)
     };
@@ -373,7 +391,7 @@ fn import_one(
         from_bib: merge.from_bib,
         kept_from_db: merge.kept_from_db,
         annotation_created,
-        dropped_keywords,
+        paper_tags_written,
         dropped_file,
     })
 }
@@ -388,13 +406,15 @@ mod tests {
         SqlitePaperRepository,
         SqlitePaperAliasRepository,
         SqliteAnnotationRepository,
+        SqlitePaperTagRepository,
     ) {
         let db = Database::open_in_memory().unwrap();
         db.migrate().unwrap();
         (
             SqlitePaperRepository::new(db.clone()),
             SqlitePaperAliasRepository::new(db.clone()),
-            SqliteAnnotationRepository::new(db),
+            SqliteAnnotationRepository::new(db.clone()),
+            SqlitePaperTagRepository::new(db),
         )
     }
 
@@ -415,15 +435,22 @@ mod tests {
     /// for every Created paper.
     #[test]
     fn imported_new_paper_gets_persisted_bibtex_key() {
-        let (papers, aliases, annotations) = fresh();
+        let (papers, aliases, annotations, tags) = fresh();
         let src = r"
 @article{ignored2025x,
     title = {Bibtex Key Persistence Test},
     author = {Smith, John},
     year = {2025}
 }";
-        let report =
-            import_bibtex_str(src, &opts_merge("lars"), &papers, &aliases, &annotations).unwrap();
+        let report = import_bibtex_str(
+            src,
+            &opts_merge("lars"),
+            &papers,
+            &aliases,
+            &annotations,
+            &tags,
+        )
+        .unwrap();
         let pid = report.rows[0].paper_id.as_deref().unwrap();
         let p = papers.get(pid).unwrap().unwrap();
         assert!(
@@ -438,7 +465,7 @@ mod tests {
     /// title-year hit) must still resolve to the existing paper.
     #[test]
     fn round_trip_resolves_via_bibtex_key_step_when_other_ids_absent() {
-        let (papers, aliases, annotations) = fresh();
+        let (papers, aliases, annotations, tags) = fresh();
         // Seed a paper with a known bibtex_key and no external ids.
         let mut p = Paper::new("Cascade Anchor");
         p.authors = vec!["Anchor, A".into()];
@@ -459,8 +486,15 @@ mod tests {
     title = {Different Title For Cascade Probe},
     year = {1900}
 }";
-        let report =
-            import_bibtex_str(src, &opts_merge("lars"), &papers, &aliases, &annotations).unwrap();
+        let report = import_bibtex_str(
+            src,
+            &opts_merge("lars"),
+            &papers,
+            &aliases,
+            &annotations,
+            &tags,
+        )
+        .unwrap();
         let row = &report.rows[0];
         assert_eq!(
             row.action,
@@ -472,7 +506,7 @@ mod tests {
 
     #[test]
     fn unmatched_entry_creates_new_paper_with_alias() {
-        let (papers, aliases, annotations) = fresh();
+        let (papers, aliases, annotations, tags) = fresh();
         let src = r"
 @article{novel2025widget,
     title = {A Novel Widget},
@@ -480,8 +514,15 @@ mod tests {
     year = {2025},
     doi = {10.1/widget}
 }";
-        let report =
-            import_bibtex_str(src, &opts_merge("lars"), &papers, &aliases, &annotations).unwrap();
+        let report = import_bibtex_str(
+            src,
+            &opts_merge("lars"),
+            &papers,
+            &aliases,
+            &annotations,
+            &tags,
+        )
+        .unwrap();
         assert_eq!(report.rows.len(), 1);
         let row = &report.rows[0];
         assert_eq!(row.action, MergeAction::Created);
@@ -493,7 +534,7 @@ mod tests {
 
     #[test]
     fn doi_matched_entry_under_merge_leaves_db_paper_unchanged() {
-        let (papers, aliases, annotations) = fresh();
+        let (papers, aliases, annotations, tags) = fresh();
         let mut existing = Paper::new("Existing Title");
         existing.doi = Some("10.1/x".into());
         existing.year = Some(2020);
@@ -507,8 +548,15 @@ mod tests {
     year = {2024},
     doi = {10.1/X}
 }";
-        let report =
-            import_bibtex_str(src, &opts_merge("lars"), &papers, &aliases, &annotations).unwrap();
+        let report = import_bibtex_str(
+            src,
+            &opts_merge("lars"),
+            &papers,
+            &aliases,
+            &annotations,
+            &tags,
+        )
+        .unwrap();
         let row = &report.rows[0];
         assert_eq!(row.action, MergeAction::Unchanged);
 
@@ -522,7 +570,7 @@ mod tests {
 
     #[test]
     fn note_field_creates_annotation_under_reader_identity() {
-        let (papers, aliases, annotations) = fresh();
+        let (papers, aliases, annotations, tags) = fresh();
         let src = r"
 @article{withNote,
     title = {Some Paper},
@@ -530,8 +578,15 @@ mod tests {
     year = {2024},
     note = {Skim showed weak methods}
 }";
-        let report =
-            import_bibtex_str(src, &opts_merge("lars"), &papers, &aliases, &annotations).unwrap();
+        let report = import_bibtex_str(
+            src,
+            &opts_merge("lars"),
+            &papers,
+            &aliases,
+            &annotations,
+            &tags,
+        )
+        .unwrap();
         let row = &report.rows[0];
         assert!(row.annotation_created);
 
@@ -553,7 +608,7 @@ mod tests {
     fn round_trip_export_then_import_touches_zero_rows() {
         use scitadel_export::export_bibtex;
 
-        let (papers, aliases, annotations) = fresh();
+        let (papers, aliases, annotations, tags) = fresh();
         let mut p1 = Paper::new("Quantum Advantage");
         p1.authors = vec!["Smith, John".into()];
         p1.year = Some(2024);
@@ -584,9 +639,15 @@ mod tests {
         // aliases for the seeded papers' citekeys. Result must report
         // every row as Unchanged (the cascade resolves via DOI / arxiv
         // / title-year and the merge strategy is db-wins under Merge).
-        let report1 =
-            import_bibtex_str(&bib_a, &opts_merge("lars"), &papers, &aliases, &annotations)
-                .unwrap();
+        let report1 = import_bibtex_str(
+            &bib_a,
+            &opts_merge("lars"),
+            &papers,
+            &aliases,
+            &annotations,
+            &tags,
+        )
+        .unwrap();
         assert!(report1.failed.is_empty());
         for row in &report1.rows {
             assert_eq!(row.action, MergeAction::Unchanged);
@@ -611,9 +672,15 @@ mod tests {
         // Second import: the actual round-trip test. Must touch zero
         // rows in any table (paper_aliases is the canary against
         // accidental duplicate-row inflation).
-        let report2 =
-            import_bibtex_str(&bib_a, &opts_merge("lars"), &papers, &aliases, &annotations)
-                .unwrap();
+        let report2 = import_bibtex_str(
+            &bib_a,
+            &opts_merge("lars"),
+            &papers,
+            &aliases,
+            &annotations,
+            &tags,
+        )
+        .unwrap();
         assert!(report2.failed.is_empty());
         assert_eq!(report2.rows.len(), 3);
         for row in &report2.rows {
@@ -658,7 +725,7 @@ mod tests {
     /// `report.failed` with all candidate paper IDs.
     #[test]
     fn ambiguous_alias_is_a_per_row_failure_not_a_silent_create() {
-        let (papers, aliases, annotations) = fresh();
+        let (papers, aliases, annotations, tags) = fresh();
 
         // Two papers that legitimately share a citekey "smith2024"
         // (e.g. two distinct .bib files were both imported earlier
@@ -687,8 +754,15 @@ mod tests {
     title = {Some Other Title Entirely},
     year = {1999}
 }";
-        let report =
-            import_bibtex_str(src, &opts_merge("lars"), &papers, &aliases, &annotations).unwrap();
+        let report = import_bibtex_str(
+            src,
+            &opts_merge("lars"),
+            &papers,
+            &aliases,
+            &annotations,
+            &tags,
+        )
+        .unwrap();
 
         assert!(
             report.rows.is_empty(),
@@ -722,7 +796,7 @@ mod tests {
     /// zero after rollback.
     #[test]
     fn per_row_tx_rolls_back_when_alias_record_fails() {
-        let (papers, aliases, _annotations) = fresh();
+        let (papers, aliases, _annotations, _tags) = fresh();
         let mut p = Paper::new("Will Be Rolled Back");
         p.year = Some(2026);
 
@@ -794,7 +868,7 @@ mod tests {
             }
         }
 
-        let (papers, aliases, annotations) = fresh();
+        let (papers, aliases, annotations, tags) = fresh();
         let mut p1 = Paper::new("First Paper");
         p1.year = Some(2024);
         let mut p2 = Paper::new("Second Paper");
@@ -823,7 +897,8 @@ mod tests {
     title = {Some Other Title Entirely},
     year = {1999}
 }";
-        let report = import_bibtex_str(src, &options, &papers, &aliases, &annotations).unwrap();
+        let report =
+            import_bibtex_str(src, &options, &papers, &aliases, &annotations, &tags).unwrap();
 
         assert!(
             report.failed.is_empty(),
@@ -843,7 +918,7 @@ mod tests {
     /// flipping the strategy.
     #[test]
     fn interactive_strategy_without_resolver_falls_back_to_validation_failure() {
-        let (papers, aliases, annotations) = fresh();
+        let (papers, aliases, annotations, tags) = fresh();
         let mut p1 = Paper::new("First Paper");
         p1.year = Some(2024);
         let mut p2 = Paper::new("Second Paper");
@@ -869,7 +944,8 @@ mod tests {
     title = {Some Other Title Entirely},
     year = {1999}
 }";
-        let report = import_bibtex_str(src, &options, &papers, &aliases, &annotations).unwrap();
+        let report =
+            import_bibtex_str(src, &options, &papers, &aliases, &annotations, &tags).unwrap();
         assert!(report.rows.is_empty());
         assert_eq!(report.failed.len(), 1);
         assert!(report.failed[0].1.contains("ambiguous alias"));
@@ -877,7 +953,7 @@ mod tests {
 
     #[test]
     fn lenient_run_continues_past_a_malformed_row() {
-        let (papers, aliases, annotations) = fresh();
+        let (papers, aliases, annotations, tags) = fresh();
         // Second entry lacks closing brace — biblatex parse fails on
         // the whole document. We simulate per-row failure differently:
         // give the second entry a known shape but ensure import
@@ -891,9 +967,195 @@ mod tests {
 @article{b, title = {B}, year = {2002}}
 @article{c, title = {C}, year = {2003}}
 ";
-        let report =
-            import_bibtex_str(src, &opts_merge("lars"), &papers, &aliases, &annotations).unwrap();
+        let report = import_bibtex_str(
+            src,
+            &opts_merge("lars"),
+            &papers,
+            &aliases,
+            &annotations,
+            &tags,
+        )
+        .unwrap();
         assert_eq!(report.rows.len(), 3);
         assert!(report.failed.is_empty());
+    }
+
+    /// #162 acceptance #1: a Zotero `.bib` entry with `keywords=` but
+    /// no `note=` must land its keywords as `paper_tags` rows rather
+    /// than dropping them on the floor.
+    #[test]
+    fn keyword_only_zotero_entry_writes_paper_tags() {
+        let (papers, aliases, annotations, tags) = fresh();
+        let src = r"
+@article{tagged2025widget,
+    title = {Tagged But Unannotated},
+    author = {Smith, John},
+    year = {2025},
+    keywords = {machine-learning, robotics, to-read}
+}";
+        let report = import_bibtex_str(
+            src,
+            &opts_merge("lars"),
+            &papers,
+            &aliases,
+            &annotations,
+            &tags,
+        )
+        .unwrap();
+        assert_eq!(report.rows.len(), 1);
+        let row = &report.rows[0];
+        assert_eq!(row.action, MergeAction::Created);
+        assert!(
+            !row.annotation_created,
+            "no note → no annotation; keywords belong on paper_tags"
+        );
+        assert_eq!(
+            row.paper_tags_written,
+            vec![
+                "machine-learning".to_string(),
+                "robotics".to_string(),
+                "to-read".to_string(),
+            ],
+        );
+
+        // Read-back through the repo confirms persistence.
+        let pid = row.paper_id.as_deref().unwrap();
+        let stored = tags.tags_for(pid).unwrap();
+        assert_eq!(stored.len(), 3);
+        assert!(stored.contains(&"machine-learning".to_string()));
+        assert!(stored.contains(&"robotics".to_string()));
+        assert!(stored.contains(&"to-read".to_string()));
+    }
+
+    /// #162: keywords-with-note path is unchanged — annotation gets
+    /// the tags, paper_tags table stays empty for that row.
+    #[test]
+    fn keywords_with_note_still_ride_on_annotation_not_paper_tags() {
+        let (papers, aliases, annotations, tags) = fresh();
+        let src = r"
+@article{withBoth,
+    title = {Annotated And Tagged},
+    year = {2025},
+    note = {Re-read carefully},
+    keywords = {physics, follow-up}
+}";
+        let report = import_bibtex_str(
+            src,
+            &opts_merge("lars"),
+            &papers,
+            &aliases,
+            &annotations,
+            &tags,
+        )
+        .unwrap();
+        let row = &report.rows[0];
+        assert!(row.annotation_created);
+        assert!(
+            row.paper_tags_written.is_empty(),
+            "keywords ride on the annotation, not paper_tags"
+        );
+        let pid = row.paper_id.as_deref().unwrap();
+        assert!(tags.tags_for(pid).unwrap().is_empty());
+        let listed = annotations.list_by_paper(pid).unwrap();
+        assert_eq!(listed[0].tags, vec!["physics", "follow-up"]);
+    }
+
+    /// #162 acceptance #2: round-trip of a keyword-only entry must
+    /// re-emit the same `keywords=` field and a second import of the
+    /// already-normalized export must touch zero rows (idempotence on
+    /// `paper_tags`). Mirrors the existing
+    /// `round_trip_export_then_import_touches_zero_rows` test: the
+    /// FIRST import of `bib_a` is a legitimate normalization pass
+    /// (export rewrites the citekey to the stable bibtex_key, adding
+    /// one alias); the SECOND import is the actual no-op assertion.
+    #[test]
+    fn keyword_only_round_trip_is_byte_stable_and_idempotent() {
+        use scitadel_export::export_bibtex_with_tags;
+
+        let (papers, aliases, annotations, tags) = fresh();
+        let src = r"
+@article{tagged2025widget,
+    title = {Round Trip Tags},
+    author = {Smith, John},
+    year = {2025},
+    keywords = {alpha, beta, gamma}
+}";
+        let report0 = import_bibtex_str(
+            src,
+            &opts_merge("lars"),
+            &papers,
+            &aliases,
+            &annotations,
+            &tags,
+        )
+        .unwrap();
+        let pid = report0.rows[0].paper_id.as_deref().unwrap().to_string();
+
+        // Export with the tags lookup — keywords must round-trip.
+        let saved = vec![papers.get(&pid).unwrap().unwrap()];
+        let bib_a = export_bibtex_with_tags(&saved, |id| tags.tags_for(id).unwrap_or_default());
+        assert!(
+            bib_a.contains("keywords = {alpha, beta, gamma}"),
+            "exported bib must round-trip keywords; got:\n{bib_a}"
+        );
+
+        // First import of the exported bib: legitimate normalization
+        // — adds one alias for the rewritten (stable) citekey.
+        let report1 = import_bibtex_str(
+            &bib_a,
+            &opts_merge("lars"),
+            &papers,
+            &aliases,
+            &annotations,
+            &tags,
+        )
+        .unwrap();
+        assert!(report1.failed.is_empty());
+        for row in &report1.rows {
+            assert_eq!(row.action, MergeAction::Unchanged);
+        }
+
+        // Snapshot row counts after the first re-import: this is the
+        // "zero diff" baseline.
+        let papers_baseline = papers.list_all(100, 0).unwrap().len();
+        let tags_baseline = tags.tags_for(&pid).unwrap().len();
+        let aliases_baseline = aliases.list_for(&pid).unwrap().len();
+
+        // Second re-import: must touch zero rows in any table.
+        let report2 = import_bibtex_str(
+            &bib_a,
+            &opts_merge("lars"),
+            &papers,
+            &aliases,
+            &annotations,
+            &tags,
+        )
+        .unwrap();
+        assert!(report2.failed.is_empty());
+        for row in &report2.rows {
+            assert_eq!(
+                row.action,
+                MergeAction::Unchanged,
+                "round-trip row {} must be Unchanged on second import",
+                row.citekey,
+            );
+        }
+        assert_eq!(papers.list_all(100, 0).unwrap().len(), papers_baseline);
+        assert_eq!(
+            tags.tags_for(&pid).unwrap().len(),
+            tags_baseline,
+            "no duplicate paper_tags",
+        );
+        assert_eq!(
+            aliases.list_for(&pid).unwrap().len(),
+            aliases_baseline,
+            "no duplicate aliases",
+        );
+
+        // Re-export must be byte-identical (paper_tags ordering is
+        // stable, deterministic by the repo contract).
+        let saved2 = vec![papers.get(&pid).unwrap().unwrap()];
+        let bib_b = export_bibtex_with_tags(&saved2, |id| tags.tags_for(id).unwrap_or_default());
+        assert_eq!(bib_a, bib_b, "round-trip must be byte-identical");
     }
 }

--- a/crates/scitadel-mcp/src/tools.rs
+++ b/crates/scitadel-mcp/src/tools.rs
@@ -267,7 +267,16 @@ pub fn export_search_tool(search_id: &str, format: &str) -> Result<String, Strin
 
     match format {
         "csv" => Ok(scitadel_export::export_csv(&papers)),
-        "bibtex" => Ok(scitadel_export::export_bibtex(&papers)),
+        "bibtex" => {
+            // #162: surface paper-level tags as `keywords={…}` so a
+            // Zotero round-trip preserves keyword-only entries.
+            use scitadel_db::sqlite::SqlitePaperTagRepository;
+            let db = open_db()?;
+            let tags = SqlitePaperTagRepository::new(db);
+            Ok(scitadel_export::export_bibtex_with_tags(&papers, |id| {
+                tags.tags_for(id).unwrap_or_default()
+            }))
+        }
         // Default to JSON for unknown formats
         _ => Ok(scitadel_export::export_json(&papers, 2)),
     }
@@ -1610,6 +1619,7 @@ pub fn import_bibtex_tool(
     use crate::bib_import::{ImportOptions, import_bibtex_file};
     use scitadel_db::sqlite::{
         SqliteAnnotationRepository, SqlitePaperAliasRepository, SqlitePaperRepository,
+        SqlitePaperTagRepository,
     };
     use scitadel_export::import::MergeStrategy;
 
@@ -1623,7 +1633,8 @@ pub fn import_bibtex_tool(
     let db = open_db()?;
     let papers = SqlitePaperRepository::new(db.clone());
     let aliases = SqlitePaperAliasRepository::new(db.clone());
-    let annotations = SqliteAnnotationRepository::new(db);
+    let annotations = SqliteAnnotationRepository::new(db.clone());
+    let tags = SqlitePaperTagRepository::new(db);
 
     let options = ImportOptions {
         strategy,
@@ -1640,6 +1651,7 @@ pub fn import_bibtex_tool(
         &papers,
         &aliases,
         &annotations,
+        &tags,
     )
     .map_err(|e| e.to_string())?;
 
@@ -1659,7 +1671,7 @@ pub fn import_bibtex_tool(
                 "from_bib": r.from_bib,
                 "kept_from_db": r.kept_from_db,
                 "annotation_created": r.annotation_created,
-                "dropped_keywords": r.dropped_keywords,
+                "paper_tags_written": r.paper_tags_written,
                 "dropped_file": r.dropped_file,
             })
         })


### PR DESCRIPTION
## Summary
- New `paper_tags` table + `SqlitePaperTagRepository` mirroring the `paper_aliases` (#134) pattern — same `(paper_id, value)` PK, `source` audit column, idempotent `record`, ordered `list_for`.
- Bib import now writes paper-tag rows for Zotero keyword-only entries (`keywords=` without `note=`) instead of dropping them on the floor under `--verbose`. Keywords-with-note still ride along on annotation tags as before.
- New `export_bibtex_with_tags` overload re-emits paper-tags as `keywords = {a, b, c}` so a Zotero round-trip preserves them. CLI `bib export` and MCP `export_paper` opt in via the new repo lookup; existing callers (`export_bibtex`) stay byte-identical.

Closes #162.

## Test plan
- [x] `SqlitePaperTagRepository` unit tests (record/list/lookup_all/cascade-delete/idempotence)
- [x] `side_effects::compute` tests for both keyword branches and the rejected-action short-circuit
- [x] `import_one` integration test: keyword-only entry persists tags on `paper_tags` and read-back returns them
- [x] Round-trip test: import → export → re-import → second re-import touches zero rows on `papers`/`paper_tags`/`paper_aliases`; re-export is byte-identical
- [x] Existing #134 round-trip test still green
- [x] `just lint` clean (cargo fmt + clippy)
- [x] `cargo test --workspace --exclude scitadel-tui` passes (263 tests)
- [ ] TUI surface for tags — explicitly out of scope per issue ("separable, can defer to a follow-up")