### PR TITLE
feat(tui): E keybind on Question Dashboard exports bibliography

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2498,6 +2498,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tempfile",
  "thiserror",
  "uuid",
 ]
@@ -2555,6 +2556,8 @@ dependencies = [
  "scitadel-adapters",
  "scitadel-core",
  "scitadel-db",
+ "scitadel-export",
+ "tempfile",
  "tokio",
  "tracing",
  "uuid",

--- a/crates/scitadel-cli/src/commands.rs
+++ b/crates/scitadel-cli/src/commands.rs
@@ -1108,15 +1108,8 @@ fn find_source_credentials(source: &str) -> Result<&'static credentials::SourceC
 
 // ---------- bib snapshot / verify (#178) ----------
 
-/// Sidecar suffix appended to the output `.bib` path. One sidecar per
-/// `.bib` keeps scope to a single (question, output_file) — see #178
-/// "Sidecar location collision" pitfall.
-pub const SIDECAR_SUFFIX: &str = ".scitadel-bib.lock";
-
 fn sidecar_path_for(bib: &std::path::Path) -> PathBuf {
-    let mut s = bib.as_os_str().to_owned();
-    s.push(SIDECAR_SUFFIX);
-    PathBuf::from(s)
+    scitadel_export::sidecar_path_for(bib)
 }
 
 fn current_reader() -> String {
@@ -1169,9 +1162,9 @@ fn load_shortlist(
     Ok((question, paper_ids, papers, tags))
 }
 
-/// Render the shortlist's `.bib`. Centralized so snapshot and verify
-/// produce byte-identical output for the same DB state — that's the
-/// whole determinism story.
+/// Render the shortlist's `.bib`. Kept as a thin wrapper around the
+/// reusable rendering helper so verify (which compares against a
+/// re-render) stays single-call-site.
 fn render_bibtex(
     papers: &[scitadel_core::models::Paper],
     tags: &std::collections::HashMap<String, Vec<String>>,
@@ -1179,9 +1172,8 @@ fn render_bibtex(
     scitadel_export::export_bibtex_with_tags(papers, |id| tags.get(id).cloned().unwrap_or_default())
 }
 
-/// Render the shortlist as canonical CSL-JSON 1.0.2 (#135 sub-feature
-/// A). Same determinism contract as [`render_bibtex`] — same DB state ⇒
-/// byte-identical output.
+/// CSL-JSON sibling of [`render_bibtex`]. Used by `bib verify` to
+/// re-render against the sidecar's recorded format.
 fn render_csl_json(
     papers: &[scitadel_core::models::Paper],
     tags: &std::collections::HashMap<String, Vec<String>>,
@@ -1191,13 +1183,14 @@ fn render_csl_json(
     })
 }
 
-/// Default output filename for a given snapshot format. Lets users skip
-/// `--output` entirely for the common case while keeping the extension
-/// honest (`.bib` for BibTeX, `.json` for CSL-JSON).
-fn default_output_for(format: &str) -> &'static std::path::Path {
+/// Parse the CLI's `--format` string into the typed enum the export
+/// helper accepts. Centralized so the error message stays consistent
+/// across snapshot + verify.
+fn parse_format(format: &str) -> Result<scitadel_export::SnapshotFormat> {
     match format {
-        "csl-json" => std::path::Path::new("paper.json"),
-        _ => std::path::Path::new("paper.bib"),
+        "csl-json" => Ok(scitadel_export::SnapshotFormat::CslJson),
+        "bibtex" | "" => Ok(scitadel_export::SnapshotFormat::BibTeX),
+        other => bail!("unknown --format: {other}; valid: bibtex, csl-json"),
     }
 }
 
@@ -1210,55 +1203,37 @@ pub fn bib_snapshot(
 ) -> Result<()> {
     let reader = reader_arg.map_or_else(current_reader, str::to_string);
     let (question, paper_ids, papers, tags) = load_shortlist(question_prefix, &reader)?;
+    let snapshot_format = parse_format(format)?;
 
-    let output_path = output.unwrap_or_else(|| default_output_for(format));
+    let output_path =
+        output.unwrap_or_else(|| scitadel_export::default_filename_for_format(snapshot_format));
 
-    let (content, lock) = match format {
-        "csl-json" => {
-            let c = render_csl_json(&papers, &tags);
-            let l = scitadel_export::BibLockfile::new_csl_json(
-                question.id.as_str(),
-                &reader,
-                &paper_ids,
-                &c,
-            );
-            (c, l)
-        }
-        "bibtex" | "" => {
-            let c = render_bibtex(&papers, &tags);
-            let l = scitadel_export::BibLockfile::new_bibtex(
-                question.id.as_str(),
-                &reader,
-                &paper_ids,
-                &c,
-            );
-            (c, l)
-        }
-        other => bail!("unknown --format: {other}; valid: bibtex, csl-json"),
-    };
+    let outcome = scitadel_export::write_snapshot(
+        output_path,
+        question.id.as_str(),
+        &reader,
+        &papers,
+        &paper_ids,
+        |id| tags.get(id).cloned().unwrap_or_default(),
+        snapshot_format,
+        !no_lock,
+    )
+    .with_context(|| format!("failed to write {}", output_path.display()))?;
 
-    std::fs::write(output_path, &content)
-        .with_context(|| format!("failed to write {}", output_path.display()))?;
-
-    if no_lock {
+    if let Some(sidecar) = outcome.sidecar_path {
+        println!(
+            "Wrote {} ({} papers) + {}",
+            outcome.output_path.display(),
+            outcome.entry_count,
+            sidecar.display()
+        );
+    } else {
         println!(
             "Wrote {} ({} papers) — sidecar skipped (--no-lock)",
-            output_path.display(),
-            papers.len()
+            outcome.output_path.display(),
+            outcome.entry_count
         );
-        return Ok(());
     }
-
-    let sidecar = sidecar_path_for(output_path);
-    std::fs::write(&sidecar, lock.to_json()?)
-        .with_context(|| format!("failed to write {}", sidecar.display()))?;
-
-    println!(
-        "Wrote {} ({} papers) + {}",
-        output_path.display(),
-        papers.len(),
-        sidecar.display()
-    );
     Ok(())
 }
 

--- a/crates/scitadel-export/Cargo.toml
+++ b/crates/scitadel-export/Cargo.toml
@@ -23,6 +23,7 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }
+tempfile = { workspace = true }
 uuid = { workspace = true }
 
 [lints]

--- a/crates/scitadel-export/src/lib.rs
+++ b/crates/scitadel-export/src/lib.rs
@@ -4,6 +4,8 @@ pub mod csv_export;
 pub mod import;
 pub mod json_export;
 pub mod sidecar;
+pub mod slug;
+pub mod snapshot;
 
 pub use bibtex::{export_bibtex, export_bibtex_with_tags};
 pub use csl_json::{export_csl_json, export_csl_json_with_tags};
@@ -15,3 +17,8 @@ pub use import::{
 };
 pub use json_export::export_json;
 pub use sidecar::{BibLockfile, content_hash, shortlist_hash};
+pub use slug::{FALLBACK_SLUG, MAX_SLUG_LEN, slugify};
+pub use snapshot::{
+    SIDECAR_SUFFIX, SnapshotFormat, SnapshotOutcome, default_filename_for_format, sidecar_path_for,
+    write_snapshot,
+};

--- a/crates/scitadel-export/src/slug.rs
+++ b/crates/scitadel-export/src/slug.rs
@@ -1,0 +1,161 @@
+//! Kebab-slug helper for question-derived filenames.
+//!
+//! Used by the TUI export keybind (#135 sub-feature B) to pre-fill the
+//! path prompt with a human-readable default like
+//! `what-is-the-role-of-attention.bib`. Lives in `scitadel-export` so
+//! the CLI can adopt the same default in a future iteration without a
+//! second copy of the rules.
+//!
+//! Rules (locked here so behavior is testable):
+//! 1. Map common Latin diacritics down to their ASCII base (`Ü` → `u`).
+//! 2. Lowercase the result.
+//! 3. Replace any non-`[a-z0-9]` rune with `-`.
+//! 4. Collapse repeated `-` runs into a single `-`.
+//! 5. Trim leading and trailing `-`.
+//! 6. Cap at [`MAX_SLUG_LEN`] characters; trim trailing `-` again after
+//!    the cap so we never emit `foo-bar-`.
+//! 7. If the result is empty (e.g. all punctuation, all CJK), return
+//!    [`FALLBACK_SLUG`].
+
+/// Maximum slug length. 60 leaves headroom under POSIX 255-char filename
+/// limits even after the user appends a long parent path + an extension.
+pub const MAX_SLUG_LEN: usize = 60;
+
+/// Slug returned when the input has no ASCII-alphanumeric characters.
+/// `paper.bib` is the same default `bib snapshot` falls back to when
+/// `--output` is omitted, so the two surfaces stay aligned.
+pub const FALLBACK_SLUG: &str = "untitled";
+
+/// Slugify a question (or any title) into a kebab-cased ASCII filename
+/// stem. See module docs for the locked rules.
+#[must_use]
+pub fn slugify(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut last_was_dash = false;
+    for ch in input.chars() {
+        let mapped = ascii_fold_lower(ch);
+        for c in mapped.chars() {
+            if c.is_ascii_alphanumeric() {
+                out.push(c);
+                last_was_dash = false;
+            } else if !last_was_dash {
+                out.push('-');
+                last_was_dash = true;
+            }
+        }
+    }
+
+    // Trim trailing `-` (leading was prevented by `last_was_dash` start).
+    while out.starts_with('-') {
+        out.remove(0);
+    }
+    while out.ends_with('-') {
+        out.pop();
+    }
+
+    if out.len() > MAX_SLUG_LEN {
+        out.truncate(MAX_SLUG_LEN);
+        while out.ends_with('-') {
+            out.pop();
+        }
+    }
+
+    if out.is_empty() {
+        FALLBACK_SLUG.to_string()
+    } else {
+        out
+    }
+}
+
+/// Map a single char to its ASCII-lower form when the rune has an
+/// obvious Latin equivalent; otherwise lowercase whatever ASCII it
+/// already is. Non-ASCII non-mapped runes pass through and will be
+/// replaced with `-` by the caller.
+fn ascii_fold_lower(ch: char) -> String {
+    match ch {
+        'À' | 'Á' | 'Â' | 'Ã' | 'Ä' | 'Å' | 'à' | 'á' | 'â' | 'ã' | 'ä' | 'å' => {
+            "a".into()
+        }
+        'Æ' | 'æ' => "ae".into(),
+        'Ç' | 'ç' => "c".into(),
+        'È' | 'É' | 'Ê' | 'Ë' | 'è' | 'é' | 'ê' | 'ë' => "e".into(),
+        'Ì' | 'Í' | 'Î' | 'Ï' | 'ì' | 'í' | 'î' | 'ï' => "i".into(),
+        'Ñ' | 'ñ' => "n".into(),
+        'Ò' | 'Ó' | 'Ô' | 'Õ' | 'Ö' | 'Ø' | 'ò' | 'ó' | 'ô' | 'õ' | 'ö' | 'ø' => {
+            "o".into()
+        }
+        'Œ' | 'œ' => "oe".into(),
+        'ß' => "ss".into(),
+        'Ù' | 'Ú' | 'Û' | 'Ü' | 'ù' | 'ú' | 'û' | 'ü' => "u".into(),
+        'Ý' | 'ý' | 'ÿ' => "y".into(),
+        c if c.is_ascii() => c.to_ascii_lowercase().to_string(),
+        // Non-ASCII rune we don't know — caller will dash-fold it.
+        c => c.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn simple_question_slugifies_lowercase_kebab() {
+        assert_eq!(
+            slugify("What is the role of attention?"),
+            "what-is-the-role-of-attention"
+        );
+    }
+
+    #[test]
+    fn punctuation_is_dashed_and_collapsed() {
+        // Ampersand + comma + multi-space all collapse to a single `-`.
+        assert_eq!(
+            slugify("Learning &  reasoning, in LLMs!"),
+            "learning-reasoning-in-llms"
+        );
+    }
+
+    #[test]
+    fn diacritics_fold_to_ascii() {
+        assert_eq!(slugify("Über résumé"), "uber-resume");
+        assert_eq!(slugify("Crème brûlée"), "creme-brulee");
+        assert_eq!(slugify("naïve façade"), "naive-facade");
+    }
+
+    #[test]
+    fn all_non_alphanumeric_returns_fallback() {
+        assert_eq!(slugify("???"), FALLBACK_SLUG);
+        assert_eq!(slugify("   "), FALLBACK_SLUG);
+        assert_eq!(slugify("--- ---"), FALLBACK_SLUG);
+    }
+
+    #[test]
+    fn empty_string_returns_fallback() {
+        assert_eq!(slugify(""), FALLBACK_SLUG);
+    }
+
+    #[test]
+    fn length_is_capped_without_trailing_dash() {
+        let long = "a ".repeat(80); // 80 alpha chars separated by spaces
+        let out = slugify(&long);
+        assert!(out.len() <= MAX_SLUG_LEN, "len = {}", out.len());
+        assert!(!out.ends_with('-'), "got: {out}");
+    }
+
+    #[test]
+    fn cjk_only_returns_fallback() {
+        // Pure non-Latin runes have no ASCII fold; everything dashes,
+        // then trims to empty → fallback.
+        assert_eq!(slugify("日本語"), FALLBACK_SLUG);
+    }
+
+    #[test]
+    fn leading_and_trailing_punctuation_trimmed() {
+        assert_eq!(slugify("--hello world!!"), "hello-world");
+    }
+
+    #[test]
+    fn numbers_are_preserved() {
+        assert_eq!(slugify("GPT-4 vs Claude 3.5"), "gpt-4-vs-claude-3-5");
+    }
+}

--- a/crates/scitadel-export/src/snapshot.rs
+++ b/crates/scitadel-export/src/snapshot.rs
@@ -1,0 +1,250 @@
+//! Pure write-side of `bib snapshot` (#178), reusable from CLI + TUI.
+//!
+//! The CLI command in `scitadel-cli` already loads a question's
+//! shortlist + papers + tags from the DB, then renders + writes the
+//! `.bib` (or CSL-JSON) file plus the `.scitadel-bib.lock` sidecar.
+//! The TUI needs to do the exact same write step from already-loaded
+//! data when the user presses `E` on the Question Dashboard
+//! (#135 sub-feature B).
+//!
+//! Lifting the rendering + I/O into this module guarantees both
+//! surfaces produce byte-identical artifacts — there is no second copy
+//! of the format-routing or sidecar-construction logic.
+
+use std::path::{Path, PathBuf};
+
+use scitadel_core::models::Paper;
+
+use crate::sidecar::BibLockfile;
+use crate::{export_bibtex_with_tags, export_csl_json_with_tags};
+
+/// Sidecar suffix appended to the snapshot's output path. One sidecar
+/// per `(question, output_file)` keeps scope focused — see #178
+/// "Sidecar location collision" pitfall.
+pub const SIDECAR_SUFFIX: &str = ".scitadel-bib.lock";
+
+/// Output flavor for [`write_snapshot`]. The string discriminants live
+/// on [`crate::sidecar`] so verify and snapshot can never disagree
+/// about the wire value of the format field.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotFormat {
+    BibTeX,
+    CslJson,
+}
+
+impl SnapshotFormat {
+    /// Suggested file extension, including the leading dot. Used by
+    /// callers building default output paths.
+    #[must_use]
+    pub fn extension(self) -> &'static str {
+        match self {
+            Self::BibTeX => ".bib",
+            Self::CslJson => ".json",
+        }
+    }
+}
+
+/// Default filename (path component, no directory) for a given
+/// snapshot format. Mirrors the CLI's `--output` fallback so `E` from
+/// the TUI without typing anything produces the same filename you'd
+/// get from `bib snapshot <id>` with no `--output`.
+#[must_use]
+pub fn default_filename_for_format(format: SnapshotFormat) -> &'static Path {
+    match format {
+        SnapshotFormat::CslJson => Path::new("paper.json"),
+        SnapshotFormat::BibTeX => Path::new("paper.bib"),
+    }
+}
+
+/// Path of the `.scitadel-bib.lock` sidecar that should sit next to
+/// `bib`. The sidecar's filename is exactly `<bib>.scitadel-bib.lock`
+/// — see `bib snapshot` docs.
+#[must_use]
+pub fn sidecar_path_for(bib: &Path) -> PathBuf {
+    let mut s = bib.as_os_str().to_owned();
+    s.push(SIDECAR_SUFFIX);
+    PathBuf::from(s)
+}
+
+/// What [`write_snapshot`] just wrote to disk. The TUI surfaces the
+/// counts in a status-bar toast; tests assert the on-disk artifacts
+/// against the returned paths.
+#[derive(Debug, Clone)]
+pub struct SnapshotOutcome {
+    /// Path the rendered bibliography was written to (verbatim from the
+    /// caller; sidecar is computed from this).
+    pub output_path: PathBuf,
+    /// Path of the `.scitadel-bib.lock` sidecar; `None` when the caller
+    /// asked us to skip the sidecar via `write_lockfile = false`.
+    pub sidecar_path: Option<PathBuf>,
+    /// Number of `Paper` rows the bibliography includes. Drives the
+    /// "exported: paper.bib (N entries)" toast in the TUI.
+    pub entry_count: usize,
+}
+
+/// Write a snapshot to disk from already-loaded inputs.
+///
+/// `papers` and `paper_ids` are expected to be in shortlist order.
+/// `tags_for(paper_id)` returns the per-paper BibTeX tags (groups);
+/// callers without tags pass a closure that always returns `vec![]`.
+///
+/// # Errors
+///
+/// Returns any [`std::io::Error`] from writing the bibliography or the
+/// sidecar. Lockfile JSON serialization errors are wrapped in
+/// `io::ErrorKind::Other`.
+#[allow(clippy::too_many_arguments)]
+pub fn write_snapshot<F>(
+    output_path: &Path,
+    question_id: &str,
+    reader: &str,
+    papers: &[Paper],
+    paper_ids: &[String],
+    tags_for: F,
+    format: SnapshotFormat,
+    write_lockfile: bool,
+) -> std::io::Result<SnapshotOutcome>
+where
+    F: Fn(&str) -> Vec<String>,
+{
+    let (content, lock) = match format {
+        SnapshotFormat::BibTeX => {
+            let c = export_bibtex_with_tags(papers, &tags_for);
+            let l = BibLockfile::new_bibtex(question_id, reader, paper_ids, &c);
+            (c, l)
+        }
+        SnapshotFormat::CslJson => {
+            let c = export_csl_json_with_tags(papers, &tags_for);
+            let l = BibLockfile::new_csl_json(question_id, reader, paper_ids, &c);
+            (c, l)
+        }
+    };
+
+    std::fs::write(output_path, &content)?;
+
+    let sidecar_path = if write_lockfile {
+        let path = sidecar_path_for(output_path);
+        let json = lock.to_json().map_err(std::io::Error::other)?;
+        std::fs::write(&path, json)?;
+        Some(path)
+    } else {
+        None
+    };
+
+    Ok(SnapshotOutcome {
+        output_path: output_path.to_path_buf(),
+        sidecar_path,
+        entry_count: papers.len(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use scitadel_core::models::{Paper, PaperId};
+
+    fn paper(id: &str, title: &str, year: i32) -> Paper {
+        let mut p = Paper::new(title);
+        p.id = PaperId::from(id);
+        p.authors = vec!["Doe, J.".into()];
+        p.year = Some(year);
+        p
+    }
+
+    #[test]
+    fn sidecar_path_appends_suffix() {
+        let p = sidecar_path_for(Path::new("out/paper.bib"));
+        assert_eq!(p, PathBuf::from("out/paper.bib.scitadel-bib.lock"));
+    }
+
+    #[test]
+    fn default_filename_matches_format() {
+        assert_eq!(
+            default_filename_for_format(SnapshotFormat::BibTeX),
+            Path::new("paper.bib")
+        );
+        assert_eq!(
+            default_filename_for_format(SnapshotFormat::CslJson),
+            Path::new("paper.json")
+        );
+    }
+
+    #[test]
+    fn write_snapshot_bibtex_writes_both_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let out = dir.path().join("p.bib");
+        let papers = vec![paper("p-1", "On Attention", 2017)];
+        let ids = vec!["p-1".to_string()];
+
+        let outcome = write_snapshot(
+            &out,
+            "q-x",
+            "lars",
+            &papers,
+            &ids,
+            |_| vec![],
+            SnapshotFormat::BibTeX,
+            true,
+        )
+        .unwrap();
+
+        assert_eq!(outcome.entry_count, 1);
+        assert_eq!(outcome.output_path, out);
+        let sidecar = outcome.sidecar_path.unwrap();
+        assert_eq!(sidecar, out.with_extension("bib.scitadel-bib.lock"));
+        let bib_bytes = std::fs::read_to_string(&out).unwrap();
+        assert!(bib_bytes.contains("On Attention"), "got: {bib_bytes}");
+        let lock_bytes = std::fs::read_to_string(&sidecar).unwrap();
+        let lock: BibLockfile = serde_json::from_str(&lock_bytes).unwrap();
+        assert_eq!(lock.question_id, "q-x");
+        assert_eq!(lock.format, "bibtex");
+    }
+
+    #[test]
+    fn write_snapshot_csl_json_writes_both_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let out = dir.path().join("p.json");
+        let papers = vec![paper("p-1", "On Attention", 2017)];
+        let ids = vec!["p-1".to_string()];
+
+        let outcome = write_snapshot(
+            &out,
+            "q-x",
+            "lars",
+            &papers,
+            &ids,
+            |_| vec![],
+            SnapshotFormat::CslJson,
+            true,
+        )
+        .unwrap();
+
+        let lock: BibLockfile =
+            serde_json::from_str(&std::fs::read_to_string(outcome.sidecar_path.unwrap()).unwrap())
+                .unwrap();
+        assert_eq!(lock.format, "csl-json");
+    }
+
+    #[test]
+    fn write_snapshot_skips_sidecar_when_requested() {
+        let dir = tempfile::tempdir().unwrap();
+        let out = dir.path().join("p.bib");
+        let papers = vec![paper("p-1", "T", 2020)];
+        let ids = vec!["p-1".to_string()];
+
+        let outcome = write_snapshot(
+            &out,
+            "q",
+            "r",
+            &papers,
+            &ids,
+            |_| vec![],
+            SnapshotFormat::BibTeX,
+            false,
+        )
+        .unwrap();
+
+        assert!(outcome.sidecar_path.is_none());
+        assert!(out.exists());
+    }
+}

--- a/crates/scitadel-tui/Cargo.toml
+++ b/crates/scitadel-tui/Cargo.toml
@@ -15,6 +15,7 @@ readme = "../../README.md"
 scitadel-core = { path = "../scitadel-core", version = "0.6.0" }
 scitadel-db = { path = "../scitadel-db", version = "0.6.0" }
 scitadel-adapters = { path = "../scitadel-adapters", version = "0.6.0" }
+scitadel-export = { path = "../scitadel-export", version = "0.6.0" }
 ratatui = { workspace = true }
 crossterm = { workspace = true }
 anyhow = { workspace = true }
@@ -23,6 +24,9 @@ tokio = { workspace = true }
 uuid = { workspace = true }
 reqwest = { workspace = true }
 chrono = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/scitadel-tui/src/app.rs
+++ b/crates/scitadel-tui/src/app.rs
@@ -18,8 +18,10 @@ use tokio::sync::mpsc;
 use crate::data::DataStore;
 use crate::tasks::{Task, TaskKind, TaskStatus, TaskUpdate, spawn_download_paper};
 use crate::views::annotation_prompt::{AnnotationPrompt, PromptCommit, PromptSubmission};
+use crate::views::bib_export_prompt::BibExportPrompt;
 use crate::views::{
-    annotation_prompt, dashboard, detail, papers, questions, queue, searches, tasks as tasks_view,
+    annotation_prompt, bib_export_prompt, dashboard, detail, papers, questions, queue, searches,
+    tasks as tasks_view,
 };
 use crate::widgets::status_bar;
 
@@ -94,10 +96,13 @@ pub enum Overlay {
     },
     /// Question Dashboard (#133). Split-pane ranked-by-score view of
     /// papers assessed against the question, with a citation shortlist
-    /// curated via `c`.
+    /// curated via `c`. The optional `export_prompt` field carries the
+    /// state of the `E` path-prompt overlay (#135 sub-feature B); when
+    /// `Some`, the prompt eats every keystroke until Enter / Esc.
     QuestionDashboard {
         question_id: String,
         selected: usize,
+        export_prompt: Option<BibExportPrompt>,
     },
 }
 
