### PR TITLE
feat(tui): runtime theme-toggle hotkey (theme iter 3)

### DIFF
--- a/crates/scitadel-tui/src/app.rs
+++ b/crates/scitadel-tui/src/app.rs
@@ -459,6 +459,35 @@ impl App {
         }
     }
 
+    /// True when the currently-active overlay is consuming character
+    /// keystrokes as text input — a per-paper annotation prompt or the
+    /// question-dashboard bib-export path prompt. Used by the global
+    /// theme-toggle hotkey (#175) to avoid hijacking `T` while the
+    /// user is typing into a field. Mirrors the same gating pattern
+    /// `handle_paper_detail_key` and `handle_question_dashboard_key`
+    /// already use to layer their own keybinds beneath an active prompt.
+    fn in_text_input_context(&self) -> bool {
+        match &self.overlay {
+            Some(Overlay::PaperDetail { prompt, .. }) => prompt.is_some(),
+            Some(Overlay::QuestionDashboard { export_prompt, .. }) => export_prompt.is_some(),
+            _ => false,
+        }
+    }
+
+    /// Swap to the next registered theme and flash the new name in the
+    /// status bar (#175). In-memory only — the user's `[ui] theme`
+    /// config isn't touched, so the next launch resolves the same way
+    /// it would have before the toggle. The `set_status_ok` slot reuses
+    /// the existing toast subsystem (#135-B / #137 P1) so this doesn't
+    /// add a second timing path.
+    fn cycle_theme(&mut self) {
+        let current = crate::theme::theme();
+        let next = crate::theme::Theme::cycle_next(current);
+        crate::theme::set(next);
+        let label = crate::theme::Theme::name(&next);
+        self.set_status_ok(format!("theme: {label}"));
+    }
+
     fn handle_key(&mut self, code: KeyCode, modifiers: KeyModifiers) {
         if code == KeyCode::Char('q') && self.overlay.is_none() {
             self.running = false;
@@ -466,6 +495,21 @@ impl App {
         }
         if code == KeyCode::Char('c') && modifiers.contains(KeyModifiers::CONTROL) {
             self.running = false;
+            return;
+        }
+
+        // #175 — runtime theme toggle. Uppercase `T` is unused
+        // elsewhere in the keymap (lowercase `t` is also free; we
+        // chose `T` so it parallels the other capital action keys
+        // — `D` (download), `R` (reader), `O` (open), `E` (export)).
+        // Gated to non-text-input contexts: text input is only active
+        // when an export prompt or annotation prompt is open inside
+        // an overlay (those layers consume `KeyCode::Char(_)`
+        // wholesale before reaching here, so a top-level dispatch is
+        // safe). If new top-level text inputs land later, gate them
+        // here explicitly.
+        if code == KeyCode::Char('T') && !self.in_text_input_context() {
+            self.cycle_theme();
             return;
         }
 
@@ -1316,10 +1360,10 @@ fn draw(frame: &mut ratatui::Frame, app: &mut App) {
             "Esc/q: back | j/k: navigate | Enter: open paper | c: toggle shortlist | E: export bib"
         }
         (None, Tab::Papers | Tab::Queue) => {
-            "Tab: switch tabs | j/k: navigate | Enter: open | s: (un)star | c: clear tasks | q: quit"
+            "Tab: switch tabs | j/k: navigate | Enter: open | s: (un)star | c: clear tasks | T: theme | q: quit"
         }
         (None, _) => {
-            "Tab/Shift-Tab: switch tabs | j/k: navigate | Enter: select | c: clear tasks | q: quit"
+            "Tab/Shift-Tab: switch tabs | j/k: navigate | Enter: select | c: clear tasks | T: theme | q: quit"
         }
     };
     // Startup toast (#137) hijacks the status bar for its lifetime so
@@ -1555,6 +1599,92 @@ mod tests {
             "got toast: {}",
             toast.message
         );
+    }
+
+    /// Pressing `T` outside a text-input context cycles the active
+    /// theme and flashes a status-bar toast naming the new palette
+    /// (#175). We snapshot the toast slot rather than the global
+    /// theme to keep the assertion independent of test ordering —
+    /// other tests may mutate `crate::theme::ACTIVE` in parallel.
+    #[tokio::test(flavor = "current_thread")]
+    async fn t_cycles_theme_outside_input_context() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (mut app, _, _) = fixture(&tmp);
+        // Reset the global theme to a known starting palette so the
+        // post-toggle name is deterministic regardless of which other
+        // test ran first.
+        crate::theme::set(crate::theme::Theme::DALTON_DARK);
+
+        app.handle_key(KeyCode::Char('T'), KeyModifiers::NONE);
+
+        let toast = app.status_toast.as_ref().expect("toast set after T");
+        assert_eq!(toast.message, "theme: dalton-bright");
+    }
+
+    /// `T` must NOT cycle the theme while the user is typing into a
+    /// prompt — the keystroke would otherwise be eaten before it reached
+    /// the export prompt's `push_char` handler. This guards the gating
+    /// added alongside the toggle (#175).
+    #[tokio::test(flavor = "current_thread")]
+    async fn t_in_export_prompt_does_not_cycle_theme() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (mut app, qid, _) = fixture(&tmp);
+        app.overlay = Some(Overlay::QuestionDashboard {
+            question_id: qid,
+            selected: 0,
+            export_prompt: Some(BibExportPrompt::from_question(
+                "x",
+                scitadel_export::SnapshotFormat::BibTeX,
+            )),
+        });
+
+        app.handle_key(KeyCode::Char('T'), KeyModifiers::NONE);
+
+        // The toast slot must NOT contain a "theme:" message. The
+        // prompt should also have absorbed the keystroke as a 'T'
+        // character (path edit), confirming it reached the prompt.
+        let toast_msg = app
+            .status_toast
+            .as_ref()
+            .map(|t| t.message.clone())
+            .unwrap_or_default();
+        assert!(
+            !toast_msg.starts_with("theme:"),
+            "theme toggle should not fire while a text-input prompt is open; got toast: {toast_msg}",
+        );
+        match &app.overlay {
+            Some(Overlay::QuestionDashboard {
+                export_prompt: Some(p),
+                ..
+            }) => assert!(
+                p.path_buf.contains('T'),
+                "T should have been pushed into prompt buffer, got {:?}",
+                p.path_buf,
+            ),
+            other => panic!("expected dashboard with prompt still open, got {other:?}"),
+        }
+    }
+
+    /// The toggle is session-only (#175) — it must not write back to
+    /// the on-disk config. Cycle the theme and assert the config file
+    /// the test fixture would have read is unchanged before/after.
+    /// Today the TUI doesn't write the config from anywhere, but this
+    /// test pins the contract so a future refactor can't quietly start
+    /// persisting toggle state.
+    #[tokio::test(flavor = "current_thread")]
+    async fn theme_toggle_does_not_persist_to_config() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg_path = tmp.path().join("config.toml");
+        let original = "[ui]\ntheme = \"dark\"\n";
+        std::fs::write(&cfg_path, original).unwrap();
+        let before = std::fs::read_to_string(&cfg_path).unwrap();
+
+        let (mut app, _, _) = fixture(&tmp);
+        crate::theme::set(crate::theme::Theme::DALTON_DARK);
+        app.handle_key(KeyCode::Char('T'), KeyModifiers::NONE);
+
+        let after = std::fs::read_to_string(&cfg_path).unwrap();
+        assert_eq!(before, after, "config.toml must not be rewritten by toggle");
     }
 
     /// Esc inside the prompt clears it without writing anything.

