### PR TITLE
feat(tui): theme iter 2 residuals — list-themes, init prompt, toast, docs (#137)

### DIFF
--- a/crates/scitadel-cli/src/commands.rs
+++ b/crates/scitadel-cli/src/commands.rs
@@ -43,6 +43,21 @@ pub async fn mcp() -> Result<()> {
     Ok(())
 }
 
+/// Print every theme advertised by `scitadel-tui::theme::Theme::registry`
+/// in `name — description` form. Pure stdout + exit-0 — meant as a
+/// discovery aid for `--theme` (#137).
+pub fn list_themes() -> Result<()> {
+    let entries = scitadel_tui::theme::Theme::registry();
+    let width = entries.iter().map(|(n, _)| n.len()).max().unwrap_or(0);
+    println!("Available themes (use with --theme or set ui.theme in config.toml):");
+    for (name, desc) in entries {
+        println!("  {name:<width$}  {desc}", width = width);
+    }
+    println!();
+    println!("Resolution order: --theme flag > SCITADEL_THEME env > [ui] theme in config > auto.");
+    Ok(())
+}
+
 pub fn tui(theme_override: Option<&str>) -> Result<()> {
     let config = load_config();
     let email = config.openalex.api_key.clone();
@@ -51,14 +66,17 @@ pub fn tui(theme_override: Option<&str>) -> Result<()> {
     // Resolve theme before any rendering so the very first frame uses
     // the right palette. Order: --theme > SCITADEL_THEME > ui.theme >
     // auto-detect (#137).
-    let resolved = scitadel_tui::theme::resolve(theme_override, &config.ui.theme);
+    let (resolved, label) =
+        scitadel_tui::theme::resolve_with_label(theme_override, &config.ui.theme);
     scitadel_tui::theme::init(resolved);
+    let toast = format!("theme: {label}");
     scitadel_tui::run(
         &config.db_path,
         email,
         papers_dir,
         config.ui.show_institutional_hint,
         reader,
+        Some(toast),
     )?;
     Ok(())
 }
@@ -112,8 +130,24 @@ pub fn init(opts: InitOptions) -> Result<()> {
         })
         .unwrap_or_else(|| config.default_sources.clone());
 
+    // Theme prompt (#137). Default `auto` keeps the existing dark
+    // behaviour when COLORFGBG is unset; users on light terminals get
+    // an automatically-readable palette without per-machine config.
+    let theme = if interactive {
+        let current = config.ui.theme.clone();
+        prompt_line(
+            "TUI theme (auto|light|dark|dalton-dark|dalton-light)",
+            &current,
+        )
+        .map(|s| sanitize_theme_input(&s))
+        .unwrap_or(current)
+    } else {
+        config.ui.theme.clone()
+    };
+
     config.openalex.api_key.clone_from(&email);
     config.default_sources.clone_from(&sources);
+    config.ui.theme.clone_from(&theme);
 
     let config_path = config_path_for_db(&config.db_path);
     write_config_toml(&config_path, &config)
@@ -130,6 +164,7 @@ pub fn init(opts: InitOptions) -> Result<()> {
         println!("  OA email:       {email}");
     }
     println!("  Sources:        {}", sources.join(", "));
+    println!("  Theme:          {theme}");
 
     let keyed_sources_needed: Vec<&str> = sources
         .iter()
@@ -184,6 +219,19 @@ fn prompt_line(prompt: &str, default: &str) -> Option<String> {
     }
 }
 