@@ -137,6 +142,12 @@ pub struct App {
     /// the 100 ms event-poll cadence, ~30 frames ≈ 3 s) rather than
     /// wall-clock so headless tape runs reproduce the same lifetime.
     startup_toast_frames: u32,
+    /// Transient status-bar toast set by user-facing actions
+    /// (currently: bib export success/failure, #135 sub-feature B).
+    /// Shape mirrors the startup toast so we don't need a second
+    /// rendering branch — both feed the same status-bar slot. Lifetime
+    /// is per-toast so a long error can linger longer than a quick OK.
+    status_toast: Option<StatusToast>,
 
     task_tx: mpsc::UnboundedSender<TaskUpdate>,
     task_rx: mpsc::UnboundedReceiver<TaskUpdate>,
@@ -147,6 +158,23 @@ pub struct App {
 /// 100 ms event-poll cadence this is ~3 seconds — long enough to read,
 /// short enough to clear before the user does anything substantial.
 const STARTUP_TOAST_FRAMES: u32 = 30;
+
+/// Lifetime budget (in draws) for action-success toasts. ~30 frames at
+/// the 100 ms poll cadence ≈ 3 s.
+const STATUS_TOAST_OK_FRAMES: u32 = 30;
+
+/// Lifetime budget (in draws) for action-failure toasts. Doubled so the
+/// user has time to read a longer error message before it clears.
+const STATUS_TOAST_ERR_FRAMES: u32 = 60;
+
+/// Action-driven status toast (success or failure). Mirrors the shape
+/// of `startup_toast` + `startup_toast_frames` but ships them in a
+/// single struct so per-toast lifetime is configurable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct StatusToast {
+    pub message: String,
+    pub frames_remaining: u32,
+}
 
 impl App {
     fn new(
@@ -186,6 +214,7 @@ impl App {
             offline: false,
             startup_toast: None,
             startup_toast_frames: 0,
+            status_toast: None,
             task_tx,
             task_rx,
             offline_rx,
@@ -203,6 +232,38 @@ impl App {
         if self.startup_toast_frames > STARTUP_TOAST_FRAMES {
             self.startup_toast = None;
         }
+    }
+
+    /// Decrement the action-toast lifetime by one draw. Mirrors
+    /// `tick_startup_toast` so both toast slots share the same
+    /// per-frame counter cadence — there is no second timing
+    /// subsystem (#135 sub-feature B keeps the existing primitive).
+    fn tick_status_toast(&mut self) {
+        let Some(toast) = self.status_toast.as_mut() else {
+            return;
+        };
+        if toast.frames_remaining == 0 {
+            self.status_toast = None;
+        } else {
+            toast.frames_remaining -= 1;
+        }
+    }
+
+    /// Show a success/info status-bar toast for ~30 frames.
+    pub(crate) fn set_status_ok(&mut self, message: impl Into<String>) {
+        self.status_toast = Some(StatusToast {
+            message: message.into(),
+            frames_remaining: STATUS_TOAST_OK_FRAMES,
+        });
+    }
+
+    /// Show an error status-bar toast for ~60 frames (longer so the
+    /// user has time to read it).
+    pub(crate) fn set_status_err(&mut self, message: impl Into<String>) {
+        self.status_toast = Some(StatusToast {
+            message: message.into(),
+            frames_remaining: STATUS_TOAST_ERR_FRAMES,
+        });
     }
 
     fn drain_offline(&mut self) {
@@ -461,52 +522,184 @@ impl App {
                 }
                 _ => {}
             },
-            Some(Overlay::QuestionDashboard {
-                ref question_id,
-                ref mut selected,
-            }) => match code {
-                KeyCode::Esc | KeyCode::Char('q') => self.overlay = None,
-                KeyCode::Char('j') | KeyCode::Down => {
-                    let count = dashboard::row_count(&self.data, question_id);
-                    if count > 0 {
-                        *selected = (*selected + 1).min(count - 1);
-                    }
-                }
-                KeyCode::Char('k') | KeyCode::Up => {
-                    *selected = selected.saturating_sub(1);
-                }
-                KeyCode::Char('c') => {
-                    let qid = question_id.clone();
-                    let sel = *selected;
-                    if let Ok(rows) = self.data.load_question_dashboard(&qid)
-                        && let Some((paper, _)) = rows.get(sel)
-                    {
-                        let pid = paper.id.as_str().to_string();
-                        let _ = self.data.toggle_shortlist(&qid, &pid, &self.reader);
-                    }
-                }
-                KeyCode::Enter => {
-                    // Open the focused paper's detail overlay on top of
-                    // the dashboard — same overlay mechanic as the
-                    // SearchPapers flow. Esc returns to the dashboard.
-                    let qid = question_id.clone();
-                    let sel = *selected;
-                    if let Ok(rows) = self.data.load_question_dashboard(&qid)
-                        && let Some((paper, _)) = rows.get(sel)
-                    {
-                        self.overlay = Some(Overlay::PaperDetail {
-                            paper_id: paper.id.as_str().to_string(),
-                            scroll: 0,
-                            annotation_focus: None,
-                            prompt: None,
-                            reader: false,
-                            highlight_focus: None,
-                        });
-                    }
-                }
-                _ => {}
-            },
+            Some(Overlay::QuestionDashboard { .. }) => {
+                self.handle_question_dashboard_key(code);
+            }
             None => {}
+        }
+    }
+
+    /// Routes a key inside the QuestionDashboard overlay. Layered just
+    /// like the PaperDetail handler so the active prompt (the `E`
+    /// export prompt) eats every keystroke before falling through to
+    /// the j/k/c/Enter list controls.
+    fn handle_question_dashboard_key(&mut self, code: KeyCode) {
+        let Some(Overlay::QuestionDashboard {
+            question_id,
+            selected,
+            export_prompt,
+        }) = self.overlay.as_mut()
+        else {
+            return;
+        };
+
+        // Layer 1: the path prompt is open — eat the keystroke here.
+        if export_prompt.is_some() {
+            self.handle_export_prompt_key(code);
+            return;
+        }
+
+        // Layer 2: plain dashboard list controls.
+        match code {
+            KeyCode::Esc | KeyCode::Char('q') => self.overlay = None,
+            KeyCode::Char('j') | KeyCode::Down => {
+                let count = dashboard::row_count(&self.data, question_id);
+                if count > 0 {
+                    *selected = (*selected + 1).min(count - 1);
+                }
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                *selected = selected.saturating_sub(1);
+            }
+            KeyCode::Char('c') => {
+                let qid = question_id.clone();
+                let sel = *selected;
+                if let Ok(rows) = self.data.load_question_dashboard(&qid)
+                    && let Some((paper, _)) = rows.get(sel)
+                {
+                    let pid = paper.id.as_str().to_string();
+                    let _ = self.data.toggle_shortlist(&qid, &pid, &self.reader);
+                }
+            }
+            // Open the export-path prompt. Uppercase `E` keeps the key
+            // out of the namespace of the lowercase `e` (annotation-edit)
+            // used inside PaperDetail and free of the global `c` we
+            // already use in tab mode (#135 sub-feature B).
+            KeyCode::Char('E') => {
+                let qid = question_id.clone();
+                let question_text = self
+                    .data
+                    .load_question(&qid)
+                    .ok()
+                    .flatten()
+                    .map(|q| q.text)
+                    .unwrap_or_default();
+                *export_prompt = Some(BibExportPrompt::from_question(
+                    &question_text,
+                    scitadel_export::SnapshotFormat::BibTeX,
+                ));
+            }
+            KeyCode::Enter => {
+                // Open the focused paper's detail overlay on top of
+                // the dashboard — same overlay mechanic as the
+                // SearchPapers flow. Esc returns to the dashboard.
+                let qid = question_id.clone();
+                let sel = *selected;
+                if let Ok(rows) = self.data.load_question_dashboard(&qid)
+                    && let Some((paper, _)) = rows.get(sel)
+                {
+                    self.overlay = Some(Overlay::PaperDetail {
+                        paper_id: paper.id.as_str().to_string(),
+                        scroll: 0,
+                        annotation_focus: None,
+                        prompt: None,
+                        reader: false,
+                        highlight_focus: None,
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Drive the export-path prompt's text edits + Enter/Esc. Pulled
+    /// into its own method so the dispatch above stays readable.
+    fn handle_export_prompt_key(&mut self, code: KeyCode) {
+        let Some(Overlay::QuestionDashboard {
+            question_id,
+            export_prompt: Some(prompt),
+            ..
+        }) = self.overlay.as_mut()
+        else {
+            return;
+        };
+
+        match code {
+            KeyCode::Esc => {
+                if let Some(Overlay::QuestionDashboard { export_prompt, .. }) =
+                    self.overlay.as_mut()
+                {
+                    *export_prompt = None;
+                }
+            }
+            KeyCode::Char(c) => prompt.push_char(c),
+            KeyCode::Backspace => prompt.backspace(),
+            KeyCode::Enter => {
+                let path = prompt.submit();
+                let format = prompt.format;
+                let qid = question_id.clone();
+                // Drop the prompt before any DB / I/O so a long-running
+                // write doesn't keep the overlay borrow alive.
+                if let Some(Overlay::QuestionDashboard { export_prompt, .. }) =
+                    self.overlay.as_mut()
+                {
+                    *export_prompt = None;
+                }
+                if let Some(path_str) = path {
+                    self.run_bib_export(&qid, std::path::PathBuf::from(path_str), format);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Resolve the question's shortlist + tags and write the snapshot.
+    ///
+    /// Routes through the shared `scitadel_export::write_snapshot`
+    /// helper so the on-disk `.bib` + `.scitadel-bib.lock` artifacts
+    /// are byte-identical to what `bib snapshot` would write from the
+    /// CLI. Surfaces the outcome as a status-bar toast — never panics,
+    /// never bubbles I/O errors past the prompt.
+    fn run_bib_export(
+        &mut self,
+        question_id: &str,
+        output_path: std::path::PathBuf,
+        format: scitadel_export::SnapshotFormat,
+    ) {
+        let (paper_ids, papers, tags) =
+            match self.data.load_snapshot_inputs(question_id, &self.reader) {
+                Ok(t) => t,
+                Err(e) => {
+                    self.set_status_err(format!("export failed: {e}"));
+                    return;
+                }
+            };
+        if papers.is_empty() {
+            self.set_status_err("export failed: shortlist is empty");
+            return;
+        }
+        let result = scitadel_export::write_snapshot(
+            &output_path,
+            question_id,
+            &self.reader,
+            &papers,
+            &paper_ids,
+            |id| tags.get(id).cloned().unwrap_or_default(),
+            format,
+            true,
+        );
+        match result {
+            Ok(outcome) => {
+                let display = outcome.output_path.file_name().map_or_else(
+                    || outcome.output_path.display().to_string(),
+                    |n| n.to_string_lossy().to_string(),
+                );
+                self.set_status_ok(format!(
+                    "exported: {display} ({} entries)",
+                    outcome.entry_count
+                ));
+            }
+            Err(e) => self.set_status_err(format!("export failed: {e}")),
         }
     }
 
@@ -837,6 +1030,7 @@ impl App {
                             self.overlay = Some(Overlay::QuestionDashboard {
                                 question_id: q.id.as_str().to_string(),
                                 selected: 0,
+                                export_prompt: None,
                             });
                         }
                     }
@@ -1036,6 +1230,7 @@ fn draw(frame: &mut ratatui::Frame, app: &mut App) {
         Some(Overlay::QuestionDashboard {
             question_id,
             selected,
+            export_prompt,
         }) => {
             dashboard::draw(
                 frame,
@@ -1045,6 +1240,9 @@ fn draw(frame: &mut ratatui::Frame, app: &mut App) {
                 &app.reader,
                 *selected,
             );
+            if let Some(prompt) = export_prompt {
+                bib_export_prompt::draw_overlay(frame, chunks[1], prompt);
+            }
         }
         None => match app.tab {
             Tab::Searches => searches::draw(frame, chunks[1], &app.data, app.search_selected),
@@ -1107,8 +1305,15 @@ fn draw(frame: &mut ratatui::Frame, app: &mut App) {
         (Some(Overlay::SearchPapers { .. }), _) => {
             "Esc/q: back | j/k: navigate | Enter: open paper"
         }
+        (
+            Some(Overlay::QuestionDashboard {
+                export_prompt: Some(_),
+                ..
+            }),
+            _,
+        ) => "Enter: export | Backspace: delete char | Esc: cancel",
         (Some(Overlay::QuestionDashboard { .. }), _) => {
-            "Esc/q: back | j/k: navigate | Enter: open paper | c: toggle shortlist"
+            "Esc/q: back | j/k: navigate | Enter: open paper | c: toggle shortlist | E: export bib"
         }
         (None, Tab::Papers | Tab::Queue) => {
             "Tab: switch tabs | j/k: navigate | Enter: open | s: (un)star | c: clear tasks | q: quit"
@@ -1120,9 +1325,15 @@ fn draw(frame: &mut ratatui::Frame, app: &mut App) {
     // Startup toast (#137) hijacks the status bar for its lifetime so
     // the user sees `theme: dalton-bright (auto)` right after launch
     // without us having to add a second status row. Falls back to the
-    // normal help_text once the toast expires.
+    // normal help_text once the toast expires. Action-driven toasts
+    // (#135 sub-feature B — "exported: paper.bib (12 entries)") share
+    // the same slot and take priority over the startup toast since
+    // they're always more recent than launch.
     let toast_text;
-    let bar_text: &str = if let Some(toast) = app.startup_toast.as_deref() {
+    let bar_text: &str = if let Some(status) = app.status_toast.as_ref() {
+        toast_text = status.message.clone();
+        &toast_text
+    } else if let Some(toast) = app.startup_toast.as_deref() {
         toast_text = toast.to_string();
         &toast_text
     } else {
@@ -1130,6 +1341,7 @@ fn draw(frame: &mut ratatui::Frame, app: &mut App) {
     };
     status_bar::draw(frame, chunks[3], bar_text, app.offline);
     app.tick_startup_toast();
+    app.tick_status_toast();
 }
 
 /// Step the active annotation prompt by one keystroke. Mutates the
@@ -1202,4 +1414,171 @@ async fn probe_network() -> bool {
         .send()
         .await
         .is_ok_and(|r| r.status().is_success() || r.status().is_redirection())
+}
+
+#[cfg(test)]
+mod tests {
+    //! End-to-end-ish tests for the export keybind (#135 sub-feature B).
+    //!
+    //! These tests exercise the App-level keystroke dispatch path with
+    //! a real `DataStore` backed by a tempfile SQLite DB. We seed a
+    //! research question + a shortlisted paper, then drive `handle_key`
+    //! and inspect the overlay state + on-disk artifacts.
+
+    use super::*;
+    use scitadel_core::models::{Paper, PaperId, ResearchQuestion};
+    use scitadel_core::ports::{PaperRepository, QuestionRepository};
+    use std::path::PathBuf;
+
+    /// Build an `App` with a fresh on-disk SQLite DB and a single
+    /// shortlisted paper attached to one research question. Returns
+    /// `(app, question_id, papers_dir)`. `papers_dir` is rooted in a
+    /// `tempfile::TempDir` whose lifetime the caller must keep alive.
+    fn fixture(tmp: &tempfile::TempDir) -> (App, String, PathBuf) {
+        let db_path = tmp.path().join("scitadel.db");
+        let data = DataStore::open(&db_path).unwrap();
+
+        // Seed: a research question + one paper + shortlist row.
+        let q = ResearchQuestion::new("What is the role of attention?");
+        let qid = q.id.as_str().to_string();
+        let mut p = Paper::new("Attention Is All You Need");
+        p.id = PaperId::from("p-attn");
+        p.authors = vec!["Vaswani, A.".into()];
+        p.year = Some(2017);
+        // Use the underlying repos directly — DataStore's API is read-
+        // mostly so seeding goes through the lower-level handles.
+        let db = scitadel_db::sqlite::Database::open(&db_path).unwrap();
+        db.migrate().unwrap();
+        let (paper_repo, _, q_repo, _, _) = db.repositories();
+        q_repo.save_question(&q).unwrap();
+        paper_repo.save(&p).unwrap();
+        let shortlist = scitadel_db::sqlite::SqliteShortlistRepository::new(db);
+        shortlist.toggle(&qid, p.id.as_str(), "lars").unwrap();
+
+        let papers_dir = tmp.path().join("papers");
+        std::fs::create_dir_all(&papers_dir).unwrap();
+
+        let app = App::new(
+            data,
+            "demo@example.org".into(),
+            papers_dir.clone(),
+            false,
+            "lars".into(),
+        );
+        (app, qid, papers_dir)
+    }
+
+    /// Pressing `E` on the QuestionDashboard opens the path-prompt
+    /// overlay with the slugified default. The dashboard `selected`
+    /// cursor is left untouched.
+    #[tokio::test(flavor = "current_thread")]
+    async fn e_on_question_dashboard_opens_export_prompt() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (mut app, qid, _) = fixture(&tmp);
+        app.overlay = Some(Overlay::QuestionDashboard {
+            question_id: qid.clone(),
+            selected: 0,
+            export_prompt: None,
+        });
+
+        app.handle_key(KeyCode::Char('E'), KeyModifiers::NONE);
+
+        match app.overlay {
+            Some(Overlay::QuestionDashboard {
+                export_prompt: Some(ref p),
+                ..
+            }) => {
+                assert_eq!(p.path_buf, "what-is-the-role-of-attention.bib");
+            }
+            other => panic!("expected QuestionDashboard with prompt, got {other:?}"),
+        }
+    }
+
+    /// The `E` key must NOT be hijacked when no overlay is active —
+    /// that namespace belongs to the underlying tab. We assert that
+    /// pressing `E` on a plain tab leaves the overlay state alone (no
+    /// QuestionDashboard appears out of nowhere).
+    #[tokio::test(flavor = "current_thread")]
+    async fn e_on_searches_tab_is_not_hijacked() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (mut app, _, _) = fixture(&tmp);
+        // No overlay; default tab is Searches.
+        assert!(app.overlay.is_none());
+
+        app.handle_key(KeyCode::Char('E'), KeyModifiers::NONE);
+        assert!(
+            app.overlay.is_none(),
+            "E on Searches tab must not pop a dashboard overlay"
+        );
+    }
+
+    /// Drive the full happy path: open dashboard → press `E` → accept
+    /// the default path → assert the `.bib` + `.scitadel-bib.lock`
+    /// land on disk. The CWD is moved into the tempdir for the test
+    /// so the slug-derived default (`what-is-the-role-of-attention.bib`)
+    /// resolves to a sandboxed location.
+    #[tokio::test(flavor = "current_thread")]
+    async fn export_writes_bib_and_sidecar_on_default_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (mut app, qid, _) = fixture(&tmp);
+        let prev_cwd = std::env::current_dir().unwrap();
+        std::env::set_current_dir(tmp.path()).unwrap();
+
+        app.overlay = Some(Overlay::QuestionDashboard {
+            question_id: qid,
+            selected: 0,
+            export_prompt: None,
+        });
+        app.handle_key(KeyCode::Char('E'), KeyModifiers::NONE);
+        app.handle_key(KeyCode::Enter, KeyModifiers::NONE);
+
+        let bib = tmp.path().join("what-is-the-role-of-attention.bib");
+        let lock = tmp
+            .path()
+            .join("what-is-the-role-of-attention.bib.scitadel-bib.lock");
+
+        // Restore CWD before any assertion so a panic doesn't pollute
+        // the rest of the test runner.
+        std::env::set_current_dir(prev_cwd).unwrap();
+
+        assert!(bib.exists(), "{} missing", bib.display());
+        assert!(lock.exists(), "{} missing", lock.display());
+        let bib_bytes = std::fs::read_to_string(&bib).unwrap();
+        assert!(
+            bib_bytes.contains("Attention Is All You Need"),
+            "bib didn't contain the seeded title; got:\n{bib_bytes}"
+        );
+        // Status toast confirms count + filename.
+        let toast = app.status_toast.as_ref().expect("status toast set");
+        assert!(
+            toast.message.starts_with("exported: ") && toast.message.contains("(1 entries)"),
+            "got toast: {}",
+            toast.message
+        );
+    }
+
+    /// Esc inside the prompt clears it without writing anything.
+    #[tokio::test(flavor = "current_thread")]
+    async fn esc_in_export_prompt_cancels() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (mut app, qid, _) = fixture(&tmp);
+        app.overlay = Some(Overlay::QuestionDashboard {
+            question_id: qid,
+            selected: 0,
+            export_prompt: Some(BibExportPrompt::from_question(
+                "x",
+                scitadel_export::SnapshotFormat::BibTeX,
+            )),
+        });
+        app.handle_key(KeyCode::Esc, KeyModifiers::NONE);
+
+        match app.overlay {
+            Some(Overlay::QuestionDashboard {
+                export_prompt: None,
+                ..
+            }) => {}
+            other => panic!("expected dashboard with prompt cleared, got {other:?}"),
+        }
+        assert!(app.status_toast.is_none(), "no toast on cancel");
+    }
 }

--- a/crates/scitadel-tui/src/data.rs
+++ b/crates/scitadel-tui/src/data.rs
@@ -10,7 +10,10 @@ use scitadel_core::models::{
 use scitadel_core::ports::{
     AssessmentRepository, PaperRepository, QuestionRepository, SearchRepository,
 };
-use scitadel_db::sqlite::{Database, SqliteAnnotationRepository, SqlitePaperStateRepository};
+use scitadel_db::sqlite::{
+    Database, SqliteAnnotationRepository, SqlitePaperStateRepository, SqlitePaperTagRepository,
+    SqliteShortlistRepository,
+};
 
 /// Wrapper around the database that loads data for each TUI view.
 pub struct DataStore {
@@ -246,5 +249,38 @@ impl DataStore {
     /// query it (#122).
     pub fn publish_tui_state(&self, state: &scitadel_db::sqlite::TuiState) -> Result<()> {
         Ok(scitadel_db::sqlite::SqliteTuiStateRepository::new(self.db.clone()).set(state)?)
+    }
+
+    /// Load the inputs needed by `scitadel_export::write_snapshot` for a
+    /// question + reader (#135 sub-feature B). Returns the shortlist's
+    /// paper IDs in DB order, the hydrated `Paper` rows, and a
+    /// `paper_id → tags` map. Mirrors `load_shortlist` in `scitadel-cli`
+    /// so the CLI and TUI surfaces produce byte-identical snapshots.
+    pub fn load_snapshot_inputs(
+        &self,
+        question_id: &str,
+        reader: &str,
+    ) -> Result<(
+        Vec<String>,
+        Vec<scitadel_core::models::Paper>,
+        std::collections::HashMap<String, Vec<String>>,
+    )> {
+        let (paper_repo, _, _, _, _) = self.db.repositories();
+        let shortlist = SqliteShortlistRepository::new(self.db.clone());
+        let tag_repo = SqlitePaperTagRepository::new(self.db.clone());
+
+        let paper_ids = shortlist
+            .list(question_id, reader)
+            .context("failed to read shortlist")?;
+        let papers: Vec<_> = paper_ids
+            .iter()
+            .filter_map(|id| paper_repo.get(id).ok().flatten())
+            .collect();
+        let mut tags = std::collections::HashMap::new();
+        for id in &paper_ids {
+            let t = tag_repo.tags_for(id).unwrap_or_default();
+            tags.insert(id.clone(), t);
+        }
+        Ok((paper_ids, papers, tags))
     }
 }

--- a/crates/scitadel-tui/src/views/bib_export_prompt.rs
+++ b/crates/scitadel-tui/src/views/bib_export_prompt.rs
@@ -1,0 +1,180 @@
+//! Path prompt overlay for the Question Dashboard `E` keybind
+//! (#135 sub-feature B).
+//!
+//! Single-buffer text prompt pre-filled with a question-derived default
+//! filename. Mirrors the shape of [`crate::views::annotation_prompt`]
+//! but with one buffer instead of a multi-stage state machine — the
+//! whole UX is "accept the default, or edit the path, then Enter".
+
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
+
+use scitadel_export::{SnapshotFormat, slugify};
+
+/// State for the export-path prompt. The format is fixed at construction
+/// time (default = BibTeX); a future iteration may add a toggle inside
+/// the overlay, but that's out of scope for sub-feature B.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BibExportPrompt {
+    /// Mutable path buffer — pre-filled with the slugified question.
+    pub path_buf: String,
+    /// Output format. Routes the export to BibTeX vs CSL-JSON; baked in
+    /// at construction so the slugified default ends with the right
+    /// extension.
+    pub format: SnapshotFormat,
+}
+
+impl BibExportPrompt {
+    /// Build a prompt pre-filled with `<slug>.bib` (or `.json`) derived
+    /// from the question text. Empty / unhelpful text falls back to
+    /// `paper.bib` to mirror the CLI's `--output` default.
+    #[must_use]
+    pub fn from_question(question_text: &str, format: SnapshotFormat) -> Self {
+        let stem = slugify(question_text);
+        let path_buf = format!("{stem}{}", format.extension());
+        Self { path_buf, format }
+    }
+
+    /// Append a typed character to the path buffer.
+    pub fn push_char(&mut self, ch: char) {
+        self.path_buf.push(ch);
+    }
+
+    /// Pop the last character from the path buffer (Backspace).
+    pub fn backspace(&mut self) {
+        self.path_buf.pop();
+    }
+
+    /// Snapshot of the path the user has typed. Returns `None` when the
+    /// buffer is empty or whitespace-only — Enter on an empty buffer
+    /// should cancel rather than write a file at `.`.
+    #[must_use]
+    pub fn submit(&self) -> Option<String> {
+        let trimmed = self.path_buf.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    }
+}
+
+/// Centred modal renderer; matches the shape of
+/// [`crate::views::annotation_prompt::draw_overlay`].
+pub fn draw_overlay(frame: &mut Frame, area: Rect, prompt: &BibExportPrompt) {
+    let modal = centered_rect(area, 70, 30);
+    frame.render_widget(Clear, modal);
+
+    let title = match prompt.format {
+        SnapshotFormat::BibTeX => " Export Bibliography (BibTeX) ",
+        SnapshotFormat::CslJson => " Export Bibliography (CSL-JSON) ",
+    };
+    let block = Block::default()
+        .title(title)
+        .borders(Borders::ALL)
+        .style(Style::default().fg(crate::theme::theme().emphasis));
+    frame.render_widget(block, modal);
+
+    let body_area = Rect {
+        x: modal.x + 2,
+        y: modal.y + 1,
+        width: modal.width.saturating_sub(4),
+        height: modal.height.saturating_sub(2),
+    };
+
+    let lines: Vec<Line<'_>> = vec![
+        Line::from(Span::styled(
+            "Write the shortlist's bibliography to:",
+            Style::default().fg(crate::theme::theme().muted),
+        )),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("path: ", Style::default().fg(crate::theme::theme().muted)),
+            Span::styled(
+                prompt.path_buf.clone(),
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::styled("█", Style::default().fg(crate::theme::theme().emphasis)),
+        ]),
+        Line::from(""),
+        Line::from(Span::styled(
+            "A `.scitadel-bib.lock` sidecar is written next to it.",
+            Style::default().fg(crate::theme::theme().muted),
+        )),
+    ];
+
+    let para = Paragraph::new(lines).wrap(Wrap { trim: false });
+    frame.render_widget(para, body_area);
+}
+
+fn centered_rect(area: Rect, percent_x: u16, percent_y: u16) -> Rect {
+    let vertical = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage((100 - percent_y) / 2),
+            Constraint::Percentage(percent_y),
+            Constraint::Percentage((100 - percent_y) / 2),
+        ])
+        .split(area);
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(vertical[1])[1]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_path_uses_slug_and_bib_extension() {
+        let p = BibExportPrompt::from_question(
+            "What is the role of attention?",
+            SnapshotFormat::BibTeX,
+        );
+        assert_eq!(p.path_buf, "what-is-the-role-of-attention.bib");
+    }
+
+    #[test]
+    fn default_path_uses_json_extension_for_csl_json() {
+        let p = BibExportPrompt::from_question("Long Short-Term Memory", SnapshotFormat::CslJson);
+        assert_eq!(p.path_buf, "long-short-term-memory.json");
+    }
+
+    #[test]
+    fn empty_question_falls_back_to_untitled_with_extension() {
+        let p = BibExportPrompt::from_question("???", SnapshotFormat::BibTeX);
+        assert_eq!(p.path_buf, "untitled.bib");
+    }
+
+    #[test]
+    fn push_and_backspace_edit_the_buffer() {
+        let mut p = BibExportPrompt::from_question("x", SnapshotFormat::BibTeX);
+        p.path_buf.clear();
+        for c in "out/foo".chars() {
+            p.push_char(c);
+        }
+        assert_eq!(p.path_buf, "out/foo");
+        p.backspace();
+        assert_eq!(p.path_buf, "out/fo");
+    }
+
+    #[test]
+    fn submit_returns_trimmed_path_or_none_on_empty() {
+        let mut p = BibExportPrompt::from_question("x", SnapshotFormat::BibTeX);
+        assert_eq!(p.submit(), Some("x.bib".to_string()));
+        p.path_buf = "  out/file.bib  ".into();
+        assert_eq!(p.submit(), Some("out/file.bib".to_string()));
+        p.path_buf.clear();
+        assert!(p.submit().is_none());
+        p.path_buf = "   ".into();
+        assert!(p.submit().is_none());
+    }
+}

--- a/crates/scitadel-tui/src/views/mod.rs
+++ b/crates/scitadel-tui/src/views/mod.rs
@@ -1,4 +1,5 @@
 pub mod annotation_prompt;
+pub mod bib_export_prompt;
 pub mod dashboard;
 pub mod detail;
 pub mod papers;

--- a/tests/vhs/tui-export-keybind.tape
+++ b/tests/vhs/tui-export-keybind.tape
@@ -1,0 +1,79 @@
+# VHS tape: TUI export keybind — `E` on Question Dashboard (#135 sub-feature B).
+#
+# Seeds a question + a single shortlisted paper, opens the Question
+# Dashboard, presses `E`, accepts the slug-derived default path, and
+# screenshots the success toast.
+
+Output "tests/vhs/snapshots/tui-export-keybind/run.gif"
+
+Set Shell "bash"
+Set FontSize 14
+Set Width 1600
+Set Height 900
+Set Padding 10
+Set TypingSpeed 40ms
+
+Hide
+Type `export PATH="$PWD/target/release:$HOME/.cargo/bin:$PATH"`
+Enter
+Type `export PS1="$ "`
+Enter
+Type `export TMPDIR=$(mktemp -d)`
+Enter
+Type `export SCITADEL_DB=$TMPDIR/scitadel.db`
+Enter
+Type `cd $TMPDIR`
+Enter
+Type "scitadel init --yes --email demo@example.org --sources arxiv --db $SCITADEL_DB"
+Enter
+Sleep 1s
+
+# Seed: 1 question + 1 paper + 1 assessment + 1 shortlist row.
+Type `sqlite3 $SCITADEL_DB "INSERT INTO research_questions (id, text, description, created_at, updated_at) VALUES ('q-attn', 'What is the role of attention?', 'For a lit review section.', datetime('now'), datetime('now'));"`
+Enter
+Sleep 200ms
+Type `sqlite3 $SCITADEL_DB "INSERT INTO papers (id, title, authors, year, abstract, created_at, updated_at) VALUES ('p-a', 'Attention Is All You Need', '[\"Vaswani, A.\"]', 2017, 'The dominant sequence transduction models are based on complex RNNs or CNNs.', datetime('now'), datetime('now'));"`
+Enter
+Sleep 100ms
+Type `sqlite3 $SCITADEL_DB "INSERT INTO assessments (id, paper_id, question_id, score, reasoning, assessor, created_at) VALUES ('a-1', 'p-a', 'q-attn', 0.95, 'Landmark Transformer paper.', 'claude-opus-4-7', datetime('now'));"`
+Enter
+Sleep 100ms
+Type `sqlite3 $SCITADEL_DB "INSERT INTO shortlist (question_id, paper_id, reader, added_at, updated_at) VALUES ('q-attn', 'p-a', '$USER', datetime('now'), datetime('now'));"`
+Enter
+Sleep 300ms
+
+Type "clear"
+Enter
+Show
+
+Type "scitadel tui"
+Enter
+Sleep 2500ms
+
+# Tab → Tab → Tab to land on Questions.
+Tab
+Sleep 400ms
+Tab
+Sleep 400ms
+Tab
+Sleep 800ms
+Screenshot "tests/vhs/snapshots/tui-export-keybind/01-questions-tab.png"
+
+Enter
+Sleep 1200ms
+Screenshot "tests/vhs/snapshots/tui-export-keybind/02-dashboard-open.png"
+
+# Press `E` (uppercase) to open the export-path prompt.
+Type "E"
+Sleep 800ms
+Screenshot "tests/vhs/snapshots/tui-export-keybind/03-export-prompt.png"
+
+# Accept the slug-derived default (`what-is-the-role-of-attention.bib`).
+Enter
+Sleep 1000ms
+Screenshot "tests/vhs/snapshots/tui-export-keybind/04-export-success-toast.png"
+
+Type "q"
+Sleep 200ms
+Type "q"
+Sleep 200ms


### PR DESCRIPTION
Refs #135 (sub-feature B of 3)

## Summary
- Adds `E` keybind on `Overlay::QuestionDashboard` that opens a path-prompt overlay pre-filled with a slugified default (`what-is-the-role-of-attention.bib`); Enter writes the `.bib` + `.scitadel-bib.lock` sidecar through the same `scitadel_export::write_snapshot` helper the CLI now uses.
- Lifts the snapshot write path (`SnapshotFormat`, `write_snapshot`, `default_filename_for_format`, `sidecar_path_for`, `slugify`) into `scitadel-export` so CLI + TUI emit byte-identical artifacts; refactors `bib_snapshot` in `scitadel-cli` to call through the new helper.
- Status-bar toast on success (`exported: paper.bib (12 entries)` for ~30 frames) and error (`export failed: <err>` for ~60 frames). Reuses the existing per-frame counter pattern (#137) — no new toast subsystem.

## What landed
- `crates/scitadel-export/src/slug.rs` — kebab-slug helper with diacritic folding, length cap, fallback for all-non-alpha input.
- `crates/scitadel-export/src/snapshot.rs` — `write_snapshot(...)` pure write helper + `SnapshotFormat` enum.
- `crates/scitadel-tui/src/views/bib_export_prompt.rs` — single-buffer path prompt with slugified default and centred modal renderer.
- `crates/scitadel-tui/src/app.rs` — `E` handler, layered overlay key dispatch (prompt eats keys before list controls), `StatusToast` slot, status-bar wiring, end-to-end tests.
- `tests/vhs/tui-export-keybind.tape` — VHS tape (uncrendered locally; vhs/ttyd not present).

## Test plan
- [x] `cargo test --workspace --exclude scitadel-tui` — all green
- [x] `cargo test -p scitadel-tui` — 42 tests pass (4 new app::tests + 5 view tests + 9 slug/snapshot tests)
- [x] `just lint` — fmt + clippy clean
- [ ] VHS tape rendered in CI (vhs/ttyd not on this machine; tape committed for CI/PR-review render)
- [ ] Manual smoke: `scitadel tui` → Questions tab → Enter → `E` → Enter → confirm `paper.bib` + `paper.bib.scitadel-bib.lock` appear, toast shows entry count