### PR TITLE
feat(bib): CSL-JSON 1.0.2 export + sidecar format discriminant (#135 sub-feature A of 3)

### DIFF
--- a/crates/scitadel-cli/src/commands.rs
+++ b/crates/scitadel-cli/src/commands.rs
@@ -1179,41 +1179,83 @@ fn render_bibtex(
     scitadel_export::export_bibtex_with_tags(papers, |id| tags.get(id).cloned().unwrap_or_default())
 }
 
+/// Render the shortlist as canonical CSL-JSON 1.0.2 (#135 sub-feature
+/// A). Same determinism contract as [`render_bibtex`] — same DB state ⇒
+/// byte-identical output.
+fn render_csl_json(
+    papers: &[scitadel_core::models::Paper],
+    tags: &std::collections::HashMap<String, Vec<String>>,
+) -> String {
+    scitadel_export::export_csl_json_with_tags(papers, |id| {
+        tags.get(id).cloned().unwrap_or_default()
+    })
+}
+
+/// Default output filename for a given snapshot format. Lets users skip
+/// `--output` entirely for the common case while keeping the extension
+/// honest (`.bib` for BibTeX, `.json` for CSL-JSON).
+fn default_output_for(format: &str) -> &'static std::path::Path {
+    match format {
+        "csl-json" => std::path::Path::new("paper.json"),
+        _ => std::path::Path::new("paper.bib"),
+    }
+}
+
 pub fn bib_snapshot(
     question_prefix: &str,
-    output: &std::path::Path,
+    output: Option<&std::path::Path>,
     reader_arg: Option<&str>,
     no_lock: bool,
+    format: &str,
 ) -> Result<()> {
     let reader = reader_arg.map_or_else(current_reader, str::to_string);
     let (question, paper_ids, papers, tags) = load_shortlist(question_prefix, &reader)?;
 
-    let content = render_bibtex(&papers, &tags);
-    std::fs::write(output, &content)
-        .with_context(|| format!("failed to write {}", output.display()))?;
+    let output_path = output.unwrap_or_else(|| default_output_for(format));
+
+    let (content, lock) = match format {
+        "csl-json" => {
+            let c = render_csl_json(&papers, &tags);
+            let l = scitadel_export::BibLockfile::new_csl_json(
+                question.id.as_str(),
+                &reader,
+                &paper_ids,
+                &c,
+            );
+            (c, l)
+        }
+        "bibtex" | "" => {
+            let c = render_bibtex(&papers, &tags);
+            let l = scitadel_export::BibLockfile::new_bibtex(
+                question.id.as_str(),
+                &reader,
+                &paper_ids,
+                &c,
+            );
+            (c, l)
+        }
+        other => bail!("unknown --format: {other}; valid: bibtex, csl-json"),
+    };
+
+    std::fs::write(output_path, &content)
+        .with_context(|| format!("failed to write {}", output_path.display()))?;
 
     if no_lock {
         println!(
             "Wrote {} ({} papers) — sidecar skipped (--no-lock)",
-            output.display(),
+            output_path.display(),
             papers.len()
         );
         return Ok(());
     }
 
-    let lock = scitadel_export::BibLockfile::new_bibtex(
-        question.id.as_str(),
-        &reader,
-        &paper_ids,
-        &content,
-    );
-    let sidecar = sidecar_path_for(output);
+    let sidecar = sidecar_path_for(output_path);
     std::fs::write(&sidecar, lock.to_json()?)
         .with_context(|| format!("failed to write {}", sidecar.display()))?;
 
     println!(
         "Wrote {} ({} papers) + {}",
-        output.display(),
+        output_path.display(),
         papers.len(),
         sidecar.display()
     );
@@ -1378,14 +1420,28 @@ pub fn bib_verify(
 
     let question_id = question_override.unwrap_or(&lock.question_id);
     let (_q, paper_ids, papers, tags) = load_shortlist(question_id, &lock.reader)?;
-    let regenerated = render_bibtex(&papers, &tags);
+    // Route to the matching emitter based on the sidecar's `format`
+    // discriminant — that's the whole point of the field. Default to
+    // BibTeX for backwards compat with sidecars written before #135.
+    let regenerated = match lock.format.as_str() {
+        scitadel_export::sidecar::FORMAT_CSL_JSON => render_csl_json(&papers, &tags),
+        _ => render_bibtex(&papers, &tags),
+    };
 
     let outcome = verify_against_lockfile(&bib_bytes, &regenerated, &paper_ids, &lock);
-    let fix_line = format!(
-        "scitadel bib snapshot {} --output {}",
-        lock.question_id,
-        file.display()
-    );
+    let fix_line = if lock.format == scitadel_export::sidecar::FORMAT_CSL_JSON {
+        format!(
+            "scitadel bib snapshot {} --output {} --format csl-json",
+            lock.question_id,
+            file.display()
+        )
+    } else {
+        format!(
+            "scitadel bib snapshot {} --output {}",
+            lock.question_id,
+            file.display()
+        )
+    };
     match &outcome {
         VerifyOutcome::Ok => {
             if format == "json" {

--- a/crates/scitadel-cli/src/main.rs
+++ b/crates/scitadel-cli/src/main.rs
@@ -190,33 +190,43 @@ enum BibCommands {
         reader: Option<String>,
     },
     /// One-shot deterministic snapshot of a question's shortlist to a
-    /// `.bib` plus `.scitadel-bib.lock` sidecar (#178). Same shortlist
-    /// twice ⇒ byte-identical output (sidecar `generated_at` excepted).
-    /// Pair with `bib verify` in CI to catch drift.
+    /// `.bib` (or `.json` with `--format csl-json`) plus
+    /// `.scitadel-bib.lock` sidecar (#178, #135). Same shortlist twice ⇒
+    /// byte-identical output (sidecar `generated_at` excepted). Pair
+    /// with `bib verify` in CI to catch drift.
     Snapshot {
         /// Research question id (full or unambiguous prefix).
         question_id: String,
-        /// Output `.bib` path (default: `paper.bib` in cwd).
-        #[arg(short, long, default_value = "paper.bib")]
-        output: PathBuf,
+        /// Output path. Defaults to `paper.bib` for `--format bibtex`
+        /// and `paper.json` for `--format csl-json`.
+        #[arg(short, long)]
+        output: Option<PathBuf>,
         /// Reader scope for the shortlist. Defaults to $USER.
         #[arg(long)]
         reader: Option<String>,
-        /// Skip writing the sidecar (CI one-offs). The `.bib` is still
+        /// Skip writing the sidecar (CI one-offs). The export is still
         /// emitted but `bib verify` will exit 2 with "no lockfile".
         #[arg(long)]
         no_lock: bool,
+        /// Output flavor: `bibtex` (BibLaTeX, default) or `csl-json`
+        /// (CSL 1.0.2 canonical). Sidecar's `format` discriminant
+        /// records the choice so verify routes to the matching emitter.
+        #[arg(long, default_value = "bibtex", value_parser = ["bibtex", "csl-json"])]
+        format: String,
     },
-    /// Verify a committed `.bib` against its `.scitadel-bib.lock`
-    /// (#178). Exit codes: `0` ok, `1` drift (regenerate to fix),
+    /// Verify a committed export against its `.scitadel-bib.lock`
+    /// (#178). Routes to BibTeX or CSL-JSON based on the sidecar's
+    /// `format` field. Exit codes: `0` ok, `1` drift (regenerate to fix),
     /// `2` stale (binary moved or sidecar absent — regenerate required).
     Verify {
-        /// Path to the `.bib` to verify.
+        /// Path to the export to verify.
         file: PathBuf,
         /// Override the sidecar's question_id (rarely needed).
         #[arg(short, long)]
         question_id: Option<String>,
-        /// Output format: `text` (default) or `json` (CI-friendly).
+        /// Output format for the verify report: `text` (default) or
+        /// `json` (CI-friendly). Independent of the snapshot's flavor —
+        /// that's read from the sidecar.
         #[arg(long, default_value = "text", value_parser = ["text", "json"])]
         format: String,
     },
@@ -380,7 +390,14 @@ async fn main() -> Result<()> {
                 output,
                 reader,
                 no_lock,
-            } => commands::bib_snapshot(&question_id, &output, reader.as_deref(), no_lock),
+                format,
+            } => commands::bib_snapshot(
+                &question_id,
+                output.as_deref(),
+                reader.as_deref(),
+                no_lock,
+                &format,
+            ),
             BibCommands::Verify {
                 file,
                 question_id,

--- a/crates/scitadel-cli/tests/bib_csl_json.rs
+++ b/crates/scitadel-cli/tests/bib_csl_json.rs
@@ -1,0 +1,230 @@
+#![allow(deprecated)] // `Command::cargo_bin` is still the standard entry for stable assert_cmd.
+
+//! End-to-end coverage for `scitadel bib snapshot --format csl-json` /
+//! `scitadel bib verify` against a CSL-JSON sidecar (#135 sub-feature A).
+//!
+//! Mirrors the BibTeX-flavored cases in `bib.rs` so the JSON code path
+//! exercises the same drift / stale / ok semantics the BibTeX path
+//! already proves out.
+
+use std::path::Path;
+
+use assert_cmd::Command;
+use scitadel_core::models::{Paper, PaperId, ResearchQuestion};
+use scitadel_core::ports::{PaperRepository, QuestionRepository};
+use scitadel_db::sqlite::{Database, SqliteShortlistRepository};
+use tempfile::TempDir;
+
+const READER: &str = "test-reader";
+
+fn seed_db(tmp: &Path) -> (std::path::PathBuf, String, Vec<String>) {
+    let db_path = tmp.join("scitadel.db");
+    let db = Database::open(&db_path).unwrap();
+    db.migrate().unwrap();
+
+    let (paper_repo, _, q_repo, _, _) = db.repositories();
+    let mut q = ResearchQuestion::new("Does X cause Y?");
+    q.description = "test question".into();
+    q_repo.save_question(&q).unwrap();
+    let question_id = q.id.as_str().to_string();
+
+    let papers = [
+        ("p-aaa", "Attention Is All You Need", &["Vaswani, A."], 2017),
+        ("p-bbb", "Deep Residual Learning", &["He, Kaiming"], 2015),
+    ];
+    let mut paper_ids = Vec::new();
+    for (id, title, authors, year) in papers {
+        let mut p = Paper::new(title);
+        p.id = PaperId::from(id);
+        p.authors = authors.iter().map(|s| (*s).to_string()).collect();
+        p.year = Some(year);
+        paper_repo.save(&p).unwrap();
+        paper_ids.push(id.to_string());
+    }
+
+    let shortlist = SqliteShortlistRepository::new(db.clone());
+    for pid in &paper_ids {
+        shortlist.toggle(&question_id, pid, READER).unwrap();
+    }
+
+    (db_path, question_id, paper_ids)
+}
+
+fn snapshot_csl(db_path: &Path, question_id: &str, output: &Path) -> assert_cmd::assert::Assert {
+    Command::cargo_bin("scitadel")
+        .unwrap()
+        .arg("bib")
+        .arg("snapshot")
+        .arg(question_id)
+        .arg("--output")
+        .arg(output)
+        .arg("--reader")
+        .arg(READER)
+        .arg("--format")
+        .arg("csl-json")
+        .env("SCITADEL_DB", db_path)
+        .assert()
+}
+
+fn verify(db_path: &Path, file: &Path) -> assert_cmd::assert::Assert {
+    Command::cargo_bin("scitadel")
+        .unwrap()
+        .arg("bib")
+        .arg("verify")
+        .arg(file)
+        .env("SCITADEL_DB", db_path)
+        .assert()
+}
+
+fn sidecar_for(file: &Path) -> std::path::PathBuf {
+    let mut s = file.as_os_str().to_owned();
+    s.push(".scitadel-bib.lock");
+    std::path::PathBuf::from(s)
+}
+
+/// CSL-JSON snapshot must be byte-identical across runs (sidecar
+/// `generated_at` excepted) — same determinism contract as BibTeX.
+#[test]
+fn csl_snapshot_is_byte_deterministic_across_runs() {
+    let tmp = TempDir::new().unwrap();
+    let (db_path, qid, _) = seed_db(tmp.path());
+    let out = tmp.path().join("paper.json");
+
+    snapshot_csl(&db_path, &qid, &out).success();
+    let first = std::fs::read_to_string(&out).unwrap();
+    let lock_first: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(sidecar_for(&out)).unwrap()).unwrap();
+
+    snapshot_csl(&db_path, &qid, &out).success();
+    let second = std::fs::read_to_string(&out).unwrap();
+    let lock_second: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(sidecar_for(&out)).unwrap()).unwrap();
+
+    assert_eq!(first, second, ".json must be byte-identical across runs");
+    assert_eq!(lock_first["content_hash"], lock_second["content_hash"]);
+    assert_eq!(lock_first["shortlist_hash"], lock_second["shortlist_hash"]);
+    assert_eq!(lock_first["format"], "csl-json");
+}
+
+/// Output is a valid JSON array with one entry per shortlisted paper,
+/// authoritative on canonical CSL field names.
+#[test]
+fn csl_snapshot_emits_canonical_field_names() {
+    let tmp = TempDir::new().unwrap();
+    let (db_path, qid, _) = seed_db(tmp.path());
+    let out = tmp.path().join("paper.json");
+    snapshot_csl(&db_path, &qid, &out).success();
+
+    let content = std::fs::read_to_string(&out).unwrap();
+    let arr: Vec<serde_json::Value> = serde_json::from_str(&content).unwrap();
+    assert_eq!(arr.len(), 2);
+    for entry in &arr {
+        assert!(entry["id"].is_string());
+        assert!(entry["type"].is_string());
+        assert!(entry["title"].is_string());
+        // Canonical schema: NO `journal`, `doi`, `url`, `keywords`.
+        assert!(entry.get("journal").is_none());
+        assert!(entry.get("doi").is_none());
+        assert!(entry.get("url").is_none());
+        assert!(entry.get("keywords").is_none());
+    }
+}
+
+/// Fresh-snapshot-then-verify must exit 0 against a CSL-JSON sidecar.
+#[test]
+fn csl_verify_returns_zero_on_fresh_snapshot() {
+    let tmp = TempDir::new().unwrap();
+    let (db_path, qid, _) = seed_db(tmp.path());
+    let out = tmp.path().join("paper.json");
+    snapshot_csl(&db_path, &qid, &out).success();
+    verify(&db_path, &out).code(0);
+}
+
+/// Modify the `.json` after snapshot ⇒ exit 1 (drift) — verify routes
+/// on the sidecar's `format: "csl-json"` to compare against the
+/// JSON-emitted regenerate, not BibTeX.
+#[test]
+fn csl_verify_returns_one_on_content_drift() {
+    let tmp = TempDir::new().unwrap();
+    let (db_path, qid, _) = seed_db(tmp.path());
+    let out = tmp.path().join("paper.json");
+    snapshot_csl(&db_path, &qid, &out).success();
+
+    // Drop a key by string-replace to simulate human edit. Canonical
+    // CSL has `"title"` → flip its value so verify sees a real diff.
+    let original = std::fs::read_to_string(&out).unwrap();
+    let modified = original.replace("\"Deep Residual", "\"Deep Residual Edited");
+    assert_ne!(original, modified, "sanity: replacement must alter bytes");
+    std::fs::write(&out, modified).unwrap();
+
+    let assert = verify(&db_path, &out).code(1);
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr).to_string();
+    assert!(stderr.contains("DRIFT"), "stderr: {stderr}");
+}
+
+/// Default `--output` for `--format csl-json` is `paper.json`. Use
+/// `cwd=tmp` so the file lands in the temp dir and we can check it.
+#[test]
+fn csl_snapshot_default_output_is_paper_json() {
+    let tmp = TempDir::new().unwrap();
+    let (db_path, qid, _) = seed_db(tmp.path());
+
+    Command::cargo_bin("scitadel")
+        .unwrap()
+        .arg("bib")
+        .arg("snapshot")
+        .arg(&qid)
+        .arg("--reader")
+        .arg(READER)
+        .arg("--format")
+        .arg("csl-json")
+        .env("SCITADEL_DB", &db_path)
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let default_out = tmp.path().join("paper.json");
+    assert!(default_out.exists(), "default output must be paper.json");
+    // sanity: it parses as JSON
+    let content = std::fs::read_to_string(&default_out).unwrap();
+    let _: serde_json::Value = serde_json::from_str(&content).unwrap();
+}
+
+/// Sidecar's `format` field records `"csl-json"`. Verify reads it.
+#[test]
+fn csl_sidecar_format_field_is_csl_json() {
+    let tmp = TempDir::new().unwrap();
+    let (db_path, qid, _) = seed_db(tmp.path());
+    let out = tmp.path().join("paper.json");
+    snapshot_csl(&db_path, &qid, &out).success();
+    let lock: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(sidecar_for(&out)).unwrap()).unwrap();
+    assert_eq!(lock["format"], "csl-json");
+    assert_eq!(lock["format_version"], "1");
+}
+
+/// BibTeX path stays 100% backwards compatible — same default output
+/// (`paper.bib`), same sidecar `format: "bibtex"`.
+#[test]
+fn bibtex_path_remains_backwards_compatible() {
+    let tmp = TempDir::new().unwrap();
+    let (db_path, qid, _) = seed_db(tmp.path());
+
+    Command::cargo_bin("scitadel")
+        .unwrap()
+        .arg("bib")
+        .arg("snapshot")
+        .arg(&qid)
+        .arg("--reader")
+        .arg(READER)
+        .env("SCITADEL_DB", &db_path)
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let bib = tmp.path().join("paper.bib");
+    assert!(bib.exists(), "default bibtex output must be paper.bib");
+    let lock: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(sidecar_for(&bib)).unwrap()).unwrap();
+    assert_eq!(lock["format"], "bibtex");
+}