--- a/crates/scitadel-tui/src/theme/mod.rs
+++ b/crates/scitadel-tui/src/theme/mod.rs
@@ -20,17 +20,22 @@
 //!    b. OSC 11 query against the controlling tty (#176; 100–200ms timeout, skipped on non-tty)
 //!    c. fall back to dark
 //!
-//! Mid-session theme change is intentionally not supported — if the
-//! terminal flips light/dark at sunset, restart the TUI.
+//! ## Runtime toggle (#175)
+//!
+//! Once the session is up, the user can press `T` to cycle through the
+//! palettes registered in [`Theme::concrete`]. The toggle goes through
+//! [`set`] — purely in-memory, never written back to config. The next
+//! launch resolves the theme exactly as it would have without the
+//! toggle, so `auto` keeps detecting on every start.
 
 mod osc11;
 
-use std::sync::OnceLock;
+use std::sync::RwLock;
 
 use ratatui::style::Color;
 
 /// Semantic color roles used across all TUI views.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Theme {
     /// Borders, headers, status-bar mode labels, the active-tab marker.
     pub emphasis: Color,
@@ -137,6 +142,59 @@ impl Theme {
         ]
     }
 
+    /// Concrete palettes the runtime toggle (#175) cycles through, paired
+    /// with their canonical names. Order matches the `registry()` listing
+    /// so the cycle is deterministic and lines up with what
+    /// `--list-themes` shows. Aliases are intentionally excluded — a
+    /// cycle that hit `dark` then `dalton-dark` would visit the same
+    /// palette twice and look broken to users.
+    ///
+    /// New named palettes plug in here AND in [`Theme::registry`].
+    #[must_use]
+    pub fn concrete() -> &'static [(&'static str, Theme)] {
+        &[
+            ("dalton-dark", Theme::DALTON_DARK),
+            ("dalton-bright", Theme::DALTON_BRIGHT),
+        ]
+    }
+
+    /// Step to the next concrete theme in [`Theme::concrete`]. Wraps
+    /// from the last entry back to the first. If `current` doesn't match
+    /// any registered palette (defensive — shouldn't happen since the
+    /// only `Theme` values in flight come from constants we control),
+    /// returns the first registered palette so the caller is never stuck
+    /// on a dead value. Used by the runtime theme toggle (#175).
+    #[must_use]
+    pub fn cycle_next(current: Theme) -> Theme {
+        let entries = Self::concrete();
+        // `entries` is non-empty by construction; this guard makes the
+        // function total even if a future refactor empties the table —
+        // returning `current` is the closest thing to a no-op the
+        // caller can recover from.
+        if entries.is_empty() {
+            return current;
+        }
+        let idx = entries
+            .iter()
+            .position(|(_, t)| *t == current)
+            .map_or(0, |i| (i + 1) % entries.len());
+        entries[idx].1
+    }
+
+    /// Canonical name for a concrete theme — looked up in
+    /// [`Theme::concrete`]. Used by the runtime toggle (#175) to label
+    /// the status-bar toast (`theme: dalton-bright`). Falls back to the
+    /// first registered name if `theme` isn't in the table — matches
+    /// the defensive behaviour of [`Theme::cycle_next`].
+    #[must_use]
+    pub fn name(theme: &Theme) -> &'static str {
+        Self::concrete()
+            .iter()
+            .find(|(_, t)| t == theme)
+            .or_else(|| Self::concrete().first())
+            .map_or("", |(n, _)| *n)
+    }
+
     /// Pick a highlight colour for a string key (e.g. annotation
     /// root_id). djb2 hash modulo palette size so the mapping is
     /// stable across runs.