+/// Normalise free-form theme input from the init wizard to a value the
+/// resolver understands. Unknown strings fall back to `auto` rather
+/// than being written verbatim — `[ui] theme = "dalton-pink"` would
+/// silently fold to Auto at TUI launch anyway, and a typo in the
+/// config file is harder to debug than one caught at write time.
+fn sanitize_theme_input(s: &str) -> String {
+    let trimmed = s.trim().to_ascii_lowercase();
+    match trimmed.as_str() {
+        "auto" | "dark" | "light" | "dalton-dark" | "dalton-bright" | "dalton-light" => trimmed,
+        _ => "auto".into(),
+    }
+}
+
 /// Parse a comma-separated source list, trimming whitespace and dropping blanks.
 fn parse_sources_csv(s: String) -> Vec<String> {
     s.split(',')
@@ -222,6 +270,13 @@ fn write_config_toml(path: &std::path::Path, config: &scitadel_core::config::Con
     if !config.openalex.api_key.is_empty() {
         out.push_str("\n[openalex]\n");
         writeln!(out, "api_key = \"{}\"", config.openalex.api_key).unwrap();
+    }
+    // Only persist `ui.theme` when it diverges from the default so
+    // users who never picked a non-default value keep an empty `[ui]`
+    // section out of their config (#137).
+    if config.ui.theme != "auto" {
+        out.push_str("\n[ui]\n");
+        writeln!(out, "theme = \"{}\"", config.ui.theme).unwrap();
     }
     std::fs::write(path, out)?;
     Ok(())

--- a/crates/scitadel-cli/src/main.rs
+++ b/crates/scitadel-cli/src/main.rs
@@ -122,6 +122,10 @@ enum Commands {
         /// Precedence: this flag > `SCITADEL_THEME` env > config > auto.
         #[arg(long)]
         theme: Option<String>,
+        /// Print the registered themes (with one-line descriptions) and
+        /// exit without launching the TUI (#137).
+        #[arg(long, conflicts_with = "theme")]
+        list_themes: bool,
     },
     /// Bibliographic operations: import / export / rekey / watch (#134)
     Bib {
@@ -314,7 +318,13 @@ async fn main() -> Result<()> {
         },
         Commands::Download { doi, output_dir } => commands::download(&doi, output_dir).await,
         Commands::Mcp => commands::mcp().await,
-        Commands::Tui { theme } => commands::tui(theme.as_deref()),
+        Commands::Tui { theme, list_themes } => {
+            if list_themes {
+                commands::list_themes()
+            } else {
+                commands::tui(theme.as_deref())
+            }
+        }
         Commands::Assess {
             search_id,
             question,

--- a/crates/scitadel-tui/src/app.rs
+++ b/crates/scitadel-tui/src/app.rs
@@ -126,11 +126,27 @@ pub struct App {
     /// always work from SQLite; downloads still run (and can succeed via
     /// cache layers), but the status bar shows a visible OFFLINE badge.
     pub offline: bool,
+    /// Transient toast shown in the status bar for the first N draws
+    /// after launch (#137). `Some(label)` until cleared by
+    /// `tick_startup_toast`. Used to flash e.g.
+    /// `theme: dalton-dark (auto)` so users can verify which palette
+    /// resolved without digging through `--list-themes`.
+    startup_toast: Option<String>,
+    /// Draw-tick counter for `startup_toast`. The toast is dropped once
+    /// this exceeds `STARTUP_TOAST_FRAMES`. We count draws (~10 Hz on
+    /// the 100 ms event-poll cadence, ~30 frames ≈ 3 s) rather than
+    /// wall-clock so headless tape runs reproduce the same lifetime.
+    startup_toast_frames: u32,
 
     task_tx: mpsc::UnboundedSender<TaskUpdate>,
     task_rx: mpsc::UnboundedReceiver<TaskUpdate>,
     offline_rx: mpsc::UnboundedReceiver<bool>,
 }
+
+/// How many draws the startup toast lingers for (#137). At the
+/// 100 ms event-poll cadence this is ~3 seconds — long enough to read,
+/// short enough to clear before the user does anything substantial.
+const STARTUP_TOAST_FRAMES: u32 = 30;
 
 impl App {
     fn new(
@@ -168,9 +184,24 @@ impl App {
             reader,
             starred,
             offline: false,
+            startup_toast: None,
+            startup_toast_frames: 0,
             task_tx,
             task_rx,
             offline_rx,
+        }
+    }
+
+    /// Advance the startup-toast lifetime by one draw (#137). Call once
+    /// per frame from the render path; clears `startup_toast` once
+    /// `STARTUP_TOAST_FRAMES` have elapsed.
+    fn tick_startup_toast(&mut self) {
+        if self.startup_toast.is_none() {
+            return;
+        }
+        self.startup_toast_frames = self.startup_toast_frames.saturating_add(1);
+        if self.startup_toast_frames > STARTUP_TOAST_FRAMES {
+            self.startup_toast = None;
         }
     }
 
@@ -885,6 +916,7 @@ pub fn run(
     papers_dir: PathBuf,
     show_institutional_hint: bool,
     reader: String,
+    startup_toast: Option<String>,
 ) -> Result<()> {
     let data = DataStore::open(db_path)?;
     let mut app = App::new(
@@ -894,6 +926,7 @@ pub fn run(
         show_institutional_hint,
         reader,
     );
+    app.startup_toast = startup_toast;
 
     enable_raw_mode()?;
     let mut stdout = io::stdout();
@@ -1084,7 +1117,19 @@ fn draw(frame: &mut ratatui::Frame, app: &mut App) {
             "Tab/Shift-Tab: switch tabs | j/k: navigate | Enter: select | c: clear tasks | q: quit"
         }
     };
-    status_bar::draw(frame, chunks[3], help_text, app.offline);
+    // Startup toast (#137) hijacks the status bar for its lifetime so
+    // the user sees `theme: dalton-bright (auto)` right after launch
+    // without us having to add a second status row. Falls back to the
+    // normal help_text once the toast expires.
+    let toast_text;
+    let bar_text: &str = if let Some(toast) = app.startup_toast.as_deref() {
+        toast_text = toast.to_string();
+        &toast_text
+    } else {
+        help_text
+    };
+    status_bar::draw(frame, chunks[3], bar_text, app.offline);
+    app.tick_startup_toast();
 }
 
 /// Step the active annotation prompt by one keystroke. Mutates the

--- a/crates/scitadel-tui/src/theme.rs
+++ b/crates/scitadel-tui/src/theme.rs
@@ -107,6 +107,32 @@ impl Theme {
         ],
     };
 
+    /// Registered themes, surfaced by `scitadel tui --list-themes`
+    /// (#137). Tuple is `(canonical-name, one-line description)`.
+    /// `auto` is included as a meta-entry so the listing matches what
+    /// users can actually pass — even though it doesn't map to a fixed
+    /// palette. New named palettes plug in here.
+    #[must_use]
+    pub fn registry() -> &'static [(&'static str, &'static str)] {
+        &[
+            (
+                "auto",
+                "detect terminal background (COLORFGBG → fall back to dark)",
+            ),
+            (
+                "dark",
+                "alias for dalton-dark (default colourblind-friendly dark palette)",
+            ),
+            ("light", "alias for dalton-bright"),
+            ("dalton-dark", "Dalton colourblind-friendly dark palette"),
+            (
+                "dalton-bright",
+                "Dalton colourblind-friendly light palette (warm cream bg)",
+            ),
+            ("dalton-light", "alias for dalton-bright"),
+        ]
+    }
+
     /// Pick a highlight colour for a string key (e.g. annotation
     /// root_id). djb2 hash modulo palette size so the mapping is
     /// stable across runs.
@@ -179,20 +205,30 @@ impl ThemeChoice {
 /// `SCITADEL_THEME` sits between them in precedence.
 #[must_use]
 pub fn resolve(cli: Option<&str>, config_value: &str) -> Theme {
+    resolve_with_label(cli, config_value).0
+}
+
+/// Like [`resolve`] but also returns a short label describing the
+/// resolved palette and how it was picked (e.g.
+/// `"dalton-dark (auto)"`). Used by the startup status-bar toast (#137).
+#[must_use]
+pub fn resolve_with_label(cli: Option<&str>, config_value: &str) -> (Theme, String) {
     let raw = cli
         .filter(|s| !s.is_empty())
         .map(str::to_string)
         .or_else(|| std::env::var("SCITADEL_THEME").ok())
         .unwrap_or_else(|| config_value.to_string());
     match ThemeChoice::parse(&raw) {
-        ThemeChoice::Dark => Theme::DALTON_DARK,
-        ThemeChoice::Light => Theme::DALTON_BRIGHT,
+        ThemeChoice::Dark => (Theme::DALTON_DARK, "dalton-dark".into()),
+        ThemeChoice::Light => (Theme::DALTON_BRIGHT, "dalton-bright".into()),
         ThemeChoice::Auto => match detect_terminal_background() {
-            Some(TerminalBackground::Light) => Theme::DALTON_BRIGHT,
+            Some(TerminalBackground::Light) => {
+                (Theme::DALTON_BRIGHT, "dalton-bright (auto)".into())
+            }
             // Dark or unknown → dark. Dark is the safer default
             // because most dev terminals are dark and Dalton Dark
             // was the previous behaviour.
-            _ => Theme::DALTON_DARK,
+            _ => (Theme::DALTON_DARK, "dalton-dark (auto)".into()),
         },
     }
 }
@@ -322,6 +358,50 @@ mod tests {
         // No probe signal → dark fallback.
         let t = resolve(None, "auto");
         assert_eq!(t.emphasis, Theme::DALTON_DARK.emphasis);
+    }
+
+    #[test]
+    fn registry_lists_every_user_facing_name() {
+        // Every name advertised by `--list-themes` must round-trip
+        // through `ThemeChoice::parse` to a non-Auto variant *or* be
+        // the literal "auto" entry. Otherwise `--list-themes` would
+        // print a value that the resolver silently folds to Auto.
+        let names: Vec<&str> = Theme::registry().iter().map(|(n, _)| *n).collect();
+        assert!(names.contains(&"auto"));
+        assert!(names.contains(&"dark"));
+        assert!(names.contains(&"light"));
+        assert!(names.contains(&"dalton-dark"));
+        assert!(names.contains(&"dalton-bright"));
+        for name in &names {
+            if *name == "auto" {
+                assert_eq!(ThemeChoice::parse(name), ThemeChoice::Auto);
+            } else {
+                assert_ne!(
+                    ThemeChoice::parse(name),
+                    ThemeChoice::Auto,
+                    "registry name '{name}' parses to Auto — listing it would mislead users",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn resolve_with_label_marks_auto_branch() {
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        unsafe {
+            std::env::remove_var("SCITADEL_THEME");
+            std::env::remove_var("COLORFGBG");
+        }
+        let (_, label) = resolve_with_label(None, "auto");
+        assert!(label.contains("(auto)"), "got label {label:?}");
+        let (_, label) = resolve_with_label(Some("dark"), "auto");
+        assert!(
+            !label.contains("(auto)"),
+            "explicit cli should not be tagged auto: {label:?}"
+        );
+        assert!(label.contains("dalton-dark"));
     }
 
     #[test]

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -1,0 +1,106 @@
+# TUI Themes
+
+Scitadel ships colourblind-friendly Dalton palettes for both dark and
+light terminals (#136, #137). The active palette is picked once at
+startup and held for the rest of the session — there is no
+mid-session re-detection.
+
+## Resolution order
+
+Highest precedence wins. The first source that is set decides the theme;
+unset sources fall through to the next.
+
+1. **`--theme <name>` CLI flag** on `scitadel tui`. Highest precedence;
+   used for one-off overrides without touching env or config.
+2. **`SCITADEL_THEME` environment variable**. Useful for tmux/zellij
+   `set-environment` users and for forcing a palette in containers
+   without rewriting config.
+3. **`[ui] theme = "..."` in `config.toml`**. Persistent per-installation
+   preference. Written by `scitadel init` if you answer the theme
+   prompt.
+4. **`auto`** (default). Probes the terminal background; see
+   [auto-detect](#auto-detect) below.
+
+Accepted names (run `scitadel tui --list-themes` for the live list):
+
+| name            | meaning                                                           |
+| --------------- | ----------------------------------------------------------------- |
+| `auto`          | detect terminal background, fall back to dark                     |
+| `dark`          | alias for `dalton-dark`                                           |
+| `light`         | alias for `dalton-bright`                                          |
+| `dalton-dark`   | Dalton colourblind-friendly dark palette (default)               |
+| `dalton-bright` | Dalton colourblind-friendly light palette (warm cream background) |
+| `dalton-light`  | alias for `dalton-bright`                                          |
+
+Unknown / typo'd values fold to `auto` rather than panicking the
+session — a misspelled `--theme darj` is treated as "let scitadel pick".
+
+## Auto-detect
+
+`auto` resolution reads `COLORFGBG` (set by most mature terminals;
+format `"<fg>;<bg>"` where each is an ANSI 0–15 colour index):
+
+- `bg` index 0–6 → dark background → `dalton-dark`.
+- `bg` index 7–15 → light background → `dalton-bright`.
+- Unset or unparseable → **dark fallback**. Dark is the safer default
+  since most dev terminals are dark, and the previous (single-theme)
+  behaviour was Dalton Dark.
+
+OSC 11 query fallback (issue [#176](https://github.com/vig-os/scitadel/issues/176))
+is **not** implemented yet. If your terminal does not set `COLORFGBG`
+(notably some iTerm2 / Ghostty configs) and you want light mode, set
+`SCITADEL_THEME=light` or pass `--theme light`.
+
+## Restart-required for change
+
+Theme is resolved exactly once when the TUI launches and is held in a
+process-wide `OnceLock` for the lifetime of the session. If your
+terminal flips light/dark mid-session — for example macOS auto-dark-mode
+flipping at sunset — scitadel will keep using the palette it picked at
+launch. Quit (`q`) and relaunch to pick up the new value.
+
+A runtime hotkey to toggle the theme without restart is tracked in
+[#175](https://github.com/vig-os/scitadel/issues/175); the resolver-side
+work in this iter is the prerequisite for it.
+
+## Startup toast
+
+On launch the status bar briefly shows the resolved theme — e.g.
+`theme: dalton-bright (auto)` — for the first few seconds, then fades
+back to the normal help text. Use this to verify the resolver picked
+what you expected without re-running `--list-themes`.
+
+## Override escape hatch
+
+If `COLORFGBG` lies (some iTerm2 versions don't update it after a
+profile change) or you want to force a palette regardless:
+
+```sh
+# one session
+scitadel tui --theme light
+
+# this shell, forever
+export SCITADEL_THEME=light
+
+# per-installation
+# add to <db_dir>/config.toml:
+[ui]
+theme = "dalton-bright"
+```
+
+## Pitfalls
+
+- **`COLORFGBG` is a de-facto standard, not RFC'd.** Some terminals
+  set it wrong; iTerm2 doesn't always update it after a theme change.
+  Trust it but allow override.
+- **Mid-session terminal theme change** is intentionally not handled.
+  Restart the TUI.
+- **Light-mode highlight readability** — the 8 annotation-highlight
+  slots use pale tints against dark text. If a highlight is nearly
+  invisible on your terminal's background, file an issue with the
+  exact bg colour and we'll tune the palette.
+
+## Deferred work
+
+- **OSC 11 fallback** — issue [#176](https://github.com/vig-os/scitadel/issues/176).
+- **Runtime theme-toggle hotkey** — issue [#175](https://github.com/vig-os/scitadel/issues/175).

--- a/tests/vhs/theme-dark.tape
+++ b/tests/vhs/theme-dark.tape
@@ -1,0 +1,50 @@
+# VHS tape: --theme dark renders Dalton Dark (#137).
+#
+# Mirrors theme-light.tape so the rendered snapshots can be diffed
+# side-by-side. CLI flag is forced (highest precedence) so the run is
+# deterministic regardless of the CI runner's COLORFGBG.
+
+Output "tests/vhs/snapshots/theme-dark/run.gif"
+
+Set Shell "bash"
+Set FontSize 14
+Set Width 1400
+Set Height 800
+Set Padding 10
+Set TypingSpeed 40ms
+
+Hide
+Type `export PATH="$PWD/target/release:$HOME/.cargo/bin:$PATH"`
+Enter
+Type `export PS1="$ "`
+Enter
+Type `export SCITADEL_DB=$(mktemp -d)/scitadel.db`
+Enter
+Type "scitadel init --yes --email demo@example.org --sources arxiv --db $SCITADEL_DB"
+Enter
+Sleep 1s
+
+# Seed two papers so the table has visible rows in both tabs.
+Type `sqlite3 $SCITADEL_DB "INSERT INTO papers (id, title, authors, year, created_at, updated_at) VALUES ('p-1', 'Attention Is All You Need', '[\"Vaswani, A.\"]', 2017, datetime('now'), datetime('now'));"`
+Enter
+Sleep 200ms
+Type `sqlite3 $SCITADEL_DB "INSERT INTO papers (id, title, authors, year, created_at, updated_at) VALUES ('p-2', 'Deep Residual Learning', '[\"He, K.\"]', 2015, datetime('now'), datetime('now'));"`
+Enter
+Sleep 200ms
+
+Type "clear"
+Enter
+Show
+
+# CLI flag overrides anything in env / config.
+Type "scitadel tui --theme dark"
+Enter
+Sleep 2500ms
+Screenshot "tests/vhs/snapshots/theme-dark/01-searches-dark.png"
+
+Tab
+Sleep 800ms
+Screenshot "tests/vhs/snapshots/theme-dark/02-papers-dark.png"
+
+Type "q"
+Sleep 300ms


### PR DESCRIPTION
## Summary

Closes the remaining acceptance items for #137 on top of #151 (which shipped the light palette + resolver + `--theme` flag + `SCITADEL_THEME` env + `[ui] theme` config + COLORFGBG auto-detect + light tape).

- **`scitadel tui --list-themes`** — prints registered themes with one-line descriptions and exits. Backed by a new `Theme::registry()` so future palettes plug in trivially.
- **`scitadel init` theme prompt** — wizard now asks for `ui.theme` (default `auto`); unknown input folds to `auto`. Only writes the key when it diverges from the default to keep generated configs minimal.
- **Startup status-bar toast** — flashes `theme: dalton-bright (auto)` (or whatever resolved) for ~30 draws (~3 s) on launch, then fades to the normal help text. Implemented as a per-frame counter on `App`; no new toast subsystem.
- **`docs/themes.md`** — covers precedence, COLORFGBG, dark fallback, the restart-required-for-change contract, and the override escape hatch. Cross-links #175 / #176 as deferred work.
- **`tests/vhs/theme-dark.tape`** — mirror of `theme-light.tape` so the two palettes diff side-by-side.

OSC 11 fallback (split into #176) and runtime hotkey toggle (split into #175) are intentionally **not** in this PR.

## Caveats

- Dark-tape rendering is deferred to CI — `vhs` / `ttyd` aren't installed in the author's worktree. CI's `Run tapes` job will produce the snapshots; the `Tape coverage` gate is satisfied because the `.tape` file ships alongside the source change.

## Test plan

- [ ] `cargo test --workspace --exclude scitadel-tui` passes
- [ ] `cargo test -p scitadel-tui` passes (`theme::tests::registry_lists_every_user_facing_name` + `resolve_with_label_marks_auto_branch` are new)
- [ ] `just lint` clean
- [ ] CI `Run tapes` job renders both `theme-light` and `theme-dark` snapshots and the distinct-snapshot gate passes
- [ ] Manual: `scitadel tui --list-themes` prints the registry and exits 0
- [ ] Manual: `scitadel tui --theme light` shows the toast `theme: dalton-bright` for ~3s then fades
- [ ] Manual: `scitadel init` prompts for theme and writes `[ui] theme = "..."` only when non-default