### PR TITLE
feat(bib): bib diff — entry-level structural diff (#135 sub-feature C of 3)

### DIFF
--- a/crates/scitadel-cli/src/commands.rs
+++ b/crates/scitadel-cli/src/commands.rs
@@ -1495,6 +1495,161 @@ fn print_verify_json(status: &str, message: &str, diff: Option<&str>) {
     println!("{}", serde_json::Value::Object(obj));
 }
 
+// ---------- bib diff (#135 sub-feature C) ----------
+
+/// Detect whether stdout is a TTY so we know whether ANSI color codes
+/// will display correctly. Routed through `IsTerminal` from `std::io`
+/// so we don't pull in a `colored`/`atty` crate just to ask the OS one
+/// question. `--no-color` overrides this to `false` regardless.
+fn stdout_is_tty() -> bool {
+    use std::io::IsTerminal as _;
+    std::io::stdout().is_terminal()
+}
+
+/// Run `scitadel bib diff` against two file paths OR a file vs. a
+/// fresh-from-DB snapshot of `--question-id`. Returns the exit code:
+/// `0` if there's no structural diff, `1` if there is (mirrors
+/// `git diff` semantics so CI scripts can `if cmd; then` them).
+pub fn bib_diff(
+    file_a: &std::path::Path,
+    file_b: Option<&std::path::Path>,
+    question_id: Option<&str>,
+    format: &str,
+    no_color: bool,
+    reader_arg: Option<&str>,
+) -> Result<i32> {
+    // Argument validation up front: exactly one of (file_b, question_id).
+    let (entries_a, fmt_a) =
+        scitadel_export::load_entries_from_path(file_a).map_err(|e| anyhow::anyhow!(e))?;
+    let (entries_b, label_b) = match (file_b, question_id) {
+        (Some(_), Some(_)) => bail!("pass either <file_b> OR --question-id, not both"),
+        (None, None) => bail!("missing second side: pass <file_b> or --question-id <id>"),
+        (Some(b), None) => {
+            let (e, _fmt) =
+                scitadel_export::load_entries_from_path(b).map_err(|err| anyhow::anyhow!(err))?;
+            (e, format!("{}", b.display()))
+        }
+        (None, Some(qid)) => {
+            // Fresh snapshot from DB. Use the same reader resolution
+            // as snapshot/verify so stars and shortlist scoping line up.
+            let reader = reader_arg.map_or_else(current_reader, str::to_string);
+            let (q, _ids, papers, tags) = load_shortlist(qid, &reader)?;
+            // Snapshot in the same flavor as the file side so the
+            // comparison is apples-to-apples (the diff is structural so
+            // either format works, but staying consistent avoids any
+            // round-trip lossiness in the format-neutral lift).
+            let content = match fmt_a {
+                scitadel_export::BibFormat::CslJson => render_csl_json(&papers, &tags),
+                scitadel_export::BibFormat::Bibtex => render_bibtex(&papers, &tags),
+            };
+            let (e, _fmt) = scitadel_export::load_entries_from_str(&content)
+                .map_err(|err| anyhow::anyhow!(err))?;
+            (e, format!("question {}", q.id.as_str()))
+        }
+    };
+
+    let diff = scitadel_export::diff_entries(&entries_a, &entries_b);
+    let exit = i32::from(!diff.is_empty());
+
+    match format {
+        "json" => {
+            print!(
+                "{}",
+                scitadel_export::render_diff_json(&diff)
+                    .context("failed to serialize diff JSON")?
+            );
+        }
+        "text" | "" => {
+            let use_color = !no_color && stdout_is_tty();
+            let header_a = file_a.display().to_string();
+            let text = scitadel_export::render_diff_text(&diff, &header_a, &label_b, use_color);
+            print!("{text}");
+        }
+        other => bail!("unknown --format: {other}; valid: text, json"),
+    }
+    Ok(exit)
+}
+
+#[cfg(test)]
+mod bib_diff_tests {
+    //! Unit tests for the CLI's `bib diff` plumbing. The pure-logic
+    //! tests live in `scitadel-export::diff::tests`; here we just
+    //! sanity-check the wiring (TTY toggle, exit-code derivation,
+    //! format dispatch).
+    use scitadel_export::{BibDiff, ChangedEntry, Entry, FieldChange};
+
+    fn no_diff() -> BibDiff {
+        BibDiff::default()
+    }
+
+    fn with_diff() -> BibDiff {
+        BibDiff {
+            added: vec![],
+            removed: vec![],
+            changed: vec![ChangedEntry {
+                citekey: "k".into(),
+                before_citekey: None,
+                field_changes: vec![FieldChange {
+                    field: "title".into(),
+                    before: Some("Old".into()),
+                    after: Some("New".into()),
+                }],
+            }],
+        }
+    }
+
+    #[test]
+    fn empty_diff_renders_no_differences_marker() {
+        let out = scitadel_export::render_diff_text(&no_diff(), "A", "B", false);
+        assert!(out.contains("No differences"));
+    }
+
+    #[test]
+    fn non_empty_diff_includes_changed_section() {
+        let out = scitadel_export::render_diff_text(&with_diff(), "A", "B", false);
+        assert!(out.contains("CHANGED (1):"));
+        assert!(out.contains("Old → New"));
+    }
+
+    #[test]
+    fn no_color_strips_ansi() {
+        let out = scitadel_export::render_diff_text(&with_diff(), "A", "B", false);
+        assert!(!out.contains('\x1b'));
+    }
+
+    #[test]
+    fn color_path_emits_ansi() {
+        let out = scitadel_export::render_diff_text(&with_diff(), "A", "B", true);
+        assert!(out.contains('\x1b'));
+    }
+
+    #[test]
+    fn json_format_round_trips_through_serde() {
+        let d = with_diff();
+        let json = scitadel_export::render_diff_json(&d).unwrap();
+        let back: BibDiff = serde_json::from_str(&json).unwrap();
+        assert_eq!(d, back);
+    }
+
+    #[test]
+    fn diff_is_empty_helper_drives_exit_code() {
+        // Simulate the `bib_diff` exit derivation: 0 iff is_empty, else 1.
+        let _no_op = no_diff();
+        assert_eq!(i32::from(!no_diff().is_empty()), 0);
+        assert_eq!(i32::from(!with_diff().is_empty()), 1);
+        // and the "summary one-liner" used in text rendering is robust
+        // when authors empty.
+        let bare = Entry {
+            citekey: "x".into(),
+            ..Default::default()
+        };
+        let mut d = BibDiff::default();
+        d.added.push(bare);
+        let out = scitadel_export::render_diff_text(&d, "A", "B", false);
+        assert!(out.contains("ADDED (1):"));
+    }
+}
+
 fn prompt_credential(label: &str, secret: bool) -> Result<String> {
     if secret {
         // Read without echo

--- a/crates/scitadel-cli/src/main.rs
+++ b/crates/scitadel-cli/src/main.rs
@@ -230,6 +230,34 @@ enum BibCommands {
         #[arg(long, default_value = "text", value_parser = ["text", "json"])]
         format: String,
     },
+    /// Structural diff between two bibliography exports — entry-level
+    /// (added / removed / changed) rather than line-level. Mirrors the
+    /// human-readable "what actually moved" report `bib verify` only
+    /// hints at via its line diff. Auto-detects BibTeX vs CSL-JSON by
+    /// content sniff; the two flavors are interchangeable. Exit codes:
+    /// `0` no diff, `1` diff (mirrors `git diff`).
+    Diff {
+        /// First file (BibTeX or CSL-JSON).
+        file_a: PathBuf,
+        /// Second file. Mutually exclusive with `--question-id`.
+        file_b: Option<PathBuf>,
+        /// Compare `file_a` against a fresh snapshot of this question's
+        /// shortlist from the DB. Mutually exclusive with `<file_b>`.
+        #[arg(long)]
+        question_id: Option<String>,
+        /// Output format: `text` (default, hand-rolled ANSI when
+        /// stdout is a TTY) or `json` (structured, CI-friendly).
+        #[arg(long, default_value = "text", value_parser = ["text", "json"])]
+        format: String,
+        /// Force ANSI color off (useful for piping into `less` without
+        /// `-R`). Color is also auto-disabled when stdout is not a TTY.
+        #[arg(long)]
+        no_color: bool,
+        /// Reader scope when comparing against `--question-id`. Defaults
+        /// to $USER. Ignored when `<file_b>` is provided.
+        #[arg(long)]
+        reader: Option<String>,
+    },
     /// Live `.bib` snapshot for a research question's shortlist.
     /// Polls SQLite at 1s, debounces bursts of edits, and skips
     /// the file write when the rendered content is byte-identical
@@ -404,6 +432,24 @@ async fn main() -> Result<()> {
                 format,
             } => {
                 let code = commands::bib_verify(&file, question_id.as_deref(), &format)?;
+                std::process::exit(code);
+            }
+            BibCommands::Diff {
+                file_a,
+                file_b,
+                question_id,
+                format,
+                no_color,
+                reader,
+            } => {
+                let code = commands::bib_diff(
+                    &file_a,
+                    file_b.as_deref(),
+                    question_id.as_deref(),
+                    &format,
+                    no_color,
+                    reader.as_deref(),
+                )?;
                 std::process::exit(code);
             }
             BibCommands::Watch {

--- a/crates/scitadel-cli/tests/bib_diff.rs
+++ b/crates/scitadel-cli/tests/bib_diff.rs
@@ -1,0 +1,258 @@
+#![allow(deprecated)] // `Command::cargo_bin` is still the standard entry for stable assert_cmd.
+
+//! End-to-end coverage for `scitadel bib diff` (#135 sub-feature C).
+//!
+//! Exercises the file-vs-file path (BibTeX, CSL-JSON, mixed), the
+//! `--question-id` path against a seeded DB, exit-code semantics, and
+//! the `--no-color` toggle. Pure-logic / format-detection tests live in
+//! `scitadel-export::diff::tests` and `scitadel-export::diff_input::tests`.
+
+use std::path::Path;
+
+use assert_cmd::Command;
+use scitadel_core::models::{Paper, PaperId, ResearchQuestion};
+use scitadel_core::ports::{PaperRepository, QuestionRepository};
+use scitadel_db::sqlite::{Database, SqliteShortlistRepository};
+use tempfile::TempDir;
+
+const READER: &str = "test-reader";
+
+fn write(p: &Path, s: &str) {
+    std::fs::write(p, s).unwrap();
+}
+
+const BIB_A: &str = r"
+@article{smith2024quantum,
+    title = {Quantum Advantage},
+    author = {Smith, John},
+    year = {2024},
+    doi = {10.1038/abc.2024}
+}
+@article{jones2022old,
+    title = {Old Z},
+    author = {Jones, Robert},
+    year = {2022}
+}
+";
+
+// Same as A but: jones2022old removed, lee2023neural added,
+// smith2024quantum's title edited.
+const BIB_B: &str = r"
+@article{smith2024quantum,
+    title = {Quantum Advantage Revisited},
+    author = {Smith, John},
+    year = {2024},
+    doi = {10.1038/abc.2024}
+}
+@article{lee2023neural,
+    title = {Neural Y},
+    author = {Lee, Kai},
+    year = {2023}
+}
+";
+
+fn diff(file_a: &Path, file_b: &Path, extra_args: &[&str]) -> assert_cmd::assert::Assert {
+    let mut cmd = Command::cargo_bin("scitadel").unwrap();
+    cmd.arg("bib").arg("diff").arg(file_a).arg(file_b);
+    for a in extra_args {
+        cmd.arg(a);
+    }
+    cmd.assert()
+}
+
+/// Identical files exit 0 and the report says so.
+#[test]
+fn identical_files_exit_zero() {
+    let tmp = TempDir::new().unwrap();
+    let a = tmp.path().join("a.bib");
+    let b = tmp.path().join("b.bib");
+    write(&a, BIB_A);
+    write(&b, BIB_A);
+    let assert = diff(&a, &b, &["--no-color"]).code(0);
+    let out = String::from_utf8_lossy(&assert.get_output().stdout).to_string();
+    assert!(out.contains("No differences"), "stdout: {out}");
+}
+
+/// Different files exit 1 with added/removed/changed sections.
+#[test]
+fn drifted_files_exit_one_with_text_report() {
+    let tmp = TempDir::new().unwrap();
+    let a = tmp.path().join("a.bib");
+    let b = tmp.path().join("b.bib");
+    write(&a, BIB_A);
+    write(&b, BIB_B);
+
+    let assert = diff(&a, &b, &["--no-color"]).code(1);
+    let out = String::from_utf8_lossy(&assert.get_output().stdout).to_string();
+    assert!(out.contains("ADDED (1):"), "missing ADDED: {out}");
+    assert!(out.contains("lee2023neural"), "lee not in added: {out}");
+    assert!(out.contains("REMOVED (1):"), "missing REMOVED: {out}");
+    assert!(out.contains("jones2022old"), "jones not in removed: {out}");
+    assert!(out.contains("CHANGED (1):"), "missing CHANGED: {out}");
+    assert!(out.contains("smith2024quantum"));
+    assert!(
+        out.contains("Quantum Advantage → Quantum Advantage Revisited"),
+        "field change missing: {out}"
+    );
+}
+
+/// `--no-color` (and / or non-TTY pipe) ⇒ no ANSI escapes in output.
+#[test]
+fn no_color_strips_ansi_escapes() {
+    let tmp = TempDir::new().unwrap();
+    let a = tmp.path().join("a.bib");
+    let b = tmp.path().join("b.bib");
+    write(&a, BIB_A);
+    write(&b, BIB_B);
+    let assert = diff(&a, &b, &["--no-color"]).code(1);
+    let out = String::from_utf8_lossy(&assert.get_output().stdout).to_string();
+    assert!(!out.contains('\x1b'), "ANSI must not appear: {out:?}");
+}
+
+/// `--format json` emits a parsable BibDiff JSON.
+#[test]
+fn json_format_emits_structured_output() {
+    let tmp = TempDir::new().unwrap();
+    let a = tmp.path().join("a.bib");
+    let b = tmp.path().join("b.bib");
+    write(&a, BIB_A);
+    write(&b, BIB_B);
+    let assert = diff(&a, &b, &["--format", "json"]).code(1);
+    let out = String::from_utf8_lossy(&assert.get_output().stdout).to_string();
+    let v: serde_json::Value = serde_json::from_str(out.trim()).unwrap();
+    assert_eq!(v["added"].as_array().unwrap().len(), 1);
+    assert_eq!(v["removed"].as_array().unwrap().len(), 1);
+    assert_eq!(v["changed"].as_array().unwrap().len(), 1);
+    assert_eq!(v["added"][0]["citekey"], "lee2023neural");
+    assert_eq!(v["removed"][0]["citekey"], "jones2022old");
+    assert_eq!(v["changed"][0]["citekey"], "smith2024quantum");
+}
+
+/// BibTeX-vs-CSL-JSON of the same shortlist produces zero diff.
+#[test]
+fn mixed_format_same_papers_zero_diff() {
+    let tmp = TempDir::new().unwrap();
+    let bib = tmp.path().join("paper.bib");
+    let json = tmp.path().join("paper.json");
+    write(
+        &bib,
+        r"
+@article{smith2024,
+    title = {Quantum},
+    author = {Smith, John},
+    year = {2024}
+}
+",
+    );
+    write(
+        &json,
+        r#"[
+            {
+                "id": "smith2024",
+                "type": "article-journal",
+                "title": "Quantum",
+                "author": [{"family": "Smith", "given": "John"}],
+                "issued": {"date-parts": [[2024]]}
+            }
+        ]"#,
+    );
+    diff(&bib, &json, &["--no-color"]).code(0);
+}
+
+// ---------- --question-id form ----------
+
+fn seed_db(tmp: &Path) -> (std::path::PathBuf, String) {
+    let db_path = tmp.join("scitadel.db");
+    let db = Database::open(&db_path).unwrap();
+    db.migrate().unwrap();
+
+    let (paper_repo, _, q_repo, _, _) = db.repositories();
+    let mut q = ResearchQuestion::new("Diff Q?");
+    q.description = "test".into();
+    q_repo.save_question(&q).unwrap();
+    let qid = q.id.as_str().to_string();
+
+    let papers = [
+        ("p-aaa", "Attention Is All You Need", "Vaswani, A.", 2017),
+        ("p-bbb", "Deep Residual Learning", "He, Kaiming", 2015),
+    ];
+    for (id, title, author, year) in papers {
+        let mut p = Paper::new(title);
+        p.id = PaperId::from(id);
+        p.authors = vec![author.to_string()];
+        p.year = Some(year);
+        paper_repo.save(&p).unwrap();
+        let shortlist = SqliteShortlistRepository::new(db.clone());
+        shortlist.toggle(&qid, id, READER).unwrap();
+    }
+    (db_path, qid)
+}
+
+#[test]
+fn question_id_form_compares_file_against_db_snapshot() {
+    let tmp = TempDir::new().unwrap();
+    let (db_path, qid) = seed_db(tmp.path());
+    let bib_path = tmp.path().join("paper.bib");
+
+    // First snapshot the DB to a file so we have a known-equal baseline.
+    Command::cargo_bin("scitadel")
+        .unwrap()
+        .arg("bib")
+        .arg("snapshot")
+        .arg(&qid)
+        .arg("--output")
+        .arg(&bib_path)
+        .arg("--reader")
+        .arg(READER)
+        .env("SCITADEL_DB", &db_path)
+        .assert()
+        .success();
+
+    // Now diff the file vs DB ⇒ exit 0.
+    Command::cargo_bin("scitadel")
+        .unwrap()
+        .arg("bib")
+        .arg("diff")
+        .arg(&bib_path)
+        .arg("--question-id")
+        .arg(&qid)
+        .arg("--reader")
+        .arg(READER)
+        .arg("--no-color")
+        .env("SCITADEL_DB", &db_path)
+        .assert()
+        .code(0);
+
+    // Edit the file ⇒ exit 1.
+    let mut content = std::fs::read_to_string(&bib_path).unwrap();
+    content = content.replace("Vaswani, A.", "Vaswani, Ashish");
+    std::fs::write(&bib_path, content).unwrap();
+    Command::cargo_bin("scitadel")
+        .unwrap()
+        .arg("bib")
+        .arg("diff")
+        .arg(&bib_path)
+        .arg("--question-id")
+        .arg(&qid)
+        .arg("--reader")
+        .arg(READER)
+        .arg("--no-color")
+        .env("SCITADEL_DB", &db_path)
+        .assert()
+        .code(1);
+}
+
+#[test]
+fn missing_second_side_is_an_error() {
+    let tmp = TempDir::new().unwrap();
+    let a = tmp.path().join("a.bib");
+    write(&a, BIB_A);
+    Command::cargo_bin("scitadel")
+        .unwrap()
+        .arg("bib")
+        .arg("diff")
+        .arg(&a)
+        .arg("--no-color")
+        .assert()
+        .failure();
+}

--- a/crates/scitadel-export/src/diff.rs
+++ b/crates/scitadel-export/src/diff.rs
@@ -1,0 +1,693 @@
+//! Entry-level structural diff between two bibliography snapshots
+//! (#135 sub-feature C).
+//!
+//! `bib verify` already prints a unified line-based diff when drift is
+//! detected, but that output is mechanically useful and editorially
+//! noisy: a one-character change in a citekey ripples through dozens of
+//! lines of BibTeX, and the reader has to reconstruct the *meaning* by
+//! eye. `bib diff` gives the reader the meaning directly: which entries
+//! were added, which were removed, which changed (and which fields
+//! changed).
+//!
+//! ## Identity rule
+//!
+//! Two entries refer to the same paper iff one of these matches —
+//! tried strictly in order, first-match-wins:
+//!
+//! 1. citekey (exact, case-sensitive — citekeys are deterministic)
+//! 2. DOI (lowercased, prefix-stripped — see [`crate::import::parse::normalize_doi`])
+//! 3. arxiv_id (trimmed)
+//! 4. (title, year) — last-resort fallback when all three persistent
+//!    identifiers are missing, e.g. an old NeurIPS PDF with no DOI yet
+//!
+//! Strict per-rung means we don't try multiple at once: if citekey
+//! matches we don't even *look* at DOI. This matters for ambiguous
+//! cases (e.g. the citekey was renamed but DOI still matches — we
+//! treat that as added/removed, not a rename, because the user's
+//! manuscripts still cite by the citekey).
+//!
+//! ## Determinism
+//!
+//! All output lists are sorted by citekey lexicographically before
+//! return so callers (CLI, MCP, tests) see stable output across runs
+//! regardless of input order.
+//!
+//! ## Format-neutral
+//!
+//! The diff operates on [`Entry`] — a deliberately narrow shape that
+//! both BibTeX and CSL-JSON parsers can populate. That way a BibTeX
+//! file and a CSL-JSON file with the same papers produce zero diff
+//! (verified by [`tests::mixed_format_same_papers_produce_zero_diff`]).
+
+use std::collections::HashSet;
+
+use serde::{Deserialize, Serialize};
+
+use crate::import::parse::{BibEntry, normalize_doi};
+
+/// Format-neutral bibliography entry. Populated by the BibTeX parser
+/// (via [`Entry::from_bib_entry`]) or the CSL-JSON parser (via
+/// [`Entry::from_csl_value`]) so the diff layer doesn't care which
+/// flavor it's looking at.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Entry {
+    pub citekey: String,
+    pub title: Option<String>,
+    pub authors: Vec<String>,
+    pub year: Option<i32>,
+    pub doi: Option<String>,
+    pub arxiv_id: Option<String>,
+    pub journal: Option<String>,
+    pub url: Option<String>,
+    pub r#abstract: Option<String>,
+}
+
+impl Entry {
+    /// Lift a parsed BibTeX entry into the format-neutral shape. DOI
+    /// is already normalized by [`normalize_doi`] inside `parse_bibtex`.
+    #[must_use]
+    pub fn from_bib_entry(b: &BibEntry) -> Self {
+        Self {
+            citekey: b.citekey.clone(),
+            title: b.title.clone(),
+            authors: b.authors.clone(),
+            year: b.year,
+            doi: b.doi.clone(),
+            arxiv_id: b.arxiv_id.clone(),
+            journal: b
+                .extra
+                .get("journal")
+                .or_else(|| b.extra.get("journaltitle"))
+                .cloned(),
+            url: b.extra.get("url").cloned(),
+            r#abstract: b.extra.get("abstract").cloned(),
+        }
+    }
+
+    /// Lift a single CSL-JSON object into the format-neutral shape. The
+    /// canonical 1.0.2 schema fixes field names: `id`, `title`,
+    /// `author[].family|given`, `issued.date-parts[0][0]`, `DOI`, `URL`,
+    /// `container-title`, `abstract`. Anything else is dropped.
+    pub fn from_csl_value(v: &serde_json::Value) -> Option<Self> {
+        let obj = v.as_object()?;
+        let citekey = obj.get("id").and_then(|x| match x {
+            serde_json::Value::String(s) => Some(s.clone()),
+            serde_json::Value::Number(n) => Some(n.to_string()),
+            _ => None,
+        })?;
+        let title = obj
+            .get("title")
+            .and_then(|t| t.as_str())
+            .map(str::to_string);
+        let authors = obj
+            .get("author")
+            .and_then(|a| a.as_array())
+            .map(|arr| arr.iter().filter_map(csl_author_to_string).collect())
+            .unwrap_or_default();
+        let year = obj
+            .get("issued")
+            .and_then(|d| d.get("date-parts"))
+            .and_then(|dp| dp.as_array())
+            .and_then(|outer| outer.first())
+            .and_then(|inner| inner.as_array())
+            .and_then(|inner| inner.first())
+            .and_then(|n| n.as_i64())
+            .map(|n| n as i32);
+        let doi = obj
+            .get("DOI")
+            .and_then(|d| d.as_str())
+            .map(normalize_doi)
+            .filter(|s| !s.is_empty());
+        let url = obj.get("URL").and_then(|u| u.as_str()).map(str::to_string);
+        let journal = obj
+            .get("container-title")
+            .and_then(|c| c.as_str())
+            .map(str::to_string);
+        let r#abstract = obj
+            .get("abstract")
+            .and_then(|a| a.as_str())
+            .map(str::to_string);
+        // CSL doesn't carry a dedicated arxiv_id; tools that round-trip
+        // arxiv ids through CSL stash them in `note` or rebuild the URL.
+        // We don't try to recover that here — the diff falls through to
+        // (title, year) when DOI/arxiv are both absent, which is the
+        // intended pre-arxiv fallback path.
+        let arxiv_id = None;
+        Some(Self {
+            citekey,
+            title,
+            authors,
+            year,
+            doi,
+            arxiv_id,
+            journal,
+            url,
+            r#abstract,
+        })
+    }
+}
+
+fn csl_author_to_string(v: &serde_json::Value) -> Option<String> {
+    let obj = v.as_object()?;
+    let family = obj
+        .get("family")
+        .and_then(|x| x.as_str())
+        .or_else(|| obj.get("literal").and_then(|x| x.as_str()))?
+        .trim();
+    if let Some(given) = obj.get("given").and_then(|x| x.as_str())
+        && !given.trim().is_empty()
+    {
+        Some(format!("{family}, {}", given.trim()))
+    } else {
+        Some(family.to_string())
+    }
+}
+
+/// One field that differs between two matched entries.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FieldChange {
+    pub field: String,
+    pub before: Option<String>,
+    pub after: Option<String>,
+}
+
+/// One entry whose identity matched on both sides but whose fields
+/// differ. `field_changes` is sorted alphabetically by field name for
+/// deterministic output.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChangedEntry {
+    pub citekey: String,
+    /// Citekey on the "before" side, in case identity matched on a
+    /// different rung (DOI / arxiv / title+year) and the citekey was
+    /// renamed. `None` when the citekey is unchanged. Always rendered
+    /// from the after-side `citekey`.
+    pub before_citekey: Option<String>,
+    pub field_changes: Vec<FieldChange>,
+}
+
+/// Structural diff between two entry lists. Lists are sorted by
+/// citekey ascending so output is byte-stable across runs.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BibDiff {
+    pub added: Vec<Entry>,
+    pub removed: Vec<Entry>,
+    pub changed: Vec<ChangedEntry>,
+}
+
+impl BibDiff {
+    /// `true` iff there is no structural change. CLI maps this to
+    /// exit code 0 (mirrors `git diff` semantics).
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.added.is_empty() && self.removed.is_empty() && self.changed.is_empty()
+    }
+}
+
+/// Compute the structural diff between two entry lists. Pure: no I/O,
+/// no global state. Deterministic: same inputs ⇒ same output, lists
+/// sorted by citekey.
+#[must_use]
+pub fn diff_entries(before: &[Entry], after: &[Entry]) -> BibDiff {
+    // Greedy first-match-wins matching. For each `after` entry try the
+    // identity rungs in order against any `before` entry not yet
+    // matched. This is O(n*m) on the rungs, which is fine for the
+    // shortlist sizes we expect (tens to low thousands).
+    let mut matched_before: HashSet<usize> = HashSet::new();
+    let mut matched_after: HashSet<usize> = HashSet::new();
+    let mut pairs: Vec<(usize, usize)> = Vec::new(); // (before_idx, after_idx)
+
+    for (ai, a) in after.iter().enumerate() {
+        if let Some(bi) = find_match(a, before, &matched_before) {
+            matched_before.insert(bi);
+            matched_after.insert(ai);
+            pairs.push((bi, ai));
+        }
+    }
+
+    let mut added: Vec<Entry> = after
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| !matched_after.contains(i))
+        .map(|(_, e)| e.clone())
+        .collect();
+    let mut removed: Vec<Entry> = before
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| !matched_before.contains(i))
+        .map(|(_, e)| e.clone())
+        .collect();
+    let mut changed: Vec<ChangedEntry> = pairs
+        .into_iter()
+        .filter_map(|(bi, ai)| {
+            let b = &before[bi];
+            let a = &after[ai];
+            let fc = field_changes(b, a);
+            if fc.is_empty() && a.citekey == b.citekey {
+                None
+            } else {
+                let before_citekey = (a.citekey != b.citekey).then(|| b.citekey.clone());
+                Some(ChangedEntry {
+                    citekey: a.citekey.clone(),
+                    before_citekey,
+                    field_changes: fc,
+                })
+            }
+        })
+        .collect();
+
+    added.sort_by(|a, b| a.citekey.cmp(&b.citekey));
+    removed.sort_by(|a, b| a.citekey.cmp(&b.citekey));
+    changed.sort_by(|a, b| a.citekey.cmp(&b.citekey));
+    BibDiff {
+        added,
+        removed,
+        changed,
+    }
+}
+
+/// Try the identity rungs in strict order. Returns the index of the
+/// matching `before` entry on first hit, or `None`.
+fn find_match(a: &Entry, before: &[Entry], used: &HashSet<usize>) -> Option<usize> {
+    // Rung 1: citekey.
+    if !a.citekey.is_empty()
+        && let Some(i) = before
+            .iter()
+            .enumerate()
+            .position(|(i, b)| !used.contains(&i) && b.citekey == a.citekey)
+    {
+        return Some(i);
+    }
+    // Rung 2: DOI.
+    if let Some(adoi) = a.doi.as_ref().filter(|s| !s.is_empty())
+        && let Some(i) = before
+            .iter()
+            .enumerate()
+            .position(|(i, b)| !used.contains(&i) && b.doi.as_deref() == Some(adoi.as_str()))
+    {
+        return Some(i);
+    }
+    // Rung 3: arxiv.
+    if let Some(ax) = a.arxiv_id.as_ref().filter(|s| !s.is_empty())
+        && let Some(i) = before
+            .iter()
+            .enumerate()
+            .position(|(i, b)| !used.contains(&i) && b.arxiv_id.as_deref() == Some(ax.as_str()))
+    {
+        return Some(i);
+    }
+    // Rung 4: title + year.
+    if let (Some(t), Some(y)) = (a.title.as_ref(), a.year)
+        && !t.is_empty()
+        && let Some(i) = before.iter().enumerate().position(|(i, b)| {
+            !used.contains(&i) && b.title.as_deref() == Some(t.as_str()) && b.year == Some(y)
+        })
+    {
+        return Some(i);
+    }
+    None
+}
+
+/// Per-field comparison. Returns a sorted-by-field list of changes.
+/// Compares the format-neutral fields; authors are compared as a
+/// single concatenation (`"; "`-joined) for diff output legibility.
+fn field_changes(b: &Entry, a: &Entry) -> Vec<FieldChange> {
+    let mut out: Vec<FieldChange> = Vec::new();
+    if b.title != a.title {
+        out.push(FieldChange {
+            field: "title".into(),
+            before: b.title.clone(),
+            after: a.title.clone(),
+        });
+    }
+    if b.authors != a.authors {
+        out.push(FieldChange {
+            field: "author".into(),
+            before: opt_str_from_authors(&b.authors),
+            after: opt_str_from_authors(&a.authors),
+        });
+    }
+    if b.year != a.year {
+        out.push(FieldChange {
+            field: "year".into(),
+            before: b.year.map(|y| y.to_string()),
+            after: a.year.map(|y| y.to_string()),
+        });
+    }
+    if b.doi != a.doi {
+        out.push(FieldChange {
+            field: "DOI".into(),
+            before: b.doi.clone(),
+            after: a.doi.clone(),
+        });
+    }
+    if b.arxiv_id != a.arxiv_id {
+        out.push(FieldChange {
+            field: "arxiv_id".into(),
+            before: b.arxiv_id.clone(),
+            after: a.arxiv_id.clone(),
+        });
+    }
+    if b.journal != a.journal {
+        out.push(FieldChange {
+            field: "journal".into(),
+            before: b.journal.clone(),
+            after: a.journal.clone(),
+        });
+    }
+    if b.url != a.url {
+        out.push(FieldChange {
+            field: "URL".into(),
+            before: b.url.clone(),
+            after: a.url.clone(),
+        });
+    }
+    if b.r#abstract != a.r#abstract {
+        out.push(FieldChange {
+            field: "abstract".into(),
+            before: b.r#abstract.clone(),
+            after: a.r#abstract.clone(),
+        });
+    }
+    out.sort_by(|x, y| x.field.cmp(&y.field));
+    out
+}
+
+fn opt_str_from_authors(authors: &[String]) -> Option<String> {
+    if authors.is_empty() {
+        None
+    } else {
+        Some(authors.join("; "))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(citekey: &str) -> Entry {
+        Entry {
+            citekey: citekey.into(),
+            ..Default::default()
+        }
+    }
+
+    fn full(citekey: &str, title: &str, year: i32) -> Entry {
+        Entry {
+            citekey: citekey.into(),
+            title: Some(title.into()),
+            year: Some(year),
+            authors: vec!["Smith, J.".into()],
+            ..Default::default()
+        }
+    }
+
+    // ---------- Identity rule: 4 separate tests, one per rung ----------
+
+    #[test]
+    fn identity_rung1_citekey_match_wins() {
+        let a = full("smith2024", "T", 2024);
+        let b = full("smith2024", "T", 2024);
+        let d = diff_entries(&[a], &[b]);
+        assert!(d.is_empty(), "same citekey + identical fields ⇒ no diff");
+    }
+
+    #[test]
+    fn identity_rung1_citekey_takes_priority_over_doi() {
+        // before has citekey=X but DOI=10.1/abc
+        let mut before = full("X", "Title", 2024);
+        before.doi = Some("10.1/abc".into());
+        // after has different citekey but same DOI — by the rule, the
+        // citekey doesn't match, so we fall through to DOI rung 2.
+        // BUT: we want to verify rung 1 strictness. So set up TWO
+        // before entries: one with the citekey, one with the DOI. The
+        // citekey match must win.
+        let mut before_decoy = full("Y", "DecoyTitle", 2020);
+        before_decoy.doi = Some("10.1/abc".into());
+        let mut after = full("X", "Title", 2024);
+        after.doi = Some("10.1/abc".into());
+
+        let d = diff_entries(&[before_decoy.clone(), before], &[after]);
+        // The citekey-matched entry should be matched (no diff for it),
+        // and the decoy should appear in `removed` (it's still in
+        // before but not after).
+        assert_eq!(d.removed.len(), 1, "decoy must be removed: {d:?}");
+        assert_eq!(d.removed[0].citekey, "Y");
+        assert!(d.changed.is_empty());
+        assert!(d.added.is_empty());
+    }
+
+    #[test]
+    fn identity_rung2_doi_when_citekeys_differ() {
+        let mut before = full("oldkey", "Title", 2024);
+        before.doi = Some("10.1/abc".into());
+        let mut after = full("newkey", "Title", 2024);
+        after.doi = Some("10.1/abc".into());
+        let d = diff_entries(&[before], &[after]);
+        // DOI matched ⇒ same paper, but citekey changed.
+        assert_eq!(d.changed.len(), 1, "DOI rung must match: {d:?}");
+        assert_eq!(d.changed[0].citekey, "newkey");
+        assert_eq!(d.changed[0].before_citekey.as_deref(), Some("oldkey"));
+        assert!(d.added.is_empty());
+        assert!(d.removed.is_empty());
+    }
+
+    #[test]
+    fn identity_rung3_arxiv_when_doi_absent() {
+        let mut before = full("oldkey", "Title", 2024);
+        before.arxiv_id = Some("2301.00001".into());
+        let mut after = full("newkey", "Title", 2024);
+        after.arxiv_id = Some("2301.00001".into());
+        let d = diff_entries(&[before], &[after]);
+        assert_eq!(d.changed.len(), 1, "arxiv rung must match: {d:?}");
+        assert_eq!(d.changed[0].citekey, "newkey");
+    }
+
+    #[test]
+    fn identity_rung4_title_year_when_all_else_absent() {
+        let before = full("oldkey", "A Common Title", 2024);
+        let after = full("newkey", "A Common Title", 2024);
+        let d = diff_entries(&[before], &[after]);
+        assert_eq!(d.changed.len(), 1, "title+year rung must match: {d:?}");
+        assert_eq!(d.changed[0].citekey, "newkey");
+    }
+
+    #[test]
+    fn identity_no_match_returns_added_and_removed() {
+        let before = full("a", "Alpha", 2024);
+        let after = full("b", "Beta", 2025);
+        let d = diff_entries(&[before], &[after]);
+        assert_eq!(d.added.len(), 1);
+        assert_eq!(d.added[0].citekey, "b");
+        assert_eq!(d.removed.len(), 1);
+        assert_eq!(d.removed[0].citekey, "a");
+        assert!(d.changed.is_empty());
+    }
+
+    // ---------- Field-change detection: one field at a time ----------
+
+    fn changed_only(b: Entry, a: Entry) -> Vec<FieldChange> {
+        let d = diff_entries(&[b], &[a]);
+        assert_eq!(d.changed.len(), 1);
+        d.changed.into_iter().next().unwrap().field_changes
+    }
+
+    #[test]
+    fn field_change_title() {
+        let mut b = full("k", "Old", 2024);
+        let mut a = full("k", "New", 2024);
+        b.authors = vec!["X".into()];
+        a.authors = vec!["X".into()];
+        let fc = changed_only(b, a);
+        assert_eq!(fc.len(), 1, "only title changed: {fc:?}");
+        assert_eq!(fc[0].field, "title");
+        assert_eq!(fc[0].before.as_deref(), Some("Old"));
+        assert_eq!(fc[0].after.as_deref(), Some("New"));
+    }
+
+    #[test]
+    fn field_change_year_only() {
+        let mut b = full("k", "T", 2023);
+        let mut a = full("k", "T", 2024);
+        b.authors = vec!["X".into()];
+        a.authors = vec!["X".into()];
+        let fc = changed_only(b, a);
+        assert_eq!(fc.len(), 1, "only year changed: {fc:?}");
+        assert_eq!(fc[0].field, "year");
+    }
+
+    #[test]
+    fn field_change_author_only() {
+        let mut b = full("k", "T", 2024);
+        let mut a = full("k", "T", 2024);
+        b.authors = vec!["Smith, J.".into()];
+        a.authors = vec!["Smith, J.".into(), "Doe, J.".into()];
+        let fc = changed_only(b, a);
+        assert_eq!(fc.len(), 1, "only author changed: {fc:?}");
+        assert_eq!(fc[0].field, "author");
+    }
+
+    #[test]
+    fn field_change_doi_only() {
+        let mut b = full("k", "T", 2024);
+        let mut a = full("k", "T", 2024);
+        b.doi = Some("10.1/old".into());
+        a.doi = Some("10.1/new".into());
+        let fc = changed_only(b, a);
+        assert_eq!(fc.len(), 1, "only DOI changed: {fc:?}");
+        assert_eq!(fc[0].field, "DOI");
+    }
+
+    #[test]
+    fn field_change_journal_only() {
+        let mut b = full("k", "T", 2024);
+        let mut a = full("k", "T", 2024);
+        b.journal = Some("Nature".into());
+        a.journal = Some("Science".into());
+        let fc = changed_only(b, a);
+        assert_eq!(fc.len(), 1, "only journal changed: {fc:?}");
+        assert_eq!(fc[0].field, "journal");
+    }
+
+    #[test]
+    fn field_change_abstract_only() {
+        let mut b = full("k", "T", 2024);
+        let mut a = full("k", "T", 2024);
+        b.r#abstract = Some("old abs".into());
+        a.r#abstract = Some("new abs".into());
+        let fc = changed_only(b, a);
+        assert_eq!(fc.len(), 1, "only abstract changed: {fc:?}");
+        assert_eq!(fc[0].field, "abstract");
+    }
+
+    // ---------- Determinism ----------
+
+    #[test]
+    fn sort_determinism_added_removed_changed() {
+        // Different insertion orders, same content ⇒ same output.
+        let b1 = full("alpha", "A", 2024);
+        let b2 = full("zeta", "Z", 2024);
+        let b3 = full("mu", "M", 2024);
+        let a1 = full("beta", "B", 2024);
+        let a2 = full("zeta", "Z2", 2024); // changed title
+        let a3 = full("nu", "N", 2024);
+
+        let r1 = diff_entries(
+            &[b1.clone(), b2.clone(), b3.clone()],
+            &[a1.clone(), a2.clone(), a3.clone()],
+        );
+        let r2 = diff_entries(&[b3, b1, b2], &[a3, a2, a1]);
+
+        let added_keys = |d: &BibDiff| {
+            d.added
+                .iter()
+                .map(|e| e.citekey.clone())
+                .collect::<Vec<_>>()
+        };
+        let removed_keys = |d: &BibDiff| {
+            d.removed
+                .iter()
+                .map(|e| e.citekey.clone())
+                .collect::<Vec<_>>()
+        };
+        let changed_keys = |d: &BibDiff| {
+            d.changed
+                .iter()
+                .map(|c| c.citekey.clone())
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(added_keys(&r1), added_keys(&r2));
+        assert_eq!(removed_keys(&r1), removed_keys(&r2));
+        assert_eq!(changed_keys(&r1), changed_keys(&r2));
+        // And actually sorted:
+        assert_eq!(added_keys(&r1), vec!["beta", "nu"]);
+        assert_eq!(removed_keys(&r1), vec!["alpha", "mu"]);
+        assert_eq!(changed_keys(&r1), vec!["zeta"]);
+    }
+
+    // ---------- JSON round-trip ----------
+
+    #[test]
+    fn json_round_trip_matches_struct() {
+        let b = full("a", "Old", 2023);
+        let a = full("a", "New", 2024);
+        let extra = full("b", "Beta", 2024);
+        let d = diff_entries(&[b], &[a, extra]);
+        let json = serde_json::to_string(&d).unwrap();
+        let back: BibDiff = serde_json::from_str(&json).unwrap();
+        assert_eq!(d, back);
+    }
+
+    // ---------- Mixed-format diff (BibTeX vs CSL-JSON) ----------
+
+    #[test]
+    fn mixed_format_same_papers_produce_zero_diff() {
+        // Build a BibTeX doc and a CSL-JSON doc that describe the same
+        // two papers; lift to Entry via both paths; assert empty diff.
+        let bib_src = r"
+@article{smith2024quantum,
+    title = {Quantum Advantage},
+    author = {Smith, John and Doe, Jane},
+    year = {2024},
+    doi = {10.1038/nature.2024}
+}
+@article{lee2023neural,
+    title = {Neural Y},
+    author = {Lee, Kai},
+    year = {2023}
+}
+        ";
+        let bib_entries = crate::import::parse::parse_bibtex(bib_src).unwrap();
+        let bib_neutral: Vec<Entry> = bib_entries.iter().map(Entry::from_bib_entry).collect();
+
+        let csl_src = serde_json::json!([
+            {
+                "id": "smith2024quantum",
+                "type": "article-journal",
+                "title": "Quantum Advantage",
+                "author": [
+                    {"family": "Smith", "given": "John"},
+                    {"family": "Doe", "given": "Jane"}
+                ],
+                "issued": {"date-parts": [[2024]]},
+                "DOI": "10.1038/nature.2024"
+            },
+            {
+                "id": "lee2023neural",
+                "type": "article-journal",
+                "title": "Neural Y",
+                "author": [{"family": "Lee", "given": "Kai"}],
+                "issued": {"date-parts": [[2023]]}
+            }
+        ]);
+        let csl_arr = csl_src.as_array().unwrap();
+        let csl_neutral: Vec<Entry> = csl_arr.iter().filter_map(Entry::from_csl_value).collect();
+        assert_eq!(csl_neutral.len(), 2);
+
+        let d = diff_entries(&bib_neutral, &csl_neutral);
+        assert!(
+            d.is_empty(),
+            "BibTeX-vs-CSL of the same papers must produce no diff: {d:?}"
+        );
+    }
+
+    // ---------- Identity strictness ----------
+
+    #[test]
+    fn identity_strict_per_rung_does_not_combine() {
+        // before: citekey=X, no DOI
+        // after:  citekey=Y, DOI=10/abc, no overlap
+        // ⇒ no match (citekey miss; DOI not present in `before`)
+        let before = entry("X");
+        let mut after = entry("Y");
+        after.doi = Some("10/abc".into());
+        let d = diff_entries(&[before], &[after]);
+        assert_eq!(d.added.len(), 1);
+        assert_eq!(d.removed.len(), 1);
+    }
+
+    #[test]
+    fn empty_inputs_are_a_no_op() {
+        let d = diff_entries(&[], &[]);
+        assert!(d.is_empty());
+    }
+}

--- a/crates/scitadel-export/src/diff_format.rs
+++ b/crates/scitadel-export/src/diff_format.rs
@@ -1,0 +1,297 @@
+//! Renderers for [`crate::diff::BibDiff`]: hand-rolled ANSI text and
+//! structured JSON (#135 sub-feature C).
+//!
+//! Hand-rolled ANSI deliberately — adding a color crate for three
+//! escape codes (green / red / yellow) would just be dependency churn.
+//! Color is gated by the caller (TTY detection lives at the CLI layer
+//! so we keep this module pure).
+
+use std::fmt::Write as _;
+
+use crate::diff::{BibDiff, ChangedEntry, Entry, FieldChange};
+
+/// ANSI escape codes used by the text renderer. Matched per-call to
+/// the user's color preference — when `use_color=false` the renderer
+/// emits empty strings and the diff is plain text.
+const GREEN: &str = "\x1b[32m";
+const RED: &str = "\x1b[31m";
+const YELLOW: &str = "\x1b[33m";
+const BOLD: &str = "\x1b[1m";
+const RESET: &str = "\x1b[0m";
+
+/// Bundle of ANSI codes the text renderer needs. Resolved once at the
+/// top of [`render_text`] from `use_color`; sub-helpers take a
+/// reference so we don't shuttle five `&str`s through every signature.
+struct Palette {
+    add: &'static str,
+    remove: &'static str,
+    change: &'static str,
+    bold: &'static str,
+    reset: &'static str,
+}
+
+impl Palette {
+    fn new(use_color: bool) -> Self {
+        if use_color {
+            Self {
+                add: GREEN,
+                remove: RED,
+                change: YELLOW,
+                bold: BOLD,
+                reset: RESET,
+            }
+        } else {
+            Self {
+                add: "",
+                remove: "",
+                change: "",
+                bold: "",
+                reset: "",
+            }
+        }
+    }
+}
+
+/// Render a `BibDiff` as a human-readable text report. `header_a` /
+/// `header_b` are free-form labels (e.g. file paths or "question
+/// abc123") that go in the "=== bib diff: <a> vs <b> ===" line.
+#[must_use]
+pub fn render_text(diff: &BibDiff, header_a: &str, header_b: &str, use_color: bool) -> String {
+    let mut out = String::new();
+    let p = Palette::new(use_color);
+    let bold = p.bold;
+    let reset = p.reset;
+
+    let _ = writeln!(
+        out,
+        "{bold}=== bib diff: {header_a} vs {header_b} ==={reset}"
+    );
+    if diff.is_empty() {
+        out.push_str("\nNo differences.\n");
+        return out;
+    }
+
+    let _ = writeln!(out, "\n{bold}ADDED ({}):{reset}", diff.added.len());
+    if diff.added.is_empty() {
+        out.push_str("  (none)\n");
+    } else {
+        for e in &diff.added {
+            let _ = writeln!(out, "  {}+ {}{}", p.add, entry_summary(e), p.reset);
+        }
+    }
+
+    let _ = writeln!(out, "\n{bold}REMOVED ({}):{reset}", diff.removed.len());
+    if diff.removed.is_empty() {
+        out.push_str("  (none)\n");
+    } else {
+        for e in &diff.removed {
+            let _ = writeln!(out, "  {}- {}{}", p.remove, entry_summary(e), p.reset);
+        }
+    }
+
+    let _ = writeln!(out, "\n{bold}CHANGED ({}):{reset}", diff.changed.len());
+    if diff.changed.is_empty() {
+        out.push_str("  (none)\n");
+    } else {
+        for ce in &diff.changed {
+            render_changed(&mut out, ce, &p);
+        }
+    }
+    out
+}
+
+fn render_changed(out: &mut String, ce: &ChangedEntry, p: &Palette) {
+    if let Some(prev) = &ce.before_citekey {
+        let _ = writeln!(
+            out,
+            "  {}~ {} (was {prev}){}",
+            p.change, ce.citekey, p.reset
+        );
+    } else {
+        let _ = writeln!(out, "  {}~ {}{}", p.change, ce.citekey, p.reset);
+    }
+    let widest = ce
+        .field_changes
+        .iter()
+        .map(|fc| fc.field.len())
+        .max()
+        .unwrap_or(0);
+    for fc in &ce.field_changes {
+        render_field_change(out, fc, widest, p);
+    }
+}
+
+fn render_field_change(out: &mut String, fc: &FieldChange, widest: usize, p: &Palette) {
+    let pad = " ".repeat(widest.saturating_sub(fc.field.len()));
+    let _ = writeln!(
+        out,
+        "    {}{}{}{pad}: {} → {}",
+        p.change,
+        fc.field,
+        p.reset,
+        elide(fc.before.as_deref()),
+        elide(fc.after.as_deref()),
+    );
+}
+
+/// One-line summary like
+/// `smith2024quantum  Smith, J. (2024) "Quantum X" — DOI:10.1234/...`.
+/// Optional fields are gracefully omitted.
+fn entry_summary(e: &Entry) -> String {
+    let mut s = String::new();
+    s.push_str(&e.citekey);
+    s.push_str("  ");
+    if let Some(first_author) = e.authors.first() {
+        s.push_str(first_author);
+    }
+    if let Some(y) = e.year {
+        if !s.ends_with("  ") {
+            s.push(' ');
+        }
+        let _ = write!(s, "({y})");
+    }
+    if let Some(t) = &e.title {
+        let _ = write!(s, " \"{}\"", truncate(t, 80));
+    }
+    if let Some(d) = &e.doi {
+        let _ = write!(s, " — DOI:{d}");
+    } else if let Some(a) = &e.arxiv_id {
+        let _ = write!(s, " — arXiv:{a}");
+    }
+    s
+}
+
+/// Render a `BibDiff` as structured JSON. Just `serde_json::to_string_pretty`
+/// — kept here so the CLI / MCP have one canonical entry point.
+pub fn render_json(diff: &BibDiff) -> Result<String, serde_json::Error> {
+    let mut s = serde_json::to_string_pretty(diff)?;
+    s.push('\n');
+    Ok(s)
+}
+
+/// Truncate a string to `max` chars (NOT bytes — Unicode-safe). Adds
+/// an ellipsis if truncation actually happened.
+fn truncate(s: &str, max: usize) -> String {
+    let count = s.chars().count();
+    if count <= max {
+        s.to_string()
+    } else {
+        let kept: String = s.chars().take(max.saturating_sub(1)).collect();
+        format!("{kept}…")
+    }
+}
+
+/// Render `Option<&str>` for the before/after columns. `None` prints
+/// as `<none>` so the user can distinguish "field absent" from
+/// "field is empty string".
+fn elide(s: Option<&str>) -> String {
+    match s {
+        None => "<none>".to_string(),
+        Some("") => "<empty>".to_string(),
+        Some(v) => truncate(v, 80),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::diff::{ChangedEntry, FieldChange};
+
+    fn full_entry(k: &str, t: &str) -> Entry {
+        Entry {
+            citekey: k.into(),
+            title: Some(t.into()),
+            year: Some(2024),
+            authors: vec!["Smith, J.".into()],
+            doi: Some("10.1/abc".into()),
+            ..Default::default()
+        }
+    }
+
+    fn sample_diff() -> BibDiff {
+        BibDiff {
+            added: vec![full_entry("a-add", "Added")],
+            removed: vec![full_entry("a-rem", "Removed")],
+            changed: vec![ChangedEntry {
+                citekey: "k".into(),
+                before_citekey: None,
+                field_changes: vec![FieldChange {
+                    field: "title".into(),
+                    before: Some("Old".into()),
+                    after: Some("New".into()),
+                }],
+            }],
+        }
+    }
+
+    #[test]
+    fn text_no_color_has_no_ansi_escapes() {
+        let out = render_text(&sample_diff(), "A", "B", false);
+        assert!(!out.contains('\x1b'), "ANSI must not appear: {out:?}");
+    }
+
+    #[test]
+    fn text_with_color_has_ansi_escapes() {
+        let out = render_text(&sample_diff(), "A", "B", true);
+        assert!(out.contains("\x1b["), "ANSI required when use_color=true");
+        assert!(out.contains(GREEN), "added uses green");
+        assert!(out.contains(RED), "removed uses red");
+        assert!(out.contains(YELLOW), "changed/field uses yellow");
+        assert!(out.contains(RESET), "must reset color");
+    }
+
+    #[test]
+    fn text_renders_section_counts() {
+        let out = render_text(&sample_diff(), "A", "B", false);
+        assert!(out.contains("ADDED (1):"));
+        assert!(out.contains("REMOVED (1):"));
+        assert!(out.contains("CHANGED (1):"));
+    }
+
+    #[test]
+    fn text_renders_field_change_arrow() {
+        let out = render_text(&sample_diff(), "A", "B", false);
+        assert!(out.contains("title"), "field name present");
+        assert!(out.contains("Old → New"), "before → after rendered");
+    }
+
+    #[test]
+    fn text_renders_no_diff_message_when_empty() {
+        let d = BibDiff::default();
+        let out = render_text(&d, "A", "B", false);
+        assert!(out.contains("No differences"));
+    }
+
+    #[test]
+    fn text_renders_renamed_citekey() {
+        let mut d = sample_diff();
+        d.changed[0].before_citekey = Some("old-key".into());
+        let out = render_text(&d, "A", "B", false);
+        assert!(out.contains("(was old-key)"), "rename hint must appear");
+    }
+
+    #[test]
+    fn json_round_trip() {
+        let d = sample_diff();
+        let json = render_json(&d).unwrap();
+        let back: BibDiff = serde_json::from_str(&json).unwrap();
+        assert_eq!(d, back);
+    }
+
+    #[test]
+    fn elide_distinguishes_none_and_empty() {
+        assert_eq!(elide(None), "<none>");
+        assert_eq!(elide(Some("")), "<empty>");
+        assert_eq!(elide(Some("hello")), "hello");
+    }
+
+    #[test]
+    fn truncate_unicode_safe() {
+        // Greek alpha is one char but two bytes — make sure we don't
+        // panic on a byte-boundary slice.
+        let s = "αβγδεζηθ";
+        let out = truncate(s, 4);
+        assert!(out.chars().count() <= 4);
+        assert!(out.ends_with('…'));
+    }
+}

--- a/crates/scitadel-export/src/diff_input.rs
+++ b/crates/scitadel-export/src/diff_input.rs
@@ -1,0 +1,165 @@
+//! Loaders for `bib diff`: read a file path, sniff format, return
+//! format-neutral [`Entry`] records.
+//!
+//! Lives next to [`crate::diff`] so the diff CLI / MCP tool can call a
+//! single helper rather than re-implementing the BibTeX-or-JSON branch
+//! at every call site. Content-sniffing is the source of truth: a
+//! `.bib` file containing valid JSON is detected as JSON. Extension is
+//! only consulted when content-sniffing is ambiguous (which it never
+//! actually is — JSON either parses or it doesn't), so extension is
+//! effectively cosmetic in this helper. Kept here purely so callers
+//! can also accept content via [`load_entries_from_str`].
+
+use std::path::Path;
+
+use crate::diff::Entry;
+use crate::import::parse::parse_bibtex;
+
+/// Detected format of a bibliography file. Returned by
+/// [`detect_format_from_str`] so callers can branch (e.g. log a warn
+/// when extension and content disagree).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BibFormat {
+    Bibtex,
+    CslJson,
+}
+
+/// Load a file and return its entries in the format-neutral shape.
+/// Errors are bubbled up verbatim with file-path context so the
+/// caller can present a useful error.
+pub fn load_entries_from_path(path: &Path) -> Result<(Vec<Entry>, BibFormat), String> {
+    let bytes =
+        std::fs::read_to_string(path).map_err(|e| format!("read {}: {e}", path.display()))?;
+    load_entries_from_str(&bytes).map_err(|e| format!("parse {}: {e}", path.display()))
+}
+
+/// Same as [`load_entries_from_path`] but takes the bytes directly.
+/// The CLI uses this for the `--question-id` form (where the "before"
+/// side is a fresh DB snapshot, not a file).
+pub fn load_entries_from_str(src: &str) -> Result<(Vec<Entry>, BibFormat), String> {
+    match detect_format_from_str(src) {
+        BibFormat::CslJson => {
+            let v: serde_json::Value =
+                serde_json::from_str(src).map_err(|e| format!("not valid JSON: {e}"))?;
+            let arr = v
+                .as_array()
+                .ok_or_else(|| "CSL-JSON top-level must be an array".to_string())?;
+            let entries: Vec<Entry> = arr.iter().filter_map(Entry::from_csl_value).collect();
+            Ok((entries, BibFormat::CslJson))
+        }
+        BibFormat::Bibtex => {
+            let parsed = parse_bibtex(src).map_err(|e| format!("BibTeX parse failed: {e}"))?;
+            let entries: Vec<Entry> = parsed.iter().map(Entry::from_bib_entry).collect();
+            Ok((entries, BibFormat::Bibtex))
+        }
+    }
+}
+
+/// Sniff format. Strategy: try parsing as JSON first (fast: `serde_json`
+/// will reject within bytes if the leading non-whitespace is `@`). If
+/// JSON parse fails, fall back to BibTeX. Note that an empty BibTeX
+/// file (zero entries) is legal, and an empty string parses as neither
+/// JSON nor BibTeX cleanly; we treat empty-or-whitespace-only as
+/// BibTeX so an empty `.bib` round-trips correctly.
+#[must_use]
+pub fn detect_format_from_str(src: &str) -> BibFormat {
+    if src.trim().is_empty() {
+        return BibFormat::Bibtex;
+    }
+    // Quick eyeball: JSON docs start with `[` or `{` after whitespace.
+    // `@article{...}` (BibTeX) starts with `@`. Don't even bother
+    // calling serde_json if the first non-whitespace byte rules JSON
+    // out — saves allocation on large `.bib` files.
+    let first = src.trim_start().as_bytes().first().copied();
+    if matches!(first, Some(b'[' | b'{')) && serde_json::from_str::<serde_json::Value>(src).is_ok()
+    {
+        return BibFormat::CslJson;
+    }
+    BibFormat::Bibtex
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_csl_json_array() {
+        let s = r#"[{"id":"a","type":"article-journal","title":"T"}]"#;
+        assert_eq!(detect_format_from_str(s), BibFormat::CslJson);
+    }
+
+    #[test]
+    fn detects_bibtex_canonical() {
+        let s = r"@article{a, title = {T}, year = {2024}}";
+        assert_eq!(detect_format_from_str(s), BibFormat::Bibtex);
+    }
+
+    #[test]
+    fn empty_input_defaults_to_bibtex() {
+        assert_eq!(detect_format_from_str(""), BibFormat::Bibtex);
+        assert_eq!(detect_format_from_str("   \n  "), BibFormat::Bibtex);
+    }
+
+    #[test]
+    fn malformed_json_falls_back_to_bibtex() {
+        // Looks JSON-ish but isn't — should fall through to bibtex parse.
+        let s = "[ this is not json {} ]";
+        assert_eq!(detect_format_from_str(s), BibFormat::Bibtex);
+    }
+
+    #[test]
+    fn content_sniff_overrides_extension_intent() {
+        // `.bib` extension by intent, but content is valid JSON.
+        // Caller should still treat as JSON.
+        let s = r#"[{"id":"x","type":"article-journal","title":"T"}]"#;
+        let (entries, fmt) = load_entries_from_str(s).unwrap();
+        assert_eq!(fmt, BibFormat::CslJson);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].citekey, "x");
+    }
+
+    #[test]
+    fn loads_bibtex_entries_into_neutral_shape() {
+        let s = r"
+@article{smith2024,
+  title = {T},
+  author = {Smith, J.},
+  year = {2024},
+  doi = {10.1/ABC}
+}";
+        let (entries, fmt) = load_entries_from_str(s).unwrap();
+        assert_eq!(fmt, BibFormat::Bibtex);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].citekey, "smith2024");
+        assert_eq!(entries[0].title.as_deref(), Some("T"));
+        // DOI normalized.
+        assert_eq!(entries[0].doi.as_deref(), Some("10.1/abc"));
+    }
+
+    #[test]
+    fn loads_csl_json_entries_into_neutral_shape() {
+        let s = r#"[
+            {"id":"smith2024","type":"article-journal","title":"T",
+             "author":[{"family":"Smith","given":"J."}],
+             "issued":{"date-parts":[[2024]]},
+             "DOI":"10.1/ABC"}
+        ]"#;
+        let (entries, fmt) = load_entries_from_str(s).unwrap();
+        assert_eq!(fmt, BibFormat::CslJson);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].citekey, "smith2024");
+        assert_eq!(entries[0].title.as_deref(), Some("T"));
+        // CSL DOI is also normalized via the lift helper.
+        assert_eq!(entries[0].doi.as_deref(), Some("10.1/abc"));
+        assert_eq!(entries[0].year, Some(2024));
+    }
+
+    #[test]
+    fn rejects_csl_top_level_object() {
+        // A single CSL entry as a bare object is not the canonical
+        // shape (must be an array). We reject explicitly.
+        let s = r#"{"id":"x","type":"article-journal","title":"T"}"#;
+        let err = load_entries_from_str(s).unwrap_err();
+        assert!(err.contains("must be an array"), "got: {err}");
+    }
+}