@@ -150,27 +208,42 @@ impl Theme {
     }
 }
 
-/// Process-wide active theme. Set once at startup via [`init`]; reads
-/// after that go through [`theme()`]. `OnceLock` makes it cheap (no
-/// lock contention on the hot draw path) and lets tests use the
-/// default without setup.
-static ACTIVE: OnceLock<Theme> = OnceLock::new();
+/// Process-wide active theme. Initialized at startup via [`init`] and
+/// can be swapped in-session by the runtime toggle (#175). `RwLock` over
+/// a `Theme` (Copy, ~24 fields) is cheap on the read-dominated draw path
+/// — readers grab a shared lock, copy the struct out by value, and
+/// release immediately. Writes happen only when the user presses the
+/// theme-toggle hotkey.
+static ACTIVE: RwLock<Theme> = RwLock::new(Theme::DALTON_DARK);
 
 /// Convenience accessor. `crate::theme::theme().emphasis` reads better
-/// at call sites than reaching into `ACTIVE` directly. Falls back to
-/// Dalton Dark if [`init`] was never called (e.g. unit tests rendering
-/// a widget in isolation).
+/// at call sites than reaching into `ACTIVE` directly. Returns by value
+/// (Theme is Copy) so callers don't hold the lock across draws. Falls
+/// back to Dalton Dark if the lock is poisoned (e.g. a panic during a
+/// previous `set`) — better to render with stale colours than crash.
 #[must_use]
-pub fn theme() -> &'static Theme {
-    ACTIVE.get().unwrap_or(&Theme::DALTON_DARK)
+pub fn theme() -> Theme {
+    ACTIVE.read().map_or(Theme::DALTON_DARK, |g| *g)
 }
 
-/// Set the process-wide theme. Must be called before the first frame
-/// is drawn; subsequent calls are no-ops (`OnceLock::set` returns Err).
-/// Pair with [`resolve`] to compute the right value from the layered
-/// preference sources.
+/// Set the process-wide theme. Called once at startup from the binary
+/// (paired with [`resolve`]) and again by the runtime toggle (#175) on
+/// every press of the theme-cycle hotkey. Lock poisoning is recovered
+/// via `into_inner` so a panicked sibling doesn't permanently freeze
+/// the palette.
 pub fn init(t: Theme) {
-    let _ = ACTIVE.set(t);
+    set(t);
+}
+
+/// In-session swap used by the #175 runtime toggle. Behaviourally
+/// identical to [`init`]; named separately so call sites read as
+/// "initial pick" vs "user toggled mid-session" — the underlying
+/// store is the same.
+pub fn set(t: Theme) {
+    let mut guard = ACTIVE
+        .write()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    *guard = t;
 }
 
 /// User's stated preference, in increasing precedence: config →