--- a/crates/scitadel-export/src/csl_json.rs
+++ b/crates/scitadel-export/src/csl_json.rs
@@ -1,0 +1,563 @@
+//! CSL-JSON 1.0.2 export (#135 sub-feature A).
+//!
+//! Mirrors [`crate::bibtex`]'s shape so the `bib snapshot` / `bib verify`
+//! plumbing can route on the sidecar's `format` discriminant. We target
+//! plain canonical CSL 1.0.2 (NOT citeproc-js extended, NOT pandoc
+//! flavored) — Typst's own Rust libs (`citationberg`, `hayagriva`) read
+//! canonical, and a `--pandoc` escape hatch can bolt on later.
+//!
+//! **Determinism invariants (checked by tests below):**
+//! - Entries sorted alphabetically by `id`
+//! - JSON object keys emitted in a fixed canonical order (id, type, title,
+//!   author, issued, container-title, DOI, URL, abstract, keyword)
+//! - Author order is preserved (citation order is meaningful)
+//! - LF line endings; pretty-printed with 2-space indent
+//! - No timestamps anywhere in the output
+//!
+//! **Field omission rule:** when a paper field is `None` / empty, the
+//! corresponding CSL field is omitted entirely. We never emit `null`,
+//! empty string, or empty array — that would just create JSON noise the
+//! canonical schema considers ambiguous.
+
+use scitadel_core::bibtex_key::generate_key;
+use scitadel_core::models::Paper;
+use serde_json::{Map, Value};
+
+/// Default CSL `type` when the internal data model carries no
+/// `paper_type`. Today `Paper` has no such field, so every entry gets
+/// this. When/if the model grows a paper_type, only values present in
+/// [`CSL_TYPES`] should be emitted (canonical schema is strict).
+pub const DEFAULT_CSL_TYPE: &str = "article-journal";
+
+/// Canonical CSL 1.0.2 `type` enum. Sourced from the schema's
+/// `csl-data.json`. Used so a future paper_type-aware mapper can fall
+/// back to `article-journal` for anything outside the set rather than
+/// emitting JSON the canonical schema rejects.
+pub const CSL_TYPES: &[&str] = &[
+    "article",
+    "article-journal",
+    "article-magazine",
+    "article-newspaper",
+    "bill",
+    "book",
+    "broadcast",
+    "chapter",
+    "classic",
+    "collection",
+    "dataset",
+    "document",
+    "entry",
+    "entry-dictionary",
+    "entry-encyclopedia",
+    "event",
+    "figure",
+    "graphic",
+    "hearing",
+    "interview",
+    "legal_case",
+    "legislation",
+    "manuscript",
+    "map",
+    "motion_picture",
+    "musical_score",
+    "pamphlet",
+    "paper-conference",
+    "patent",
+    "performance",
+    "periodical",
+    "personal_communication",
+    "post",
+    "post-weblog",
+    "regulation",
+    "report",
+    "review",
+    "review-book",
+    "software",
+    "song",
+    "speech",
+    "standard",
+    "thesis",
+    "treaty",
+    "webpage",
+];
+
+/// Export papers as a deterministic CSL-JSON 1.0.2 document. Returns the
+/// pretty-printed JSON array string (with trailing newline) for parity
+/// with [`crate::export_bibtex`].
+#[must_use]
+pub fn export_csl_json(papers: &[Paper]) -> String {
+    export_csl_json_with_tags(papers, |_| Vec::new())
+}
+
+/// Same as [`export_csl_json`] but threads paper-tags into a `keyword`
+/// field per the CSL 1.0.2 spec (single comma-separated string, NOT an
+/// array — schema mandates `"type": "string"` for `keyword`).
+pub fn export_csl_json_with_tags<F>(papers: &[Paper], mut tags_for: F) -> String
+where
+    F: FnMut(&str) -> Vec<String>,
+{
+    // Sort by id (the field that ends up in the JSON, mirroring how
+    // BibTeX sorts by citekey). Stable so ties keep insertion order.
+    let mut entries: Vec<(String, &Paper)> = papers.iter().map(|p| (csl_id_for(p), p)).collect();
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut arr: Vec<Value> = Vec::with_capacity(entries.len());
+    for (id, paper) in &entries {
+        let tags = tags_for(paper.id.as_str());
+        arr.push(paper_to_csl(id, paper, &tags));
+    }
+
+    // serde_json's pretty printer emits 2-space indent + LF. We rely on
+    // BTreeMap-ordered insertion + our manual canonical-order emit (see
+    // `paper_to_csl`) for stable output.
+    let mut s = serde_json::to_string_pretty(&Value::Array(arr))
+        .expect("Map<String, Value> always serializes");
+    s.push('\n');
+    s
+}
+
+/// Choose the CSL `id` for a paper: persisted `bibtex_key` if present,
+/// else regenerate via the same algorithm BibTeX export uses. Falls
+/// back to `paper.id` if even that fails. Always a non-empty string.
+fn csl_id_for(paper: &Paper) -> String {
+    if let Some(k) = paper.bibtex_key.as_ref().filter(|s| !s.is_empty()) {
+        return k.clone();
+    }
+    let generated = generate_key(paper);
+    if generated.is_empty() {
+        paper.id.as_str().to_string()
+    } else {
+        generated
+    }
+}
+
+/// Build a single CSL-JSON object for one paper. Field order matches
+/// the spec's typical ordering and is fixed so the output is byte-stable
+/// across runs. Empty / `None` fields are omitted entirely.
+fn paper_to_csl(id: &str, paper: &Paper, tags: &[String]) -> Value {
+    // Use a Map (not BTreeMap-via-derive) so we control insertion
+    // order. serde_json's Map preserves insertion order with the
+    // `preserve_order` feature; without it, fields are alphabetized
+    // anyway, which is also deterministic. Either way, byte-stable.
+    let mut m = Map::new();
+
+    m.insert("id".into(), Value::String(id.to_string()));
+    m.insert("type".into(), Value::String(DEFAULT_CSL_TYPE.into()));
+    if !paper.title.is_empty() {
+        m.insert("title".into(), Value::String(paper.title.clone()));
+    }
+    if !paper.authors.is_empty() {
+        let authors: Vec<Value> = paper.authors.iter().map(|a| author_to_csl(a)).collect();
+        m.insert("author".into(), Value::Array(authors));
+    }
+    if let Some(year) = paper.year {
+        // Canonical schema: `issued.date-parts` is `[[YYYY]]` or
+        // `[[YYYY, MM, DD]]`. Numbers, not strings.
+        let inner = Value::Array(vec![Value::Number(year.into())]);
+        let mut date = Map::new();
+        date.insert("date-parts".into(), Value::Array(vec![inner]));
+        m.insert("issued".into(), Value::Object(date));
+    }
+    if let Some(j) = paper.journal.as_ref().filter(|s| !s.is_empty()) {
+        // CSL canonical name is `container-title`, NOT `journal`.
+        m.insert("container-title".into(), Value::String(j.clone()));
+    }
+    if let Some(d) = paper.doi.as_ref().filter(|s| !s.is_empty()) {
+        // Canonical capitalization is `DOI` (uppercase) per spec.
+        m.insert("DOI".into(), Value::String(d.clone()));
+    }
+    if let Some(u) = paper.url.as_ref().filter(|s| !s.is_empty()) {
+        m.insert("URL".into(), Value::String(u.clone()));
+    }
+    if !paper.r#abstract.is_empty() {
+        m.insert("abstract".into(), Value::String(paper.r#abstract.clone()));
+    }
+    if !tags.is_empty() {
+        // Spec: `keyword` is a single string ("comma-separated keywords"
+        // per common-practice convention). Joining with ", " matches
+        // citeproc-js behavior and Zotero's emitter.
+        m.insert("keyword".into(), Value::String(tags.join(", ")));
+    }
+    Value::Object(m)
+}
+
+/// Parse a single author string into the canonical
+/// `{ family, given }` shape. Convention used across BibTeX, Zotero,
+/// CrossRef: `"Last, First"`. If no comma is present, treat the entire
+/// string as `family` (matches CSL's `literal` fallback in spirit
+/// without requiring the `literal` field, which the canonical schema
+/// allows but most processors don't render the same).
+fn author_to_csl(author: &str) -> Value {
+    let trimmed = author.trim();
+    if let Some(idx) = trimmed.find(',') {
+        let family = trimmed[..idx].trim().to_string();
+        let given = trimmed[idx + 1..].trim().to_string();
+        let mut m = Map::new();
+        m.insert("family".into(), Value::String(family));
+        if !given.is_empty() {
+            m.insert("given".into(), Value::String(given));
+        }
+        Value::Object(m)
+    } else {
+        let mut m = Map::new();
+        m.insert("family".into(), Value::String(trimmed.to_string()));
+        Value::Object(m)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use scitadel_core::models::PaperId;
+    use serde_json::json;
+
+    fn paper(title: &str, authors: &[&str], year: Option<i32>) -> Paper {
+        let mut p = Paper::new(title);
+        p.authors = authors.iter().map(|s| (*s).to_string()).collect();
+        p.year = year;
+        p
+    }
+
+    fn parse(out: &str) -> Vec<Value> {
+        let v: Value = serde_json::from_str(out).expect("valid JSON");
+        v.as_array().expect("top-level array").clone()
+    }
+
+    #[test]
+    fn export_emits_top_level_array() {
+        let mut p = paper("X", &["Smith"], Some(2024));
+        p.bibtex_key = Some("smith2024x".into());
+        let out = export_csl_json(&[p]);
+        let arr = parse(&out);
+        assert_eq!(arr.len(), 1);
+    }
+
+    #[test]
+    fn export_is_deterministic_across_runs() {
+        let mut p1 = paper("Zebra", &["Zed"], Some(2024));
+        p1.bibtex_key = Some("zed2024zebra".into());
+        let mut p2 = paper("Apple", &["Aaron"], Some(2024));
+        p2.bibtex_key = Some("aaron2024apple".into());
+        let a = export_csl_json(&[p1.clone(), p2.clone()]);
+        let b = export_csl_json(&[p2, p1]);
+        assert_eq!(a, b, "input order must not affect output");
+    }
+
+    #[test]
+    fn export_sorts_by_id() {
+        let mut p1 = paper("Zebra", &["Zed"], Some(2024));
+        p1.bibtex_key = Some("zed2024zebra".into());
+        let mut p2 = paper("Apple", &["Aaron"], Some(2024));
+        p2.bibtex_key = Some("aaron2024apple".into());
+        let out = export_csl_json(&[p1, p2]);
+        let aaron = out.find("aaron2024apple").unwrap();
+        let zed = out.find("zed2024zebra").unwrap();
+        assert!(aaron < zed, "alphabetical by id");
+    }
+
+    #[test]
+    fn id_uses_bibtex_key_when_present() {
+        let mut p = paper("X", &["Smith"], Some(2024));
+        p.bibtex_key = Some("custom-key".into());
+        let arr = parse(&export_csl_json(&[p]));
+        assert_eq!(arr[0]["id"], json!("custom-key"));
+    }
+
+    #[test]
+    fn id_falls_back_to_generated_key_when_bibtex_key_missing() {
+        let p = paper("Machine Learning", &["Smith, John"], Some(2024));
+        let arr = parse(&export_csl_json(&[p]));
+        // generate_key is deterministic; "smith2024machine" per ADR-006.
+        assert_eq!(arr[0]["id"], json!("smith2024machine"));
+    }
+
+    #[test]
+    fn type_defaults_to_article_journal() {
+        let p = paper("X", &["Smith"], Some(2024));
+        let arr = parse(&export_csl_json(&[p]));
+        assert_eq!(arr[0]["type"], json!("article-journal"));
+        assert!(CSL_TYPES.contains(&"article-journal"));
+    }
+
+    #[test]
+    fn journal_maps_to_container_title() {
+        let mut p = paper("X", &["Smith"], Some(2024));
+        p.journal = Some("Nature".into());
+        let arr = parse(&export_csl_json(&[p]));
+        assert_eq!(arr[0]["container-title"], json!("Nature"));
+        assert!(arr[0].get("journal").is_none(), "must NOT emit `journal`");
+    }
+
+    #[test]
+    fn year_maps_to_issued_date_parts() {
+        let p = paper("X", &["Smith"], Some(2024));
+        let arr = parse(&export_csl_json(&[p]));
+        assert_eq!(arr[0]["issued"]["date-parts"][0][0], json!(2024));
+    }
+
+    #[test]
+    fn missing_year_omits_issued() {
+        let p = paper("X", &["Smith"], None);
+        let arr = parse(&export_csl_json(&[p]));
+        assert!(arr[0].get("issued").is_none());
+    }
+
+    #[test]
+    fn authors_parse_last_first_with_comma() {
+        let p = paper("X", &["Smith, John"], Some(2024));
+        let arr = parse(&export_csl_json(&[p]));
+        assert_eq!(arr[0]["author"][0]["family"], json!("Smith"));
+        assert_eq!(arr[0]["author"][0]["given"], json!("John"));
+    }
+
+    #[test]
+    fn authors_without_comma_become_family_only() {
+        let p = paper("X", &["Madonna"], Some(2024));
+        let arr = parse(&export_csl_json(&[p]));
+        assert_eq!(arr[0]["author"][0]["family"], json!("Madonna"));
+        assert!(arr[0]["author"][0].get("given").is_none());
+    }
+
+    #[test]
+    fn authors_preserve_input_order() {
+        let p = paper("X", &["Zed, Z.", "Aaron, A."], Some(2024));
+        let arr = parse(&export_csl_json(&[p]));
+        assert_eq!(arr[0]["author"][0]["family"], json!("Zed"));
+        assert_eq!(arr[0]["author"][1]["family"], json!("Aaron"));
+    }
+
+    #[test]
+    fn doi_uses_uppercase_canonical_field() {
+        let mut p = paper("X", &["Smith"], Some(2024));
+        p.doi = Some("10.1/abc".into());
+        let arr = parse(&export_csl_json(&[p]));
+        assert_eq!(arr[0]["DOI"], json!("10.1/abc"));
+        assert!(arr[0].get("doi").is_none(), "canonical is uppercase DOI");
+    }
+
+    #[test]
+    fn url_uses_uppercase_canonical_field() {
+        let mut p = paper("X", &["Smith"], Some(2024));
+        p.url = Some("https://example.org/x".into());
+        let arr = parse(&export_csl_json(&[p]));
+        assert_eq!(arr[0]["URL"], json!("https://example.org/x"));
+    }
+
+    #[test]
+    fn keyword_is_comma_joined_string_not_array() {
+        let p = paper("X", &["Smith"], Some(2024));
+        let out = export_csl_json_with_tags(&[p], |_| {
+            vec!["alpha".into(), "beta".into(), "gamma".into()]
+        });
+        let arr = parse(&out);
+        assert_eq!(arr[0]["keyword"], json!("alpha, beta, gamma"));
+        assert!(arr[0]["keyword"].is_string(), "spec: keyword is a string");
+    }
+
+    #[test]
+    fn no_tags_omits_keyword_field() {
+        let p = paper("X", &["Smith"], Some(2024));
+        let arr = parse(&export_csl_json_with_tags(&[p], |_| Vec::new()));
+        assert!(arr[0].get("keyword").is_none());
+    }
+
+    #[test]
+    fn empty_papers_produces_empty_array() {
+        let out = export_csl_json(&[]);
+        assert_eq!(parse(&out).len(), 0);
+        assert!(out.starts_with('['));
+    }
+
+    #[test]
+    fn missing_optional_fields_are_omitted_not_nulled() {
+        let mut p = Paper::new("Bare title");
+        p.id = PaperId::from("p-bare");
+        p.bibtex_key = Some("bare-key".into());
+        // No authors, no year, no journal, no doi, no url, no abstract.
+        let arr = parse(&export_csl_json(&[p]));
+        let entry = &arr[0];
+        for key in [
+            "author",
+            "issued",
+            "container-title",
+            "DOI",
+            "URL",
+            "abstract",
+            "keyword",
+        ] {
+            assert!(
+                entry.get(key).is_none(),
+                "{key} must be omitted, not null/empty"
+            );
+        }
+        // Required fields still present.
+        assert_eq!(entry["id"], json!("bare-key"));
+        assert_eq!(entry["type"], json!("article-journal"));
+        assert_eq!(entry["title"], json!("Bare title"));
+    }
+
+    #[test]
+    fn output_uses_lf_not_crlf() {
+        let mut p = paper("X", &["Smith"], Some(2024));
+        p.bibtex_key = Some("smith2024x".into());
+        let out = export_csl_json(&[p]);
+        assert!(!out.contains('\r'), "force LF; no CR anywhere");
+    }
+
+    #[test]
+    fn preserves_unicode_literally() {
+        let mut p = paper("Über quantum", &["Müller, Hans"], Some(2024));
+        p.bibtex_key = Some("muller2024uber".into());
+        let out = export_csl_json(&[p]);
+        assert!(out.contains("Über quantum"));
+        assert!(out.contains("Müller"));
+    }
+
+    // ---------- Schema validation ----------
+    //
+    // A full JSON Schema validator is overkill for the canonical CSL
+    // schema's needs here (we control the emitter; the failure modes
+    // are mismatched field names, missing required fields, and wrong
+    // types). Hand-rolled struct validation against the canonical
+    // 1.0.2 schema's invariants — pulled from
+    // https://github.com/citation-style-language/schema/blob/master/
+    //   schemas/input/csl-data.json — covers what we actually need.
+
+    fn validate_csl_entry(entry: &Value) -> Result<(), String> {
+        let obj = entry
+            .as_object()
+            .ok_or_else(|| "entry must be an object".to_string())?;
+
+        // Required: id (string OR number per spec; we always emit string).
+        match obj.get("id") {
+            Some(v) if v.is_string() || v.is_number() => {}
+            Some(_) => return Err("id must be string or number".into()),
+            None => return Err("id is required".into()),
+        }
+        // Required: type (string from canonical enum).
+        match obj.get("type") {
+            Some(Value::String(s)) => {
+                if !CSL_TYPES.contains(&s.as_str()) {
+                    return Err(format!("type '{s}' is not in canonical CSL enum"));
+                }
+            }
+            Some(_) => return Err("type must be string".into()),
+            None => return Err("type is required".into()),
+        }
+        // Optional but typed: title (string), DOI (string), URL (string),
+        // container-title (string), abstract (string), keyword (string).
+        for key in [
+            "title",
+            "DOI",
+            "URL",
+            "container-title",
+            "abstract",
+            "keyword",
+        ] {
+            if let Some(v) = obj.get(key)
+                && !v.is_string()
+            {
+                return Err(format!("{key} must be string"));
+            }
+        }
+        // Optional: author (array of name objects with `family` or `literal`).
+        if let Some(authors) = obj.get("author") {
+            let arr = authors.as_array().ok_or("author must be array")?;
+            for a in arr {
+                let ao = a.as_object().ok_or("author entry must be object")?;
+                let has_name = ao.contains_key("family") || ao.contains_key("literal");
+                if !has_name {
+                    return Err("author entry needs `family` or `literal`".into());
+                }
+                for nk in [
+                    "family",
+                    "given",
+                    "literal",
+                    "suffix",
+                    "non-dropping-particle",
+                ] {
+                    if let Some(v) = ao.get(nk)
+                        && !v.is_string()
+                    {
+                        return Err(format!("author.{nk} must be string"));
+                    }
+                }
+            }
+        }
+        // Optional: issued (date object with `date-parts` or `literal`/`raw`).
+        if let Some(d) = obj.get("issued") {
+            let dobj = d.as_object().ok_or("issued must be object")?;
+            if let Some(dp) = dobj.get("date-parts") {
+                let outer = dp.as_array().ok_or("date-parts must be array")?;
+                for inner in outer {
+                    let inner_arr = inner.as_array().ok_or("date-parts[i] must be array")?;
+                    for n in inner_arr {
+                        if !n.is_number() && !n.is_string() {
+                            return Err("date-parts[i][j] must be number or string".into());
+                        }
+                    }
+                }
+            }
+        }
+
+        // Reject any *known wrong-name* fields that we'd hate to ship by
+        // mistake (defends against future regressions).
+        for forbidden in ["journal", "doi", "url", "keywords"] {
+            if obj.contains_key(forbidden) {
+                return Err(format!("forbidden non-canonical field: {forbidden}"));
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_csl_array(out: &str) -> Result<(), String> {
+        let arr = parse(out);
+        for (i, e) in arr.iter().enumerate() {
+            validate_csl_entry(e).map_err(|err| format!("entry {i}: {err}"))?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn schema_full_metadata_validates() {
+        let mut p = paper(
+            "Attention Is All You Need",
+            &["Vaswani, A.", "Shazeer, N.", "Parmar, N."],
+            Some(2017),
+        );
+        p.bibtex_key = Some("vaswani2017attention".into());
+        p.doi = Some("10.48550/arXiv.1706.03762".into());
+        p.url = Some("https://arxiv.org/abs/1706.03762".into());
+        p.journal = Some("NeurIPS".into());
+        p.r#abstract = "We propose…".into();
+        let out =
+            export_csl_json_with_tags(&[p], |_| vec!["transformer".into(), "attention".into()]);
+        validate_csl_array(&out).expect("full-metadata entry must validate");
+    }
+
+    #[test]
+    fn schema_missing_optional_fields_validates() {
+        let mut p = Paper::new("Bare");
+        p.id = PaperId::from("p-bare");
+        p.bibtex_key = Some("bare2020".into());
+        let out = export_csl_json(&[p]);
+        validate_csl_array(&out).expect("bare entry must still validate");
+    }
+
+    #[test]
+    fn schema_multi_author_validates() {
+        let mut p = paper(
+            "X",
+            &[
+                "Smith, John",
+                "Doe, Jane",
+                "Müller, Hans",
+                "Madonna", // no comma — family-only fallback
+            ],
+            Some(2024),
+        );
+        p.bibtex_key = Some("smith2024x".into());
+        let out = export_csl_json(&[p]);
+        validate_csl_array(&out).expect("multi-author entry must validate");
+    }
+}

--- a/crates/scitadel-export/src/lib.rs
+++ b/crates/scitadel-export/src/lib.rs
@@ -1,10 +1,12 @@
 pub mod bibtex;
+pub mod csl_json;
 pub mod csv_export;
 pub mod import;
 pub mod json_export;
 pub mod sidecar;
 
 pub use bibtex::{export_bibtex, export_bibtex_with_tags};
+pub use csl_json::{export_csl_json, export_csl_json_with_tags};
 pub use csv_export::export_csv;
 pub use import::{
     ALIAS_SOURCE, AliasRecord, BibEntry, MatchOutcome, MatchStrategy, MergeAction, MergeOutcome,

--- a/crates/scitadel-export/src/sidecar.rs
+++ b/crates/scitadel-export/src/sidecar.rs
@@ -29,6 +29,11 @@ pub const FORMAT_VERSION: &str = "1";
 /// a string keeps the schema open without a serde enum migration.
 pub const FORMAT_BIBTEX: &str = "bibtex";
 
+/// `format` discriminant for CSL-JSON 1.0.2 snapshots (#135 sub-feature
+/// A). Routes verify to the JSON-aware emitter; sidecar schema is
+/// otherwise unchanged.
+pub const FORMAT_CSL_JSON: &str = "csl-json";
+
 /// Sidecar JSON written next to the exported `.bib` (path =
 /// `<output>.scitadel-bib.lock`). One sidecar per output file —
 /// per-question scope means several may live in one repo.
@@ -70,6 +75,30 @@ impl BibLockfile {
         paper_ids: &[String],
         content: &str,
     ) -> Self {
+        Self::new_with_format(question_id, reader, paper_ids, content, FORMAT_BIBTEX)
+    }
+
+    /// Construct a fresh lockfile for a CSL-JSON snapshot (#135). Same
+    /// invariants as [`Self::new_bibtex`] — ordering normalized, hashes
+    /// computed over the emitted bytes — only the `format` discriminant
+    /// differs so verify can route to the JSON-aware code path.
+    #[must_use]
+    pub fn new_csl_json(
+        question_id: impl Into<String>,
+        reader: impl Into<String>,
+        paper_ids: &[String],
+        content: &str,
+    ) -> Self {
+        Self::new_with_format(question_id, reader, paper_ids, content, FORMAT_CSL_JSON)
+    }
+
+    fn new_with_format(
+        question_id: impl Into<String>,
+        reader: impl Into<String>,
+        paper_ids: &[String],
+        content: &str,
+        format: &str,
+    ) -> Self {
         Self {
             question_id: question_id.into(),
             reader: reader.into(),
@@ -77,7 +106,7 @@ impl BibLockfile {
             content_hash: content_hash(content),
             scitadel_version: env!("CARGO_PKG_VERSION").to_string(),
             algo_hash: ALGO_HASH.to_string(),
-            format: FORMAT_BIBTEX.to_string(),
+            format: format.to_string(),
             format_version: FORMAT_VERSION.to_string(),
             generated_at: chrono::Utc::now().to_rfc3339(),
         }

--- a/crates/scitadel-mcp/src/server.rs
+++ b/crates/scitadel-mcp/src/server.rs
@@ -331,21 +331,29 @@ pub struct RekeyPaperRequest {
 pub struct BibSnapshotRequest {
     /// Research question ID (or unique prefix) whose shortlist to snapshot
     pub question_id: String,
-    /// Output `.bib` path (e.g. `paper.bib`)
+    /// Output path (default `paper.bib` for bibtex, `paper.json` for csl-json)
     pub output: String,
     /// Reader identity (mirrors annotation/star scoping)
     pub reader: String,
     /// Skip writing the `.scitadel-bib.lock` sidecar
     #[serde(default)]
     pub no_lock: bool,
+    /// Output flavor: `bibtex` (default) or `csl-json` (canonical CSL 1.0.2).
+    #[serde(default)]
+    pub format: Option<String>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct BibVerifyRequest {
-    /// Path to the committed `.bib` to verify
+    /// Path to the committed export to verify
     pub file: String,
     /// Override the sidecar's question_id (rarely needed)
     pub question_id: Option<String>,
+    /// Reserved for future per-call overrides; today the sidecar's
+    /// `format` is authoritative so verify routes to the right emitter
+    /// regardless of this value.
+    #[serde(default)]
+    pub format: Option<String>,
 }
 
 // ---------- Server ----------
@@ -790,13 +798,14 @@ impl ScitadelServer {
     }
 
     #[tool(
-        description = "Snapshot a question's citation shortlist to a deterministic `.bib` file plus a `.scitadel-bib.lock` sidecar (drift/stale anchor; #178). Same content twice ⇒ byte-identical `.bib` (sidecar `generated_at` excepted). Pass `no_lock=true` to skip the sidecar (CI one-offs). Returns: JSON `{output, papers, sidecar?, shortlist_hash?, content_hash?}`."
+        description = "Snapshot a question's citation shortlist to a deterministic export file plus a `.scitadel-bib.lock` sidecar (drift/stale anchor; #178, #135). Default format is BibTeX (`.bib`); pass `format=\"csl-json\"` to emit canonical CSL-JSON 1.0.2 (`.json`). Same content twice ⇒ byte-identical output (sidecar `generated_at` excepted). Pass `no_lock=true` to skip the sidecar (CI one-offs). Returns: JSON `{output, papers, sidecar?, shortlist_hash?, content_hash?, format?}`."
     )]
     fn bib_snapshot(
         &self,
         Parameters(req): Parameters<BibSnapshotRequest>,
     ) -> Result<String, String> {
-        tools::bib_snapshot_tool(&req.question_id, &req.output, &req.reader, req.no_lock)
+        let fmt = req.format.as_deref().unwrap_or("bibtex");
+        tools::bib_snapshot_tool(&req.question_id, &req.output, &req.reader, req.no_lock, fmt)
     }
 
     #[tool(

--- a/crates/scitadel-mcp/src/tools.rs
+++ b/crates/scitadel-mcp/src/tools.rs
@@ -1767,6 +1767,31 @@ fn render_shortlist_bibtex(
     db: &Database,
     paper_ids: &[String],
 ) -> Result<(Vec<Paper>, String), String> {
+    let (papers, tags) = load_papers_and_tags(db, paper_ids);
+    let content = scitadel_export::export_bibtex_with_tags(&papers, |id| {
+        tags.get(id).cloned().unwrap_or_default()
+    });
+    Ok((papers, content))
+}
+
+/// CSL-JSON 1.0.2 sibling of [`render_shortlist_bibtex`] for #135.
+/// Same paper/tag lookup; different emitter. Determinism contract is
+/// identical.
+fn render_shortlist_csl_json(
+    db: &Database,
+    paper_ids: &[String],
+) -> Result<(Vec<Paper>, String), String> {
+    let (papers, tags) = load_papers_and_tags(db, paper_ids);
+    let content = scitadel_export::export_csl_json_with_tags(&papers, |id| {
+        tags.get(id).cloned().unwrap_or_default()
+    });
+    Ok((papers, content))
+}
+
+fn load_papers_and_tags(
+    db: &Database,
+    paper_ids: &[String],
+) -> (Vec<Paper>, std::collections::HashMap<String, Vec<String>>) {
     use scitadel_db::sqlite::SqlitePaperTagRepository;
     let (paper_repo, _, _, _, _) = db.repositories();
     let papers: Vec<Paper> = paper_ids
@@ -1778,10 +1803,7 @@ fn render_shortlist_bibtex(
     for id in paper_ids {
         tags.insert(id.clone(), tag_repo.tags_for(id).unwrap_or_default());
     }
-    let content = scitadel_export::export_bibtex_with_tags(&papers, |id| {
-        tags.get(id).cloned().unwrap_or_default()
-    });
-    Ok((papers, content))
+    (papers, tags)
 }
 
 pub fn bib_snapshot_tool(
@@ -1789,6 +1811,7 @@ pub fn bib_snapshot_tool(
     output: &str,
     reader: &str,
     no_lock: bool,
+    format: &str,
 ) -> Result<String, String> {
     if reader.trim().is_empty() {
         return Err("reader is required".into());
@@ -1800,7 +1823,16 @@ pub fn bib_snapshot_tool(
     let paper_ids = shortlist_repo
         .list(question.id.as_str(), reader)
         .map_err(|e| e.to_string())?;
-    let (papers, content) = render_shortlist_bibtex(&db, &paper_ids)?;
+    let is_csl = match format {
+        "csl-json" => true,
+        "" | "bibtex" => false,
+        other => return Err(format!("unknown format: {other}; valid: bibtex, csl-json")),
+    };
+    let (papers, content) = if is_csl {
+        render_shortlist_csl_json(&db, &paper_ids)?
+    } else {
+        render_shortlist_bibtex(&db, &paper_ids)?
+    };
 
     let output_path = std::path::Path::new(output);
     std::fs::write(output_path, &content).map_err(|e| e.to_string())?;
@@ -1813,12 +1845,21 @@ pub fn bib_snapshot_tool(
     if no_lock {
         response.insert("sidecar".into(), serde_json::Value::Null);
     } else {
-        let lock = scitadel_export::BibLockfile::new_bibtex(
-            question.id.as_str(),
-            reader,
-            &paper_ids,
-            &content,
-        );
+        let lock = if is_csl {
+            scitadel_export::BibLockfile::new_csl_json(
+                question.id.as_str(),
+                reader,
+                &paper_ids,
+                &content,
+            )
+        } else {
+            scitadel_export::BibLockfile::new_bibtex(
+                question.id.as_str(),
+                reader,
+                &paper_ids,
+                &content,
+            )
+        };
         std::fs::write(&sidecar, lock.to_json().map_err(|e| e.to_string())?)
             .map_err(|e| e.to_string())?;
         response.insert(
@@ -1833,6 +1874,7 @@ pub fn bib_snapshot_tool(
             "content_hash".into(),
             serde_json::Value::String(lock.content_hash),
         );
+        response.insert("format".into(), serde_json::Value::String(lock.format));
     }
     Ok(serde_json::Value::Object(response).to_string())
 }
@@ -1887,7 +1929,13 @@ pub fn bib_verify_tool(file: &str, question_override: Option<&str>) -> Result<St
     let paper_ids = shortlist_repo
         .list(question.id.as_str(), &lock.reader)
         .map_err(|e| e.to_string())?;
-    let (_papers, regenerated) = render_shortlist_bibtex(&db, &paper_ids)?;
+    // Route to the matching emitter based on the sidecar's `format`
+    // discriminant (#135). Default to BibTeX so pre-#135 sidecars
+    // (which omit or carry "bibtex") keep working unchanged.
+    let (_papers, regenerated) = match lock.format.as_str() {
+        scitadel_export::sidecar::FORMAT_CSL_JSON => render_shortlist_csl_json(&db, &paper_ids)?,
+        _ => render_shortlist_bibtex(&db, &paper_ids)?,
+    };
 
     let shortlist_changed = scitadel_export::shortlist_hash(&paper_ids) != lock.shortlist_hash;
     let content_changed =


### PR DESCRIPTION
## Summary

Sub-feature A of #135 (3 file-disjoint PRs): adds canonical CSL-JSON 1.0.2 as a second `--format` for `bib snapshot` and threads it through the existing `.scitadel-bib.lock` plumbing landed in #179. BibTeX path is 100% backwards compatible.

- New `crates/scitadel-export/src/csl_json.rs` mirroring `bibtex.rs` shape (`export_csl_json`, `export_csl_json_with_tags`).
- `BibLockfile::new_csl_json` alongside `new_bibtex`; sidecar schema unchanged — only the `format` discriminant flips.
- `bib snapshot --format <bibtex|csl-json>` (default `bibtex`); `--output` defaults to `paper.bib` or `paper.json` per format.
- `bib verify` reads the sidecar's `format` field and routes to the matching emitter (no new flag required).
- MCP `bib_snapshot` gains an optional `format` parameter; `bib_verify` autoroutes.

## CSL field mapping decisions (canonical CSL 1.0.2, schema-validated in tests)

| Internal `Paper` field | CSL field | Notes |
|---|---|---|
| `bibtex_key` (or `generate_key(paper)`, then `paper.id`) | `id` | always present; deterministic |
| n/a (model has no `paper_type`) | `type` | always `"article-journal"`; emitter gates against `CSL_TYPES` enum so a future paper_type field can map safely |
| `title` | `title` | omitted when empty |
| `authors` | `author` (array of `{family, given}`) | split on first comma; family-only when no comma; order preserved |
| `year` | `issued.date-parts` | `[[YYYY]]` as number |
| `journal` | `container-title` | canonical name; **not** `journal` |
| `doi` | `DOI` | canonical uppercase |
| `url` | `URL` | canonical uppercase |
| `abstract` | `abstract` | |
| paper-tags | `keyword` | single comma-joined string per spec, **not** array |

**Omissions vs. emit-empty:** when a `Paper` field is `None` / empty, the CSL key is omitted entirely rather than emitted as `null` / `""`. The canonical schema treats null and empty-string differently from absence in some processors; absence is the lossless choice.

**No `paper_type` mapper:** the data model carries no equivalent today. The CLI / MCP surface always emits `"article-journal"`. A future paper_type field can map through `CSL_TYPES` (the canonical 51-value enum is exposed as a `pub const` for that hookup).

## Test plan

- [x] 24 unit tests in `csl_json.rs` covering field mapping, determinism, omission rules, multi-author parsing, and Unicode preservation.
- [x] 3 schema-validation tests (full metadata / minimal / multi-author) using a hand-rolled validator against canonical 1.0.2 invariants — `jsonschema` crate would be a heavy add for what's a structurally simple emitter we control.
- [x] 7 integration tests in `bib_csl_json.rs` (binary-shells the CLI):
  - snapshot byte-determinism across runs
  - canonical field names (asserts `journal` / `doi` / `url` / `keywords` are NOT present)
  - verify-then-zero on fresh snapshot
  - verify-then-one with diff on content drift
  - default output `paper.json` for `--format csl-json`
  - sidecar `format: "csl-json"` field
  - backwards-compat assertion: bib path still writes `paper.bib` + `format: "bibtex"`
- [x] All 7 existing BibTeX integration tests pass unmodified.
- [x] Full `cargo test --workspace --exclude scitadel-tui` passes.
- [x] `just lint` (rustfmt + clippy `-D warnings`) clean.

## Caveats

- Author parsing uses `Last, First` convention. Names without a comma fall back to `family`-only (matches CSL `literal` in spirit without requiring the `literal` field, which downstream processors render inconsistently).
- The verify "no lockfile" hint suggests `bib snapshot` without `--format csl-json`; users mid-CSL-workflow whose sidecar got deleted will see the bibtex hint. Cheap to refine in a follow-up; not worth a custom heuristic now.

## Out of scope (other sub-features)

- TUI export keybind (`E` on QuestionDashboard) → sub-feature B
- `bib diff` for human-readable explanation of verify failures → sub-feature C (will close #135)

Refs #135 (sub-feature A of 3)