--- a/crates/scitadel-export/src/lib.rs
+++ b/crates/scitadel-export/src/lib.rs
@@ -1,6 +1,9 @@
 pub mod bibtex;
 pub mod csl_json;
 pub mod csv_export;
+pub mod diff;
+pub mod diff_format;
+pub mod diff_input;
 pub mod import;
 pub mod json_export;
 pub mod sidecar;
@@ -8,6 +11,11 @@ pub mod sidecar;
 pub use bibtex::{export_bibtex, export_bibtex_with_tags};
 pub use csl_json::{export_csl_json, export_csl_json_with_tags};
 pub use csv_export::export_csv;
+pub use diff::{BibDiff, ChangedEntry, Entry, FieldChange, diff_entries};
+pub use diff_format::{render_json as render_diff_json, render_text as render_diff_text};
+pub use diff_input::{
+    BibFormat, detect_format_from_str, load_entries_from_path, load_entries_from_str,
+};
 pub use import::{
     ALIAS_SOURCE, AliasRecord, BibEntry, MatchOutcome, MatchStrategy, MergeAction, MergeOutcome,
     MergeStrategy, PaperLookup, SideEffects, compute_side_effects, match_entry, paper_from_bib,

--- a/crates/scitadel-mcp/src/server.rs
+++ b/crates/scitadel-mcp/src/server.rs
@@ -344,6 +344,23 @@ pub struct BibSnapshotRequest {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+pub struct BibDiffRequest {
+    /// First bibliography file (BibTeX or CSL-JSON; auto-detected).
+    pub file_a: String,
+    /// Second bibliography file. Mutually exclusive with `question_id`.
+    #[serde(default)]
+    pub file_b: Option<String>,
+    /// Compare `file_a` against a fresh snapshot of this question's
+    /// shortlist. Mutually exclusive with `file_b`.
+    #[serde(default)]
+    pub question_id: Option<String>,
+    /// Reader scope when comparing against `question_id` (mirrors
+    /// annotation/star scoping). Required when `question_id` is set.
+    #[serde(default)]
+    pub reader: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct BibVerifyRequest {
     /// Path to the committed export to verify
     pub file: String,
@@ -813,6 +830,18 @@ impl ScitadelServer {
     )]
     fn bib_verify(&self, Parameters(req): Parameters<BibVerifyRequest>) -> Result<String, String> {
         tools::bib_verify_tool(&req.file, req.question_id.as_deref())
+    }
+
+    #[tool(
+        description = "Structural diff between two bibliographies — added/removed/changed entries with per-field changes — instead of the line-level diff `bib verify` prints. Auto-detects BibTeX vs CSL-JSON by content sniff (extension is cosmetic). Identity rule: citekey → DOI → arxiv_id → title+year (first match wins). Pass `file_b` for file-vs-file or `question_id` for file-vs-fresh-snapshot. Returns: JSON `{added: [...], removed: [...], changed: [{citekey, before_citekey?, field_changes: [...]}]}` — empty arrays mean no drift."
+    )]
+    fn bib_diff(&self, Parameters(req): Parameters<BibDiffRequest>) -> Result<String, String> {
+        tools::bib_diff_tool(
+            &req.file_a,
+            req.file_b.as_deref(),
+            req.question_id.as_deref(),
+            req.reader.as_deref(),
+        )
     }
 }
 