@@ -433,6 +506,95 @@ mod tests {
             "explicit cli should not be tagged auto: {label:?}"
         );
         assert!(label.contains("dalton-dark"));
+    }
+
+    /// Build a synthetic third theme so we can drive a 3-element cycle
+    /// without coupling the test to whatever palette ships next. The
+    /// concrete fields don't matter — only the identity (`emphasis`)
+    /// has to differ from the two registered palettes.
+    fn synthetic_theme() -> Theme {
+        let mut t = Theme::DALTON_DARK;
+        t.emphasis = Color::Rgb(0x01, 0x02, 0x03);
+        t
+    }
+
+    #[test]
+    fn cycle_next_two_themes_round_trips() {
+        // The shipped registry has exactly two concrete palettes today.
+        // Dark → Light → Dark documents the binary toggle that #175
+        // ships with.
+        let dark = Theme::DALTON_DARK;
+        let light = Theme::DALTON_BRIGHT;
+        let next = Theme::cycle_next(dark);
+        assert_eq!(next, light, "dark should cycle to bright");
+        let wrapped = Theme::cycle_next(next);
+        assert_eq!(wrapped, dark, "bright should wrap back to dark");
+    }
+
+    #[test]
+    fn cycle_next_single_theme_returns_itself() {
+        // Defensive: if a future build registered exactly one palette,
+        // cycle_next should be a no-op. We can't shrink the real
+        // registry from a test, so exercise the pure helper directly.
+        let only = Theme::DALTON_DARK;
+        let table: &[(&str, Theme)] = &[("only", only)];
+        let idx = table
+            .iter()
+            .position(|(_, t)| *t == only)
+            .map_or(0, |i| (i + 1) % table.len());
+        assert_eq!(table[idx].1, only);
+    }
+
+    #[test]
+    fn cycle_next_three_themes_full_cycle() {
+        // Mirror cycle_next's loop against an in-test 3-element table
+        // so we exercise the wrap arithmetic without waiting for a
+        // third palette to land in the registry.
+        let a = Theme::DALTON_DARK;
+        let b = Theme::DALTON_BRIGHT;
+        let c = synthetic_theme();
+        let table: &[(&str, Theme)] = &[("a", a), ("b", b), ("c", c)];
+        let cycle = |current: Theme| {
+            let idx = table
+                .iter()
+                .position(|(_, t)| *t == current)
+                .map_or(0, |i| (i + 1) % table.len());
+            table[idx].1
+        };
+        assert_eq!(cycle(a), b);
+        assert_eq!(cycle(b), c);
+        assert_eq!(cycle(c), a);
+    }
+
+    #[test]
+    fn cycle_next_unknown_current_returns_first() {
+        // Defensive: a Theme that isn't in the registry shouldn't
+        // panic or stick — it wraps to the first registered palette.
+        let unknown = synthetic_theme();
+        let next = Theme::cycle_next(unknown);
+        assert_eq!(next, Theme::concrete()[0].1);
+    }
+
+    #[test]
+    fn theme_name_round_trips_concrete_palettes() {
+        // The runtime toggle's status-bar toast uses Theme::name to
+        // build "theme: dalton-bright". Round-trip both palettes so a
+        // future palette rename can't silently break the toast.
+        assert_eq!(Theme::name(&Theme::DALTON_DARK), "dalton-dark");
+        assert_eq!(Theme::name(&Theme::DALTON_BRIGHT), "dalton-bright");
+    }
+
+    #[test]
+    fn set_swaps_active_theme() {
+        // Mid-session swap (#175) — `set` replaces what `theme()`
+        // returns. Tests run in parallel across the workspace; we
+        // restore the prior value to keep adjacent assertions stable.
+        let prev = theme();
+        set(Theme::DALTON_BRIGHT);
+        assert_eq!(theme().emphasis, Theme::DALTON_BRIGHT.emphasis);
+        set(Theme::DALTON_DARK);
+        assert_eq!(theme().emphasis, Theme::DALTON_DARK.emphasis);
+        set(prev);
     }
 
     #[test]

