### PR TITLE
feat(bib): snapshot + verify + .scitadel-bib.lock sidecar (#178, #132 carry-over)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2497,6 +2497,7 @@ dependencies = [
  "scitadel-core",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror",
  "uuid",
 ]

--- a/crates/scitadel-cli/src/commands.rs
+++ b/crates/scitadel-cli/src/commands.rs
@@ -1106,6 +1106,339 @@ fn find_source_credentials(source: &str) -> Result<&'static credentials::SourceC
         })
 }
 
+// ---------- bib snapshot / verify (#178) ----------
+
+/// Sidecar suffix appended to the output `.bib` path. One sidecar per
+/// `.bib` keeps scope to a single (question, output_file) — see #178
+/// "Sidecar location collision" pitfall.
+pub const SIDECAR_SUFFIX: &str = ".scitadel-bib.lock";
+
+fn sidecar_path_for(bib: &std::path::Path) -> PathBuf {
+    let mut s = bib.as_os_str().to_owned();
+    s.push(SIDECAR_SUFFIX);
+    PathBuf::from(s)
+}
+
+fn current_reader() -> String {
+    std::env::var("USER").unwrap_or_else(|_| "unknown".into())
+}
+
+/// Load the question's shortlist once: returns the resolved question,
+/// the shortlist's paper IDs (in shortlist insertion order), the
+/// `Paper` records, and a paper_id → tags map. Snapshot and verify
+/// share this code path so they can never disagree about what the
+/// shortlist *is* at this moment in time.
+fn load_shortlist(
+    question_prefix: &str,
+    reader: &str,
+) -> Result<(
+    scitadel_core::models::ResearchQuestion,
+    Vec<String>,
+    Vec<scitadel_core::models::Paper>,
+    std::collections::HashMap<String, Vec<String>>,
+)> {
+    use scitadel_db::sqlite::{SqlitePaperTagRepository, SqliteShortlistRepository};
+
+    let db = open_db()?;
+    let (paper_repo, _, q_repo, _, _) = db.repositories();
+    let shortlist_repo = SqliteShortlistRepository::new(db.clone());
+    let tag_repo = SqlitePaperTagRepository::new(db);
+
+    let question = if let Some(q) = q_repo.get_question(question_prefix)? {
+        q
+    } else {
+        let questions = q_repo.list_questions()?;
+        resolve_prefix(&questions, question_prefix, |q| q.id.as_str())?.clone()
+    };
+
+    let paper_ids = shortlist_repo
+        .list(question.id.as_str(), reader)
+        .context("failed to read shortlist")?;
+    let papers: Vec<_> = paper_ids
+        .iter()
+        .filter_map(|id| paper_repo.get(id).ok().flatten())
+        .collect();
+
+    // Pre-load tags so the export closure isn't doing per-call I/O.
+    let mut tags = std::collections::HashMap::new();
+    for id in &paper_ids {
+        let t = tag_repo.tags_for(id).unwrap_or_default();
+        tags.insert(id.clone(), t);
+    }
+
+    Ok((question, paper_ids, papers, tags))
+}
+
+/// Render the shortlist's `.bib`. Centralized so snapshot and verify
+/// produce byte-identical output for the same DB state — that's the
+/// whole determinism story.
+fn render_bibtex(
+    papers: &[scitadel_core::models::Paper],
+    tags: &std::collections::HashMap<String, Vec<String>>,
+) -> String {
+    scitadel_export::export_bibtex_with_tags(papers, |id| tags.get(id).cloned().unwrap_or_default())
+}
+
+pub fn bib_snapshot(
+    question_prefix: &str,
+    output: &std::path::Path,
+    reader_arg: Option<&str>,
+    no_lock: bool,
+) -> Result<()> {
+    let reader = reader_arg.map_or_else(current_reader, str::to_string);
+    let (question, paper_ids, papers, tags) = load_shortlist(question_prefix, &reader)?;
+
+    let content = render_bibtex(&papers, &tags);
+    std::fs::write(output, &content)
+        .with_context(|| format!("failed to write {}", output.display()))?;
+
+    if no_lock {
+        println!(
+            "Wrote {} ({} papers) — sidecar skipped (--no-lock)",
+            output.display(),
+            papers.len()
+        );
+        return Ok(());
+    }
+
+    let lock = scitadel_export::BibLockfile::new_bibtex(
+        question.id.as_str(),
+        &reader,
+        &paper_ids,
+        &content,
+    );
+    let sidecar = sidecar_path_for(output);
+    std::fs::write(&sidecar, lock.to_json()?)
+        .with_context(|| format!("failed to write {}", sidecar.display()))?;
+
+    println!(
+        "Wrote {} ({} papers) + {}",
+        output.display(),
+        papers.len(),
+        sidecar.display()
+    );
+    Ok(())
+}
+
+/// Outcome of `bib verify`. Exit code follows `0/1/2` (ok/drift/stale).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VerifyOutcome {
+    /// `.bib` and sidecar both match a fresh re-snapshot.
+    Ok,
+    /// shortlist or content changed since the lockfile.
+    Drift {
+        shortlist_changed: bool,
+        content_changed: bool,
+        diff: String,
+    },
+    /// Lockfile fields don't match the current binary, OR sidecar absent.
+    Stale { reason: String },
+}
+
+impl VerifyOutcome {
+    fn exit_code(&self) -> i32 {
+        match self {
+            Self::Ok => 0,
+            Self::Drift { .. } => 1,
+            Self::Stale { .. } => 2,
+        }
+    }
+}
+
+/// Cap a unified-style diff to `max_lines` so verify output stays
+/// scannable. Anything longer is truncated with a sentinel line.
+fn cap_diff(s: &str, max_lines: usize) -> String {
+    use std::fmt::Write as _;
+    let lines: Vec<&str> = s.lines().collect();
+    if lines.len() <= max_lines {
+        return s.to_string();
+    }
+    let mut out = lines[..max_lines].join("\n");
+    let _ = write!(
+        out,
+        "\n... ({} more lines truncated)",
+        lines.len() - max_lines
+    );
+    out
+}
+
+/// Tiny line-level diff. Real `diff -u` is overkill here — verify only
+/// needs to *show* the user what moved, not produce a patch.
+fn line_diff(old: &str, new: &str) -> String {
+    use std::fmt::Write as _;
+    let old_lines: Vec<&str> = old.lines().collect();
+    let new_lines: Vec<&str> = new.lines().collect();
+    let mut out = String::new();
+    out.push_str("--- committed\n+++ regenerated\n");
+    let max = old_lines.len().max(new_lines.len());
+    for i in 0..max {
+        match (old_lines.get(i), new_lines.get(i)) {
+            (Some(a), Some(b)) if a == b => {}
+            (Some(a), Some(b)) => {
+                let _ = writeln!(out, "-{a}");
+                let _ = writeln!(out, "+{b}");
+            }
+            (Some(a), None) => {
+                let _ = writeln!(out, "-{a}");
+            }
+            (None, Some(b)) => {
+                let _ = writeln!(out, "+{b}");
+            }
+            (None, None) => break,
+        }
+    }
+    out
+}
+
+/// Pure verify primitive — no I/O on shortlist, no DB. The CLI command
+/// pulls the shortlist + sidecar + bib bytes and hands them off here so
+/// tests can drive every exit-code branch from in-memory inputs.
+pub fn verify_against_lockfile(
+    bib_committed: &str,
+    bib_regenerated: &str,
+    paper_ids: &[String],
+    lock: &scitadel_export::BibLockfile,
+) -> VerifyOutcome {
+    // Stale (algorithm or binary moved) is the most fundamental
+    // failure: fail fast, the drift comparison would be nonsensical.
+    let current_algo = scitadel_export::sidecar::ALGO_HASH;
+    let current_version = env!("CARGO_PKG_VERSION");
+    if lock.algo_hash != current_algo {
+        return VerifyOutcome::Stale {
+            reason: format!(
+                "algo_hash mismatch: sidecar has {}, current binary has {} — \
+                 the citation-key algorithm has moved (ADR-006). Regenerate.",
+                short_hash(&lock.algo_hash),
+                short_hash(current_algo),
+            ),
+        };
+    }
+    if lock.scitadel_version != current_version {
+        return VerifyOutcome::Stale {
+            reason: format!(
+                "scitadel_version mismatch: sidecar has {}, current binary has {}. \
+                 Regenerate to refresh.",
+                lock.scitadel_version, current_version
+            ),
+        };
+    }
+
+    let shortlist_changed = scitadel_export::shortlist_hash(paper_ids) != lock.shortlist_hash;
+    let content_changed = scitadel_export::content_hash(bib_committed) != lock.content_hash
+        || bib_committed != bib_regenerated;
+    if shortlist_changed || content_changed {
+        let diff = cap_diff(&line_diff(bib_committed, bib_regenerated), 40);
+        return VerifyOutcome::Drift {
+            shortlist_changed,
+            content_changed,
+            diff,
+        };
+    }
+    VerifyOutcome::Ok
+}
+
+fn short_hash(h: &str) -> String {
+    // Strip optional `sha256:` prefix and keep first 12 chars for human
+    // legibility — full hashes are noise in error messages.
+    let bare = h.strip_prefix("sha256:").unwrap_or(h);
+    if bare.len() <= 12 {
+        bare.to_string()
+    } else {
+        format!("{}…", &bare[..12])
+    }
+}
+
+/// Returns the exit code (0/1/2). main.rs forwards via `process::exit`.
+pub fn bib_verify(
+    file: &std::path::Path,
+    question_override: Option<&str>,
+    format: &str,
+) -> Result<i32> {
+    let bib_bytes =
+        std::fs::read_to_string(file).with_context(|| format!("read {}", file.display()))?;
+
+    let sidecar = sidecar_path_for(file);
+    if !sidecar.exists() {
+        let msg = format!(
+            "no lockfile at {} — run `scitadel bib snapshot <question_id> --output {}` first",
+            sidecar.display(),
+            file.display()
+        );
+        if format == "json" {
+            print_verify_json("stale", &msg, None);
+        } else {
+            eprintln!("STALE: {msg}");
+        }
+        return Ok(2);
+    }
+    let lock_bytes =
+        std::fs::read_to_string(&sidecar).with_context(|| format!("read {}", sidecar.display()))?;
+    let lock = scitadel_export::BibLockfile::from_json(&lock_bytes)
+        .with_context(|| format!("parse {}", sidecar.display()))?;
+
+    let question_id = question_override.unwrap_or(&lock.question_id);
+    let (_q, paper_ids, papers, tags) = load_shortlist(question_id, &lock.reader)?;
+    let regenerated = render_bibtex(&papers, &tags);
+
+    let outcome = verify_against_lockfile(&bib_bytes, &regenerated, &paper_ids, &lock);
+    let fix_line = format!(
+        "scitadel bib snapshot {} --output {}",
+        lock.question_id,
+        file.display()
+    );
+    match &outcome {
+        VerifyOutcome::Ok => {
+            if format == "json" {
+                print_verify_json("ok", "matches lockfile", None);
+            } else {
+                println!("OK: {} matches lockfile", file.display());
+            }
+        }
+        VerifyOutcome::Drift {
+            shortlist_changed,
+            content_changed,
+            diff,
+        } => {
+            let label = match (shortlist_changed, content_changed) {
+                (true, true) => "shortlist + content",
+                (true, false) => "shortlist",
+                (false, true) => "content",
+                (false, false) => "lockfile",
+            };
+            if format == "json" {
+                print_verify_json(
+                    "drift",
+                    &format!("{label} changed since lockfile"),
+                    Some(diff),
+                );
+            } else {
+                eprintln!("DRIFT: {label} changed since lockfile");
+                eprintln!("{diff}");
+                eprintln!("\nFix: {fix_line}");
+            }
+        }
+        VerifyOutcome::Stale { reason } => {
+            if format == "json" {
+                print_verify_json("stale", reason, None);
+            } else {
+                eprintln!("STALE: {reason}");
+                eprintln!("\nFix: {fix_line}");
+            }
+        }
+    }
+    Ok(outcome.exit_code())
+}
+
+fn print_verify_json(status: &str, message: &str, diff: Option<&str>) {
+    let mut obj = serde_json::Map::new();
+    obj.insert("status".into(), serde_json::Value::String(status.into()));
+    obj.insert("message".into(), serde_json::Value::String(message.into()));
+    if let Some(d) = diff {
+        obj.insert("diff".into(), serde_json::Value::String(d.into()));
+    }
+    println!("{}", serde_json::Value::Object(obj));
+}
+
 fn prompt_credential(label: &str, secret: bool) -> Result<String> {
     if secret {
         // Read without echo
@@ -1119,5 +1452,119 @@ fn prompt_credential(label: &str, secret: bool) -> Result<String> {
         let mut value = String::new();
         std::io::stdin().read_line(&mut value)?;
         Ok(value.trim().to_string())
+    }
+}
+
+#[cfg(test)]
+mod bib_verify_tests {
+    use super::{VerifyOutcome, cap_diff, verify_against_lockfile};
+    use scitadel_export::BibLockfile;
+    use std::fmt::Write as _;
+
+    fn fresh_lock(content: &str, paper_ids: &[String]) -> BibLockfile {
+        BibLockfile::new_bibtex("q-1", "lars", paper_ids, content)
+    }
+
+    #[test]
+    fn verify_returns_ok_when_committed_matches_lockfile() {
+        let bib = "@article{a,\n  title = {A},\n}\n";
+        let ids = vec!["p-1".to_string()];
+        let lock = fresh_lock(bib, &ids);
+        let outcome = verify_against_lockfile(bib, bib, &ids, &lock);
+        assert_eq!(outcome, VerifyOutcome::Ok);
+    }
+
+    #[test]
+    fn verify_returns_drift_when_content_differs() {
+        let original = "@article{a,\n  title = {A},\n}\n";
+        let modified = "@article{a,\n  title = {A — edited},\n}\n";
+        let ids = vec!["p-1".to_string()];
+        let lock = fresh_lock(original, &ids);
+        let outcome = verify_against_lockfile(modified, original, &ids, &lock);
+        match outcome {
+            VerifyOutcome::Drift {
+                content_changed,
+                shortlist_changed,
+                diff,
+            } => {
+                assert!(content_changed);
+                assert!(!shortlist_changed);
+                assert!(
+                    diff.contains("--- committed") && diff.contains("+++ regenerated"),
+                    "diff: {diff}"
+                );
+            }
+            other => panic!("expected Drift, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn verify_returns_drift_when_shortlist_differs() {
+        let bib = "@article{a,\n  title = {A},\n}\n";
+        let lock = fresh_lock(bib, &["p-1".into(), "p-2".into()]);
+        let new_ids = vec!["p-1".to_string(), "p-2".into(), "p-3".into()];
+        let outcome = verify_against_lockfile(bib, bib, &new_ids, &lock);
+        match outcome {
+            VerifyOutcome::Drift {
+                shortlist_changed, ..
+            } => {
+                assert!(shortlist_changed);
+            }
+            other => panic!("expected Drift, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn verify_returns_stale_when_algo_hash_flips() {
+        let bib = "@article{a,\n}\n";
+        let ids = vec!["p-1".to_string()];
+        let mut lock = fresh_lock(bib, &ids);
+        lock.algo_hash = "deadbeef".into();
+        let outcome = verify_against_lockfile(bib, bib, &ids, &lock);
+        match &outcome {
+            VerifyOutcome::Stale { reason } => {
+                assert!(reason.contains("algo_hash"), "reason: {reason}");
+            }
+            other => panic!("expected Stale, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn verify_returns_stale_when_scitadel_version_flips() {
+        let bib = "@article{a,\n}\n";
+        let ids = vec!["p-1".to_string()];
+        let mut lock = fresh_lock(bib, &ids);
+        lock.scitadel_version = "0.0.0-time-traveler".into();
+        let outcome = verify_against_lockfile(bib, bib, &ids, &lock);
+        match outcome {
+            VerifyOutcome::Stale { reason } => {
+                assert!(reason.contains("scitadel_version"), "reason: {reason}");
+            }
+            other => panic!("expected Stale, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn verify_stale_takes_precedence_over_drift() {
+        // If both algo_hash AND content disagree, we return stale —
+        // drift comparisons are meaningless when the algorithm itself moved.
+        let original = "@article{a,\n}\n";
+        let modified = "@article{a, modified}\n";
+        let ids = vec!["p-1".to_string()];
+        let mut lock = fresh_lock(original, &ids);
+        lock.algo_hash = "old-algo".into();
+        let outcome = verify_against_lockfile(modified, original, &ids, &lock);
+        assert!(matches!(outcome, VerifyOutcome::Stale { .. }));
+    }
+
+    #[test]
+    fn diff_capping_preserves_head_and_marks_truncation() {
+        let mut big = String::new();
+        for i in 0..200 {
+            let _ = writeln!(big, "line {i}");
+        }
+        let capped = cap_diff(&big, 40);
+        assert!(capped.lines().count() <= 41);
+        assert!(capped.contains("more lines truncated"));
     }
 }

--- a/crates/scitadel-cli/src/main.rs
+++ b/crates/scitadel-cli/src/main.rs
@@ -189,6 +189,37 @@ enum BibCommands {
         #[arg(long)]
         reader: Option<String>,
     },
+    /// One-shot deterministic snapshot of a question's shortlist to a
+    /// `.bib` plus `.scitadel-bib.lock` sidecar (#178). Same shortlist
+    /// twice ⇒ byte-identical output (sidecar `generated_at` excepted).
+    /// Pair with `bib verify` in CI to catch drift.
+    Snapshot {
+        /// Research question id (full or unambiguous prefix).
+        question_id: String,
+        /// Output `.bib` path (default: `paper.bib` in cwd).
+        #[arg(short, long, default_value = "paper.bib")]
+        output: PathBuf,
+        /// Reader scope for the shortlist. Defaults to $USER.
+        #[arg(long)]
+        reader: Option<String>,
+        /// Skip writing the sidecar (CI one-offs). The `.bib` is still
+        /// emitted but `bib verify` will exit 2 with "no lockfile".
+        #[arg(long)]
+        no_lock: bool,
+    },
+    /// Verify a committed `.bib` against its `.scitadel-bib.lock`
+    /// (#178). Exit codes: `0` ok, `1` drift (regenerate to fix),
+    /// `2` stale (binary moved or sidecar absent — regenerate required).
+    Verify {
+        /// Path to the `.bib` to verify.
+        file: PathBuf,
+        /// Override the sidecar's question_id (rarely needed).
+        #[arg(short, long)]
+        question_id: Option<String>,
+        /// Output format: `text` (default) or `json` (CI-friendly).
+        #[arg(long, default_value = "text", value_parser = ["text", "json"])]
+        format: String,
+    },
     /// Live `.bib` snapshot for a research question's shortlist.
     /// Polls SQLite at 1s, debounces bursts of edits, and skips
     /// the file write when the rendered content is byte-identical
@@ -344,6 +375,20 @@ async fn main() -> Result<()> {
                 key,
                 reader,
             } => commands::bib_rekey(&paper_id, key.as_deref(), reader),
+            BibCommands::Snapshot {
+                question_id,
+                output,
+                reader,
+                no_lock,
+            } => commands::bib_snapshot(&question_id, &output, reader.as_deref(), no_lock),
+            BibCommands::Verify {
+                file,
+                question_id,
+                format,
+            } => {
+                let code = commands::bib_verify(&file, question_id.as_deref(), &format)?;
+                std::process::exit(code);
+            }
             BibCommands::Watch {
                 question_id,
                 output,

--- a/crates/scitadel-cli/tests/bib.rs
+++ b/crates/scitadel-cli/tests/bib.rs
@@ -1,0 +1,237 @@
+#![allow(deprecated)] // `Command::cargo_bin` is still the standard entry for stable assert_cmd.
+
+//! End-to-end coverage for `scitadel bib snapshot` / `scitadel bib verify` (#178).
+//!
+//! Tests seed an in-process scitadel-db file directly (there's no CLI
+//! command for shortlist toggling yet — the TUI/MCP own that surface),
+//! then shell out the CLI binary with `SCITADEL_DB` pointing at the
+//! seeded file. This mirrors the workflow CI users actually exercise.
+
+use std::path::Path;
+
+use assert_cmd::Command;
+use scitadel_core::models::{Paper, PaperId, ResearchQuestion};
+use scitadel_core::ports::{PaperRepository, QuestionRepository};
+use scitadel_db::sqlite::{Database, SqliteShortlistRepository};
+use tempfile::TempDir;
+
+const READER: &str = "test-reader";
+
+/// Seed a fresh DB with one question + N papers shortlisted under
+/// `READER`. Returns `(db_path, question_id, paper_ids)`.
+fn seed_db(tmp: &Path) -> (std::path::PathBuf, String, Vec<String>) {
+    let db_path = tmp.join("scitadel.db");
+    let db = Database::open(&db_path).unwrap();
+    db.migrate().unwrap();
+
+    let (paper_repo, _, q_repo, _, _) = db.repositories();
+    let mut q = ResearchQuestion::new("Does X cause Y?");
+    q.description = "test question".into();
+    q_repo.save_question(&q).unwrap();
+    let question_id = q.id.as_str().to_string();
+
+    let papers = [
+        ("p-aaa", "Attention Is All You Need", &["Vaswani, A."], 2017),
+        ("p-bbb", "Deep Residual Learning", &["He, Kaiming"], 2015),
+    ];
+    let mut paper_ids = Vec::new();
+    for (id, title, authors, year) in papers {
+        let mut p = Paper::new(title);
+        p.id = PaperId::from(id);
+        p.authors = authors.iter().map(|s| (*s).to_string()).collect();
+        p.year = Some(year);
+        paper_repo.save(&p).unwrap();
+        paper_ids.push(id.to_string());
+    }
+
+    let shortlist = SqliteShortlistRepository::new(db.clone());
+    for pid in &paper_ids {
+        shortlist.toggle(&question_id, pid, READER).unwrap();
+    }
+
+    (db_path, question_id, paper_ids)
+}
+
+fn snapshot(db_path: &Path, question_id: &str, output: &Path) -> assert_cmd::assert::Assert {
+    Command::cargo_bin("scitadel")
+        .unwrap()
+        .arg("bib")
+        .arg("snapshot")
+        .arg(question_id)
+        .arg("--output")
+        .arg(output)
+        .arg("--reader")
+        .arg(READER)
+        .env("SCITADEL_DB", db_path)
+        .assert()
+}
+
+fn verify(db_path: &Path, file: &Path) -> assert_cmd::assert::Assert {
+    Command::cargo_bin("scitadel")
+        .unwrap()
+        .arg("bib")
+        .arg("verify")
+        .arg(file)
+        .env("SCITADEL_DB", db_path)
+        .assert()
+}
+
+fn sidecar_for(bib: &Path) -> std::path::PathBuf {
+    let mut s = bib.as_os_str().to_owned();
+    s.push(".scitadel-bib.lock");
+    std::path::PathBuf::from(s)
+}
+
+/// Snapshot must be byte-identical (modulo `generated_at`) on the
+/// second run — that's the whole determinism story per #178.
+#[test]
+fn snapshot_is_byte_deterministic_across_runs() {
+    let tmp = TempDir::new().unwrap();
+    let (db_path, qid, _) = seed_db(tmp.path());
+    let bib = tmp.path().join("paper.bib");
+
+    snapshot(&db_path, &qid, &bib).success();
+    let bib_first = std::fs::read_to_string(&bib).unwrap();
+    let lock_first: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(sidecar_for(&bib)).unwrap()).unwrap();
+
+    // Sleep is tempting here but unnecessary: only `generated_at`
+    // differs across runs, and we explicitly exclude it from the
+    // determinism comparison below.
+    snapshot(&db_path, &qid, &bib).success();
+    let bib_second = std::fs::read_to_string(&bib).unwrap();
+    let lock_second: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(sidecar_for(&bib)).unwrap()).unwrap();
+
+    assert_eq!(
+        bib_first, bib_second,
+        ".bib must be byte-identical across runs"
+    );
+    assert_eq!(
+        lock_first["content_hash"], lock_second["content_hash"],
+        "content_hash must match across runs"
+    );
+    assert_eq!(
+        lock_first["shortlist_hash"], lock_second["shortlist_hash"],
+        "shortlist_hash must match across runs"
+    );
+    assert_eq!(lock_first["algo_hash"], lock_second["algo_hash"]);
+    assert_eq!(
+        lock_first["scitadel_version"],
+        lock_second["scitadel_version"]
+    );
+    // generated_at is allowed to differ — that's the whole point.
+}
+
+/// Fresh-snapshot-then-verify must exit 0.
+#[test]
+fn verify_returns_zero_on_fresh_snapshot() {
+    let tmp = TempDir::new().unwrap();
+    let (db_path, qid, _) = seed_db(tmp.path());
+    let bib = tmp.path().join("paper.bib");
+    snapshot(&db_path, &qid, &bib).success();
+    verify(&db_path, &bib).code(0);
+}
+
+/// Modify the `.bib` after snapshot ⇒ exit 1 (drift) with diff text.
+#[test]
+fn verify_returns_one_on_content_drift() {
+    let tmp = TempDir::new().unwrap();
+    let (db_path, qid, _) = seed_db(tmp.path());
+    let bib = tmp.path().join("paper.bib");
+    snapshot(&db_path, &qid, &bib).success();
+
+    let mut content = std::fs::read_to_string(&bib).unwrap();
+    content.push_str("\n@misc{drift,\n  title = {oops},\n}\n");
+    std::fs::write(&bib, content).unwrap();
+
+    let assert = verify(&db_path, &bib).code(1);
+    let out = String::from_utf8_lossy(&assert.get_output().stderr).to_string();
+    assert!(out.contains("DRIFT"), "stderr: {out}");
+    assert!(
+        out.contains("--- committed") || out.contains("+++ regenerated"),
+        "expected diff text, got: {out}"
+    );
+}
+
+/// Manually flip `algo_hash` in the sidecar ⇒ exit 2 (stale).
+#[test]
+fn verify_returns_two_on_algo_hash_stale() {
+    let tmp = TempDir::new().unwrap();
+    let (db_path, qid, _) = seed_db(tmp.path());
+    let bib = tmp.path().join("paper.bib");
+    snapshot(&db_path, &qid, &bib).success();
+
+    let sidecar = sidecar_for(&bib);
+    let mut lock: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&sidecar).unwrap()).unwrap();
+    lock["algo_hash"] = serde_json::Value::String("deadbeef-stale".into());
+    std::fs::write(&sidecar, serde_json::to_string_pretty(&lock).unwrap()).unwrap();
+
+    let assert = verify(&db_path, &bib).code(2);
+    let out = String::from_utf8_lossy(&assert.get_output().stderr).to_string();
+    assert!(out.contains("STALE"), "stderr: {out}");
+    assert!(out.contains("algo_hash"), "stderr: {out}");
+}
+
+/// Manually flip `scitadel_version` in the sidecar ⇒ exit 2 (stale).
+#[test]
+fn verify_returns_two_on_scitadel_version_stale() {
+    let tmp = TempDir::new().unwrap();
+    let (db_path, qid, _) = seed_db(tmp.path());
+    let bib = tmp.path().join("paper.bib");
+    snapshot(&db_path, &qid, &bib).success();
+
+    let sidecar = sidecar_for(&bib);
+    let mut lock: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&sidecar).unwrap()).unwrap();
+    lock["scitadel_version"] = serde_json::Value::String("0.0.0-time-traveler".into());
+    std::fs::write(&sidecar, serde_json::to_string_pretty(&lock).unwrap()).unwrap();
+
+    let assert = verify(&db_path, &bib).code(2);
+    let out = String::from_utf8_lossy(&assert.get_output().stderr).to_string();
+    assert!(out.contains("STALE"), "stderr: {out}");
+    assert!(out.contains("scitadel_version"), "stderr: {out}");
+}
+
+/// Sidecar absent ⇒ exit 2 with a useful "run snapshot" hint.
+#[test]
+fn verify_returns_two_when_sidecar_missing() {
+    let tmp = TempDir::new().unwrap();
+    let (db_path, qid, _) = seed_db(tmp.path());
+    let bib = tmp.path().join("paper.bib");
+    snapshot(&db_path, &qid, &bib).success();
+    std::fs::remove_file(sidecar_for(&bib)).unwrap();
+
+    let assert = verify(&db_path, &bib).code(2);
+    let out = String::from_utf8_lossy(&assert.get_output().stderr).to_string();
+    assert!(
+        out.contains("STALE") && out.contains("no lockfile"),
+        "stderr: {out}"
+    );
+}
+
+/// `--no-lock` skips the sidecar; verify then reports stale.
+#[test]
+fn snapshot_no_lock_skips_sidecar() {
+    let tmp = TempDir::new().unwrap();
+    let (db_path, qid, _) = seed_db(tmp.path());
+    let bib = tmp.path().join("paper.bib");
+
+    Command::cargo_bin("scitadel")
+        .unwrap()
+        .arg("bib")
+        .arg("snapshot")
+        .arg(&qid)
+        .arg("--output")
+        .arg(&bib)
+        .arg("--reader")
+        .arg(READER)
+        .arg("--no-lock")
+        .env("SCITADEL_DB", &db_path)
+        .assert()
+        .success();
+
+    assert!(bib.exists());
+    assert!(!sidecar_for(&bib).exists(), "--no-lock should skip sidecar");
+}

--- a/crates/scitadel-export/Cargo.toml
+++ b/crates/scitadel-export/Cargo.toml
@@ -15,6 +15,8 @@ readme = "../../README.md"
 scitadel-core = { path = "../scitadel-core", version = "0.6.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
+chrono = { workspace = true }
+sha2 = { workspace = true }
 csv = "1"
 biblatex = "0.11"
 thiserror = { workspace = true }
@@ -22,7 +24,6 @@ thiserror = { workspace = true }
 [dev-dependencies]
 insta = { workspace = true }
 uuid = { workspace = true }
-chrono = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/scitadel-export/src/lib.rs
+++ b/crates/scitadel-export/src/lib.rs
@@ -2,6 +2,7 @@ pub mod bibtex;
 pub mod csv_export;
 pub mod import;
 pub mod json_export;
+pub mod sidecar;
 
 pub use bibtex::{export_bibtex, export_bibtex_with_tags};
 pub use csv_export::export_csv;
@@ -11,3 +12,4 @@ pub use import::{
     parse_bibtex, resolve as resolve_merge,
 };
 pub use json_export::export_json;
+pub use sidecar::{BibLockfile, content_hash, shortlist_hash};

--- a/crates/scitadel-export/src/sidecar.rs
+++ b/crates/scitadel-export/src/sidecar.rs
@@ -1,0 +1,215 @@
+//! `.scitadel-bib.lock` sidecar for `bib snapshot` / `bib verify` (#178).
+//!
+//! Carry-over of the dropped pieces of #132. The lockfile is the
+//! comparison anchor that lets `bib verify` detect drift (shortlist or
+//! content changed) versus stale (algorithm or scitadel version moved
+//! since the lockfile was written).
+//!
+//! Schema is intentionally extensible via the `format` discriminant so
+//! the CSL-JSON variant in #135 can layer on without a schema bump.
+
+use std::collections::BTreeSet;
+use std::fmt::Write as _;
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+/// Algorithm-pinned `algo_hash` constant for BibTeX exports — sourced
+/// from the same `KEY_ALGO_HASH` ADR-006 freezes in [`crate::bibtex`].
+/// Sidecar code references this rather than recomputing per build,
+/// otherwise every `cargo build` would flip the stale flag.
+pub use crate::bibtex::KEY_ALGO_HASH as ALGO_HASH;
+
+/// Schema-version discriminant. Bump only on incompatible field
+/// changes — additive optional fields don't require a bump.
+pub const FORMAT_VERSION: &str = "1";
+
+/// `format` discriminant for BibTeX-flavored snapshots. The CSL-JSON
+/// variant in #135 will introduce `"csl-json"` alongside; keeping this
+/// a string keeps the schema open without a serde enum migration.
+pub const FORMAT_BIBTEX: &str = "bibtex";
+
+/// Sidecar JSON written next to the exported `.bib` (path =
+/// `<output>.scitadel-bib.lock`). One sidecar per output file —
+/// per-question scope means several may live in one repo.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BibLockfile {
+    /// Research question this snapshot was scoped to.
+    pub question_id: String,
+    /// Reader identity at snapshot time. Mirrors annotation/star
+    /// scoping — different readers may produce different shortlists.
+    pub reader: String,
+    /// SHA-256 of the lex-sorted `paper_id\n` list. The drift anchor.
+    pub shortlist_hash: String,
+    /// SHA-256 of the emitted `.bib` bytes. Cheap re-emit skip.
+    pub content_hash: String,
+    /// `scitadel` binary version that produced this snapshot. Drives
+    /// the stale exit code when the binary moves forward.
+    pub scitadel_version: String,
+    /// Pinned key-generation algorithm hash from ADR-006. Drives the
+    /// stale exit code when the algorithm itself drifts.
+    pub algo_hash: String,
+    /// Output flavor — `"bibtex"` here. `#135` adds `"csl-json"`.
+    pub format: String,
+    /// Schema version of this lockfile.
+    pub format_version: String,
+    /// RFC3339 timestamp of when the snapshot was written. Excluded
+    /// from byte-determinism guarantees — snapshot-twice-same-bytes
+    /// holds for everything else.
+    pub generated_at: String,
+}
+
+impl BibLockfile {
+    /// Construct a fresh lockfile for a BibTeX snapshot. `paper_ids`
+    /// must be the shortlist's paper IDs; ordering is normalized
+    /// internally so callers don't have to think about it.
+    #[must_use]
+    pub fn new_bibtex(
+        question_id: impl Into<String>,
+        reader: impl Into<String>,
+        paper_ids: &[String],
+        content: &str,
+    ) -> Self {
+        Self {
+            question_id: question_id.into(),
+            reader: reader.into(),
+            shortlist_hash: shortlist_hash(paper_ids),
+            content_hash: content_hash(content),
+            scitadel_version: env!("CARGO_PKG_VERSION").to_string(),
+            algo_hash: ALGO_HASH.to_string(),
+            format: FORMAT_BIBTEX.to_string(),
+            format_version: FORMAT_VERSION.to_string(),
+            generated_at: chrono::Utc::now().to_rfc3339(),
+        }
+    }
+
+    /// Pretty-printed JSON serialization with a trailing newline so
+    /// editors don't dirty the file on first open.
+    pub fn to_json(&self) -> Result<String, serde_json::Error> {
+        let mut s = serde_json::to_string_pretty(self)?;
+        s.push('\n');
+        Ok(s)
+    }
+
+    /// Parse from JSON. Errors propagate the serde failure verbatim.
+    pub fn from_json(s: &str) -> Result<Self, serde_json::Error> {
+        serde_json::from_str(s)
+    }
+}
+
+/// SHA-256 of the lex-sorted `paper_id\n` list. Sort happens here so
+/// callers cannot accidentally pass insertion-ordered IDs and produce
+/// a non-canonical hash. Returns `sha256:<hex>` so the field stays
+/// self-describing in the JSON.
+#[must_use]
+pub fn shortlist_hash(paper_ids: &[String]) -> String {
+    let sorted: BTreeSet<&String> = paper_ids.iter().collect();
+    let mut hasher = Sha256::new();
+    for id in sorted {
+        hasher.update(id.as_bytes());
+        hasher.update(b"\n");
+    }
+    format!("sha256:{}", hex_lower(&hasher.finalize()))
+}
+
+/// SHA-256 of the emitted bytes. Returned as `sha256:<hex>`.
+#[must_use]
+pub fn content_hash(content: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(content.as_bytes());
+    format!("sha256:{}", hex_lower(&hasher.finalize()))
+}
+
+fn hex_lower(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        let _ = write!(out, "{b:02x}");
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shortlist_hash_is_order_independent() {
+        let a = shortlist_hash(&["p-zeta".into(), "p-alpha".into(), "p-mu".into()]);
+        let b = shortlist_hash(&["p-mu".into(), "p-alpha".into(), "p-zeta".into()]);
+        assert_eq!(a, b, "input order must not affect shortlist_hash");
+    }
+
+    #[test]
+    fn shortlist_hash_changes_on_membership_change() {
+        let a = shortlist_hash(&["p-1".into(), "p-2".into()]);
+        let b = shortlist_hash(&["p-1".into(), "p-2".into(), "p-3".into()]);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn shortlist_hash_format_self_describing() {
+        let h = shortlist_hash(&["p-1".into()]);
+        assert!(h.starts_with("sha256:"), "got: {h}");
+        // 7 prefix + 64 hex chars
+        assert_eq!(h.len(), 7 + 64);
+    }
+
+    #[test]
+    fn content_hash_format_self_describing() {
+        let h = content_hash("@article{x,\n  title={Y},\n}\n");
+        assert!(h.starts_with("sha256:"));
+        assert_eq!(h.len(), 7 + 64);
+    }
+
+    #[test]
+    fn content_hash_distinguishes_inputs() {
+        let a = content_hash("foo");
+        let b = content_hash("bar");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn lockfile_round_trips_via_serde() {
+        let lock = BibLockfile::new_bibtex(
+            "q-abc",
+            "lars",
+            &["p-1".into(), "p-2".into()],
+            "@article{x,\n}\n",
+        );
+        let json = lock.to_json().unwrap();
+        let back = BibLockfile::from_json(&json).unwrap();
+        assert_eq!(lock, back);
+    }
+
+    #[test]
+    fn lockfile_has_all_required_fields() {
+        let lock = BibLockfile::new_bibtex("q", "r", &[], "");
+        let json = lock.to_json().unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        for key in [
+            "question_id",
+            "reader",
+            "shortlist_hash",
+            "content_hash",
+            "scitadel_version",
+            "algo_hash",
+            "format",
+            "format_version",
+            "generated_at",
+        ] {
+            assert!(v.get(key).is_some(), "missing field: {key}");
+        }
+        assert_eq!(v["format"], "bibtex");
+        assert_eq!(v["format_version"], "1");
+    }
+
+    /// Sourcing `algo_hash` from the same `KEY_ALGO_HASH` constant the
+    /// exporter pins guarantees `bib verify` and the algorithm itself
+    /// can never disagree about freshness — they read the same byte.
+    #[test]
+    fn algo_hash_is_sourced_from_key_algo_hash_constant() {
+        assert_eq!(ALGO_HASH, crate::bibtex::KEY_ALGO_HASH);
+        let lock = BibLockfile::new_bibtex("q", "r", &[], "");
+        assert_eq!(lock.algo_hash, crate::bibtex::KEY_ALGO_HASH);
+    }
+}

--- a/crates/scitadel-mcp/src/server.rs
+++ b/crates/scitadel-mcp/src/server.rs
@@ -327,6 +327,27 @@ pub struct RekeyPaperRequest {
     pub reader: String,
 }
 
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct BibSnapshotRequest {
+    /// Research question ID (or unique prefix) whose shortlist to snapshot
+    pub question_id: String,
+    /// Output `.bib` path (e.g. `paper.bib`)
+    pub output: String,
+    /// Reader identity (mirrors annotation/star scoping)
+    pub reader: String,
+    /// Skip writing the `.scitadel-bib.lock` sidecar
+    #[serde(default)]
+    pub no_lock: bool,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct BibVerifyRequest {
+    /// Path to the committed `.bib` to verify
+    pub file: String,
+    /// Override the sidecar's question_id (rarely needed)
+    pub question_id: Option<String>,
+}
+
 // ---------- Server ----------
 
 #[derive(Debug, Clone)]
@@ -766,6 +787,23 @@ impl ScitadelServer {
         Parameters(req): Parameters<RekeyPaperRequest>,
     ) -> Result<String, String> {
         tools::rekey_paper_tool(&req.paper_id, req.explicit_key.as_deref(), &req.reader)
+    }
+
+    #[tool(
+        description = "Snapshot a question's citation shortlist to a deterministic `.bib` file plus a `.scitadel-bib.lock` sidecar (drift/stale anchor; #178). Same content twice ⇒ byte-identical `.bib` (sidecar `generated_at` excepted). Pass `no_lock=true` to skip the sidecar (CI one-offs). Returns: JSON `{output, papers, sidecar?, shortlist_hash?, content_hash?}`."
+    )]
+    fn bib_snapshot(
+        &self,
+        Parameters(req): Parameters<BibSnapshotRequest>,
+    ) -> Result<String, String> {
+        tools::bib_snapshot_tool(&req.question_id, &req.output, &req.reader, req.no_lock)
+    }
+
+    #[tool(
+        description = "Verify a `.bib` against its sidecar lockfile (#178). Computes shortlist + content hashes, compares with the lockfile, recognizes algo/version drift. Returns: JSON `{status, exit_code, ...}` where status is `ok` (0), `drift` (1: shortlist or content changed), or `stale` (2: lockfile absent or binary moved); shells should map exit_code to their process status."
+    )]
+    fn bib_verify(&self, Parameters(req): Parameters<BibVerifyRequest>) -> Result<String, String> {
+        tools::bib_verify_tool(&req.file, req.question_id.as_deref())
     }
 }
 

--- a/crates/scitadel-mcp/src/tools.rs
+++ b/crates/scitadel-mcp/src/tools.rs
@@ -1723,6 +1723,193 @@ pub fn rekey_paper_tool(
     }
 }
 
+// ---------- bib snapshot / verify (#178) ----------
+
+/// Sidecar suffix; mirrors the CLI constant. Kept in lockstep so MCP
+/// snapshots and CLI verifies share the same lockfile path.
+const SIDECAR_SUFFIX: &str = ".scitadel-bib.lock";
+
+fn sidecar_path_for(bib: &std::path::Path) -> std::path::PathBuf {
+    let mut s = bib.as_os_str().to_owned();
+    s.push(SIDECAR_SUFFIX);
+    std::path::PathBuf::from(s)
+}
+
+fn resolve_question_id(
+    db: &Database,
+    question_prefix: &str,
+) -> Result<scitadel_core::models::ResearchQuestion, String> {
+    let (_, _, q_repo, _, _) = db.repositories();
+    if let Some(q) = q_repo
+        .get_question(question_prefix)
+        .map_err(|e| e.to_string())?
+    {
+        return Ok(q);
+    }
+    let questions = q_repo.list_questions().map_err(|e| e.to_string())?;
+    let matches: Vec<_> = questions
+        .iter()
+        .filter(|q| q.id.as_str().starts_with(question_prefix))
+        .collect();
+    match matches.len() {
+        0 => Err(format!("no question matching '{question_prefix}'")),
+        1 => Ok(matches[0].clone()),
+        n => Err(format!(
+            "ambiguous question prefix '{question_prefix}' — {n} matches"
+        )),
+    }
+}
+
+/// Render the shortlist's `.bib` reusing `export_bibtex_with_tags` so
+/// the CLI and MCP code paths produce byte-identical output for the
+/// same DB state — the determinism contract that makes verify possible.
+fn render_shortlist_bibtex(
+    db: &Database,
+    paper_ids: &[String],
+) -> Result<(Vec<Paper>, String), String> {
+    use scitadel_db::sqlite::SqlitePaperTagRepository;
+    let (paper_repo, _, _, _, _) = db.repositories();
+    let papers: Vec<Paper> = paper_ids
+        .iter()
+        .filter_map(|id| paper_repo.get(id).ok().flatten())
+        .collect();
+    let tag_repo = SqlitePaperTagRepository::new(db.clone());
+    let mut tags = std::collections::HashMap::new();
+    for id in paper_ids {
+        tags.insert(id.clone(), tag_repo.tags_for(id).unwrap_or_default());
+    }
+    let content = scitadel_export::export_bibtex_with_tags(&papers, |id| {
+        tags.get(id).cloned().unwrap_or_default()
+    });
+    Ok((papers, content))
+}
+
+pub fn bib_snapshot_tool(
+    question_prefix: &str,
+    output: &str,
+    reader: &str,
+    no_lock: bool,
+) -> Result<String, String> {
+    if reader.trim().is_empty() {
+        return Err("reader is required".into());
+    }
+    let db = open_db()?;
+    let shortlist_repo = scitadel_db::sqlite::SqliteShortlistRepository::new(db.clone());
+    let question = resolve_question_id(&db, question_prefix)?;
+
+    let paper_ids = shortlist_repo
+        .list(question.id.as_str(), reader)
+        .map_err(|e| e.to_string())?;
+    let (papers, content) = render_shortlist_bibtex(&db, &paper_ids)?;
+
+    let output_path = std::path::Path::new(output);
+    std::fs::write(output_path, &content).map_err(|e| e.to_string())?;
+
+    let sidecar = sidecar_path_for(output_path);
+    let mut response = serde_json::Map::new();
+    response.insert("output".into(), serde_json::Value::String(output.into()));
+    response.insert("papers".into(), serde_json::Value::from(papers.len()));
+
+    if no_lock {
+        response.insert("sidecar".into(), serde_json::Value::Null);
+    } else {
+        let lock = scitadel_export::BibLockfile::new_bibtex(
+            question.id.as_str(),
+            reader,
+            &paper_ids,
+            &content,
+        );
+        std::fs::write(&sidecar, lock.to_json().map_err(|e| e.to_string())?)
+            .map_err(|e| e.to_string())?;
+        response.insert(
+            "sidecar".into(),
+            serde_json::Value::String(sidecar.display().to_string()),
+        );
+        response.insert(
+            "shortlist_hash".into(),
+            serde_json::Value::String(lock.shortlist_hash),
+        );
+        response.insert(
+            "content_hash".into(),
+            serde_json::Value::String(lock.content_hash),
+        );
+    }
+    Ok(serde_json::Value::Object(response).to_string())
+}
+
+pub fn bib_verify_tool(file: &str, question_override: Option<&str>) -> Result<String, String> {
+    let bib_path = std::path::Path::new(file);
+    let bib_bytes = std::fs::read_to_string(bib_path).map_err(|e| e.to_string())?;
+
+    let sidecar = sidecar_path_for(bib_path);
+    if !sidecar.exists() {
+        return Ok(serde_json::json!({
+            "status": "stale",
+            "exit_code": 2,
+            "message": format!("no lockfile at {} — run bib_snapshot first", sidecar.display()),
+        })
+        .to_string());
+    }
+    let lock_bytes = std::fs::read_to_string(&sidecar).map_err(|e| e.to_string())?;
+    let lock = scitadel_export::BibLockfile::from_json(&lock_bytes).map_err(|e| e.to_string())?;
+
+    // Stale checks first — if the binary moved, drift comparisons mean nothing.
+    let current_algo = scitadel_export::sidecar::ALGO_HASH;
+    let current_version = env!("CARGO_PKG_VERSION");
+    if lock.algo_hash != current_algo {
+        return Ok(serde_json::json!({
+            "status": "stale",
+            "exit_code": 2,
+            "message": format!(
+                "algo_hash mismatch: sidecar={} current={}",
+                lock.algo_hash, current_algo,
+            ),
+        })
+        .to_string());
+    }
+    if lock.scitadel_version != current_version {
+        return Ok(serde_json::json!({
+            "status": "stale",
+            "exit_code": 2,
+            "message": format!(
+                "scitadel_version mismatch: sidecar={} current={}",
+                lock.scitadel_version, current_version,
+            ),
+        })
+        .to_string());
+    }
+
+    let db = open_db()?;
+    let shortlist_repo = scitadel_db::sqlite::SqliteShortlistRepository::new(db.clone());
+    let qid = question_override.unwrap_or(&lock.question_id);
+    let question = resolve_question_id(&db, qid)?;
+
+    let paper_ids = shortlist_repo
+        .list(question.id.as_str(), &lock.reader)
+        .map_err(|e| e.to_string())?;
+    let (_papers, regenerated) = render_shortlist_bibtex(&db, &paper_ids)?;
+
+    let shortlist_changed = scitadel_export::shortlist_hash(&paper_ids) != lock.shortlist_hash;
+    let content_changed =
+        scitadel_export::content_hash(&bib_bytes) != lock.content_hash || bib_bytes != regenerated;
+    if shortlist_changed || content_changed {
+        return Ok(serde_json::json!({
+            "status": "drift",
+            "exit_code": 1,
+            "shortlist_changed": shortlist_changed,
+            "content_changed": content_changed,
+            "fix": format!("scitadel bib snapshot {} --output {}", lock.question_id, file),
+        })
+        .to_string());
+    }
+    Ok(serde_json::json!({
+        "status": "ok",
+        "exit_code": 0,
+        "message": "matches lockfile",
+    })
+    .to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::{


### PR DESCRIPTION
## Summary

- Lands the BibTeX-only pieces #132 dropped: `scitadel bib snapshot` (deterministic one-shot export of a question's shortlist) and `scitadel bib verify` (exit `0` ok / `1` drift / `2` stale) plus the `.scitadel-bib.lock` sidecar that anchors both.
- Snapshot reuses `export_bibtex_with_tags` so it produces byte-identical output to `bib watch` for the same DB state. `shortlist_hash` lex-sorts paper IDs before SHA-256 (the main pitfall called out in #178). `algo_hash` is sourced from the same `KEY_ALGO_HASH` constant ADR-006 freezes — never recomputed per build, so `cargo build` can't flip the stale flag.
- Adds matching `bib_snapshot` / `bib_verify` MCP tools so agents can drive the same workflow. `format` is a string discriminant (`"bibtex"` here) so #135 can add `"csl-json"` without a schema bump.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --tests -- -D warnings`
- [x] `cargo test --workspace --exclude scitadel-tui` — 22 new tests:
  - `scitadel-export::sidecar` (8): order-independent shortlist hash, schema completeness, `algo_hash` provenance, serde round-trip, content_hash format/distinctness.
  - `scitadel-cli::commands::bib_verify_tests` (7): every exit-code branch via the pure `verify_against_lockfile` primitive.
  - `scitadel-cli/tests/bib.rs` (7) end-to-end via the CLI binary: byte-determinism across runs, fresh-snapshot exit 0, content drift exit 1 with diff text, algo-hash stale exit 2, version stale exit 2, missing sidecar exit 2, `--no-lock` skip.
- [ ] Manual: `scitadel bib snapshot <q> --output paper.bib && scitadel bib verify paper.bib` against a real DB (smoke).

CLI surface change is `--help`-only (no TUI movement, no rendering changes), so no VHS tape: [tape-exempt: text-only `--help` addition under `scitadel bib`].

Out of scope per #178 and deferred:
- CSL-JSON variant (#135)
- TUI keybind (#135)
- Richer integrity checks (dangling citekeys, link validity)

Closes #178