--- a/crates/scitadel-mcp/src/tools.rs
+++ b/crates/scitadel-mcp/src/tools.rs
@@ -1958,6 +1958,50 @@ pub fn bib_verify_tool(file: &str, question_override: Option<&str>) -> Result<St
     .to_string())
 }
 
+/// Structural diff between two bibliography files (or one file +
+/// fresh DB snapshot of a question). Mirrors the CLI's `bib diff`.
+/// Returns: JSON `{added, removed, changed}` (empty arrays if zero
+/// drift). Exit-code semantics live in the CLI; the MCP tool returns
+/// the structure unconditionally so the caller can branch on it.
+pub fn bib_diff_tool(
+    file_a: &str,
+    file_b: Option<&str>,
+    question_id: Option<&str>,
+    reader: Option<&str>,
+) -> Result<String, String> {
+    let path_a = std::path::Path::new(file_a);
+    let (entries_a, fmt_a) = scitadel_export::load_entries_from_path(path_a)?;
+    let entries_b = match (file_b, question_id) {
+        (Some(_), Some(_)) => return Err("pass file_b OR question_id, not both".into()),
+        (None, None) => return Err("pass file_b or question_id".into()),
+        (Some(b), None) => {
+            let (e, _) = scitadel_export::load_entries_from_path(std::path::Path::new(b))?;
+            e
+        }
+        (None, Some(qid)) => {
+            let reader = reader
+                .map(str::to_string)
+                .ok_or_else(|| "reader is required when using question_id".to_string())?;
+            let db = open_db()?;
+            let shortlist_repo = scitadel_db::sqlite::SqliteShortlistRepository::new(db.clone());
+            let question = resolve_question_id(&db, qid)?;
+            let paper_ids = shortlist_repo
+                .list(question.id.as_str(), &reader)
+                .map_err(|e| e.to_string())?;
+            // Match the file's flavor so the comparison is apples-to-apples.
+            let (_papers, content) = match fmt_a {
+                scitadel_export::BibFormat::CslJson => render_shortlist_csl_json(&db, &paper_ids)?,
+                scitadel_export::BibFormat::Bibtex => render_shortlist_bibtex(&db, &paper_ids)?,
+            };
+            let (e, _) = scitadel_export::load_entries_from_str(&content)?;
+            e
+        }
+    };
+
+    let diff = scitadel_export::diff_entries(&entries_a, &entries_b);
+    serde_json::to_string(&diff).map_err(|e| e.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::{


### PR DESCRIPTION
## Summary

- New `scitadel bib diff <file_a> [<file_b>] [--question-id <id>]` — entry-level (added / removed / changed) structural diff between two bibliographies, the human-readable explainer when `bib verify` says drift detected. Auto-detects BibTeX vs CSL-JSON by content sniff; the two flavors are interchangeable in either argument slot.
- Identity rule per the design: `citekey → DOI → arxiv_id → (title, year)`, strict per-rung first-match-wins. Lists sorted by citekey for deterministic output.
- Hand-rolled ANSI in `scitadel-export::diff_format` (no new color/diff crates), TTY-detect via `std::io::IsTerminal`, `--no-color` for CI.
- `--format json` for structured CI consumption; serde-derived round-trip.
- Exit codes `0` (no diff) / `1` (any diff) mirror `git diff`.
- MCP tool `bib_diff` mirroring the CLI for agent workflows.

## Test plan

- [x] 34 unit tests in `scitadel-export` (4 identity-rung tests, 6 field-change tests, sort determinism, JSON round-trip, mixed-format zero-diff, format detection, ANSI color toggle)
- [x] 7 end-to-end CLI tests (identical files exit 0, drifted files exit 1 with the documented text report, `--no-color` strips ANSI, `--format json` round-trips, BibTeX-vs-CSL-JSON of the same shortlist exit 0, `--question-id` form against a seeded DB, missing-second-side error)
- [x] 6 inline CLI plumbing tests (TTY toggle, exit-code derivation, format dispatch)
- [x] 335 workspace tests passing (excluding `scitadel-tui` per quality gate)
- [x] `just lint` clean

## Closes

Closes #135 (after #180 sub-feature A and #151 sub-feature B landed)

[tape-exempt: text-only --help addition under bib diff; output is colored text on stdout, not TUI rendering]