--- a/tests/vhs/theme-toggle.tape
+++ b/tests/vhs/theme-toggle.tape
@@ -1,0 +1,59 @@
+# VHS tape: runtime `T` toggle flips dark → light mid-session (#175).
+#
+# Launches with `--theme dark` (deterministic regardless of the CI
+# runner's COLORFGBG), captures the dark palette, presses uppercase T
+# to cycle, and captures the light palette + the `theme: dalton-bright`
+# status-bar toast that fires for ~30 frames after the toggle.
+
+Output "tests/vhs/snapshots/theme-toggle/run.gif"
+
+Set Shell "bash"
+Set FontSize 14
+Set Width 1400
+Set Height 800
+Set Padding 10
+Set TypingSpeed 40ms
+
+Hide
+Type `export PATH="$PWD/target/release:$HOME/.cargo/bin:$PATH"`
+Enter
+Type `export PS1="$ "`
+Enter
+Type `export SCITADEL_DB=$(mktemp -d)/scitadel.db`
+Enter
+Type "scitadel init --yes --email demo@example.org --sources arxiv --db $SCITADEL_DB"
+Enter
+Sleep 1s
+
+# Seed a paper so the table has at least one visible row — the toggle
+# is recognisable even on an empty screen via the status bar, but the
+# selected-row background is the strongest visual signal of a swap.
+Type `sqlite3 $SCITADEL_DB "INSERT INTO papers (id, title, authors, year, created_at, updated_at) VALUES ('p-1', 'Attention Is All You Need', '[\"Vaswani, A.\"]', 2017, datetime('now'), datetime('now'));"`
+Enter
+Sleep 200ms
+
+Type "clear"
+Enter
+Show
+
+# Start in the dark palette so the post-toggle frame is unambiguous.
+Type "scitadel tui --theme dark"
+Enter
+Sleep 2500ms
+Screenshot "tests/vhs/snapshots/theme-toggle/01-before-dark.png"
+
+# Cycle to dalton-bright. Status bar should flash `theme: dalton-bright`
+# for ~30 frames; the screenshot below is captured well within that
+# window so the toast is still on screen.
+Type "T"
+Sleep 500ms
+Screenshot "tests/vhs/snapshots/theme-toggle/02-after-light.png"
+
+# Cycle back to dalton-dark so the wrap-around is also exercised
+# visually, not just in the unit tests.
+Type "T"
+Sleep 500ms
+Screenshot "tests/vhs/snapshots/theme-toggle/03-wrap-back-dark.png"
+
+Type "q"
+Sleep 300ms


### PR DESCRIPTION
## Summary

- Press uppercase `T` from any non-text-input context to cycle the active palette (today: `dalton-dark` ↔ `dalton-bright`). Status bar flashes `theme: <name>` via the existing toast slot (#135-B / #137 P1).
- Toggle is purely in-memory — never writes back to `[ui] theme` in `config.toml`. Next launch resolves theme exactly as before through the CLI / env / config / auto-detect precedence chain (the #137 contract is preserved).
- `Theme::cycle_next` + `Theme::concrete()` table are deterministic and wrap last → first; defensive when `current` is unknown.

## Why `T`?

Both `t` and `T` were unused across the entire TUI keymap (verified by full-crate grep). Picked `T` so it parallels the other capital action keys — `D` (download), `R` (reader), `O` (open externally), `E` (export). Lowercase letters are reserved for navigation / list controls.

## Mechanical changes

- `theme::ACTIVE` moved from `OnceLock<Theme>` to `RwLock<Theme>`; `theme()` now returns `Theme` by value (Copy, ~24 fields), so view callsites don't hold the lock across the hot draw path.
- New `theme::set(t)` is the in-session swap.
- `App::cycle_theme()` + `App::in_text_input_context()` — the latter mirrors the prompt-gating pattern already used in `handle_paper_detail_key` / `handle_question_dashboard_key`.

## Test plan

- [x] `cargo test -p scitadel-tui` — 51/51 passing (4 new `cycle_next` cases + `theme_name_round_trips_concrete_palettes` + `set_swaps_active_theme` + 3 new `App` keybind tests).
- [x] `cargo test --workspace --exclude scitadel-tui` — all green.
- [x] `just lint` — fmt + clippy clean (`-D warnings`).
- [x] `tests/vhs/theme-toggle.tape` ships dark → light → wrap-back-to-dark and the post-toggle status-bar toast.
- [ ] Manual: launch `scitadel tui --theme dark`, press `T`, confirm light palette + toast; press `T` again, confirm wrap to dark.
- [ ] Manual: open the bib-export prompt (Q-tab → Enter → `E`), press `T`, confirm theme is unchanged and `T` lands in the path buffer.

Closes #175