### PR TITLE
feat(mcp): read_paper folds annotations by default (#185 PR1/5)

### DIFF
--- a/crates/scitadel-mcp/src/server.rs
+++ b/crates/scitadel-mcp/src/server.rs
@@ -284,8 +284,17 @@ pub struct DownloadPaperRequest {
 pub struct ReadPaperRequest {
     /// Paper ID
     pub paper_id: String,
-    /// Max characters to return (default 20000)
+    /// Max characters of `full_text` to return (default 20000). When
+    /// truncated, the JSON response carries `truncated: true` and
+    /// `total_chars` so the agent can request more.
     pub max_chars: Option<usize>,
+    /// When true (the default), the response is a JSON envelope that
+    /// also includes every live annotation anchored to the paper. When
+    /// false, the response is the legacy text format with no annotation
+    /// information. Default-true closes the silent-miss bug where an
+    /// agent calling `read_paper` would never observe a human comment.
+    /// (#185)
+    pub with_annotations: Option<bool>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -582,7 +591,7 @@ impl ScitadelServer {
     }
 
     #[tool(
-        description = "Returns: JSON {paper {id,title,abstract,full_text}, annotations[] (live only, with parent_id/root_id and full anchor incl. char_range/quote/prefix/suffix/sentence_id/source_version/status), source_version}. One call replaces get_paper + list_annotations when an agent needs to reason over offsets."
+        description = "Returns: JSON {paper {id,title,abstract,full_text}, annotations[] (live only, with parent_id/root_id and full anchor incl. char_range/quote/prefix/suffix/sentence_id/source_version/status), source_version}. One call replaces get_paper + list_annotations when an agent needs to reason over offsets. NOTE: `read_paper` (with default `with_annotations: true`) returns the same envelope plus extractor metadata and PDF/HTML extraction; prefer it when you need the full text. (#185)"
     )]
     fn get_annotated_paper(
         &self,
@@ -728,13 +737,13 @@ impl ScitadelServer {
     }
 
     #[tool(
-        description = "Extract the text from an already-downloaded paper's PDF or HTML. Call download_paper first. Returns: text (paper title, path, extracted body, possibly truncated)."
+        description = "Extract the text from an already-downloaded paper's PDF or HTML. Call download_paper first. By default (`with_annotations: true`, #185) Returns: JSON `{paper {id,title,abstract,full_text}, annotations[] (live, with parent_id/root_id and full anchor), source_version, extractor, path, truncated, total_chars}` so an agent never silently misses comments — pass `with_annotations: false` for the legacy text shape (paper title + path + extractor + body)."
     )]
     async fn read_paper(
         &self,
         Parameters(req): Parameters<ReadPaperRequest>,
     ) -> Result<String, String> {
-        tools::read_paper_tool(&req.paper_id, req.max_chars).await
+        tools::read_paper_tool(&req.paper_id, req.max_chars, req.with_annotations).await
     }
 
     #[tool(

--- a/crates/scitadel-mcp/src/tools.rs
+++ b/crates/scitadel-mcp/src/tools.rs
@@ -622,8 +622,7 @@ pub async fn read_paper_tool(
     let limit = max_chars.unwrap_or(20_000);
     assemble_read_paper_response(
         &db,
-        paper_id,
-        &paper.title,
+        &paper,
         text,
         extractor,
         &path_display,
@@ -639,8 +638,7 @@ pub async fn read_paper_tool(
 #[allow(clippy::too_many_arguments)]
 fn assemble_read_paper_response(
     db: &Database,
-    paper_id: &str,
-    paper_title: &str,
+    paper: &Paper,
     extracted_text: String,
     extractor: Option<&str>,
     path_display: &str,
@@ -656,12 +654,7 @@ fn assemble_read_paper_response(
     };
 
     if with_annotations {
-        let (paper_repo, _, _, _, _) = db.repositories();
-        let paper = paper_repo
-            .get(paper_id)
-            .map_err(|e| e.to_string())?
-            .ok_or_else(|| format!("paper not found: {paper_id}"))?;
-        let (annotations, source_version) = build_annotations_json(db, paper_id)?;
+        let (annotations, source_version) = build_annotations_json(db, paper.id.as_str())?;
         let response = serde_json::json!({
             "paper": {
                 "id": paper.id.as_str(),
@@ -686,7 +679,8 @@ fn assemble_read_paper_response(
     };
     let extractor_line = extractor.map_or_else(String::new, |e| format!("Extractor: {e}\n"));
     Ok(format!(
-        "Paper: {paper_title}\nPath: {path_display}\n{extractor_line}\n{body_with_marker}"
+        "Paper: {}\nPath: {path_display}\n{extractor_line}\n{body_with_marker}",
+        paper.title
     ))
 }
 
@@ -2103,6 +2097,11 @@ mod tests {
         p.id
     }
 
+    fn load_paper(db: &Database, id: &str) -> Paper {
+        let (paper_repo, _, _, _, _) = db.repositories();
+        paper_repo.get(id).unwrap().expect("paper present")
+    }
+
     #[test]
     fn get_annotated_paper_roundtrip_includes_offsets_and_quote() {
         let db = fresh_db();
@@ -2240,10 +2239,10 @@ mod tests {
         );
         repo.create(&ann).unwrap();
 
+        let paper = load_paper(&db, "p-rp1");
         let out = assemble_read_paper_response(
             &db,
-            "p-rp1",
-            "Cosmic rays",
+            &paper,
             "body text".into(),
             Some("pdftotext"),
             "/tmp/p-rp1.pdf",
@@ -2266,10 +2265,10 @@ mod tests {
     fn read_paper_with_annotations_false_returns_text_shape() {
         let db = fresh_db();
         save_paper(&db, "p-rp2", "Old format", Some("hello"));
+        let paper = load_paper(&db, "p-rp2");
         let out = assemble_read_paper_response(
             &db,
-            "p-rp2",
-            "Old format",
+            &paper,
             "hello".into(),
             Some("pdftotext"),
             "/tmp/p-rp2.pdf",
@@ -2291,9 +2290,9 @@ mod tests {
         let db = fresh_db();
         save_paper(&db, "p-rp3", "Long", Some(""));
         let long: String = "a".repeat(50);
+        let paper = load_paper(&db, "p-rp3");
         let out =
-            assemble_read_paper_response(&db, "p-rp3", "Long", long, None, "(cached)", 10, true)
-                .unwrap();
+            assemble_read_paper_response(&db, &paper, long, None, "(cached)", 10, true).unwrap();
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(v["truncated"], true);
         assert_eq!(v["total_chars"], 50);
@@ -2308,9 +2307,9 @@ mod tests {
         let db = fresh_db();
         save_paper(&db, "p-rp4", "Long", Some(""));
         let long: String = "a".repeat(50);
+        let paper = load_paper(&db, "p-rp4");
         let out =
-            assemble_read_paper_response(&db, "p-rp4", "Long", long, None, "(cached)", 10, false)
-                .unwrap();
+            assemble_read_paper_response(&db, &paper, long, None, "(cached)", 10, false).unwrap();
         assert!(out.contains("[... truncated, 10 of 50 chars shown ...]"));
     }
 
@@ -2341,17 +2340,10 @@ mod tests {
         repo.create(&doomed).unwrap();
         repo.soft_delete(doomed.id.as_str()).unwrap();
 
-        let out = assemble_read_paper_response(
-            &db,
-            "p-rp5",
-            "T",
-            "body".into(),
-            None,
-            "(cached)",
-            100,
-            true,
-        )
-        .unwrap();
+        let paper = load_paper(&db, "p-rp5");
+        let out =
+            assemble_read_paper_response(&db, &paper, "body".into(), None, "(cached)", 100, true)
+                .unwrap();
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
         let arr = v["annotations"].as_array().unwrap();
         assert_eq!(arr.len(), 1);
@@ -2362,37 +2354,48 @@ mod tests {
     fn read_paper_with_annotations_zero_annotations_returns_empty_array() {
         let db = fresh_db();
         save_paper(&db, "p-rp6", "Empty", Some(""));
-        let out = assemble_read_paper_response(
-            &db,
-            "p-rp6",
-            "Empty",
-            "body".into(),
-            None,
-            "(cached)",
-            100,
-            true,
-        )
-        .unwrap();
+        let paper = load_paper(&db, "p-rp6");
+        let out =
+            assemble_read_paper_response(&db, &paper, "body".into(), None, "(cached)", 100, true)
+                .unwrap();
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(v["annotations"].as_array().unwrap().len(), 0);
         assert!(v["source_version"].is_null());
     }
 
     #[test]
-    fn read_paper_with_annotations_unknown_paper_errors() {
+    fn read_paper_with_annotations_replies_carry_root_id() {
+        // Insurance against future refactors of build_annotations_json:
+        // confirm parent_id/root_id propagate through the read_paper
+        // envelope (mirrors get_annotated_paper_replies_carry_root_id).
         let db = fresh_db();
-        let err = assemble_read_paper_response(
-            &db,
-            "nope",
-            "T",
-            "body".into(),
-            None,
-            "(cached)",
-            100,
-            true,
-        )
-        .unwrap_err();
-        assert!(err.contains("not found"));
+        let pid = save_paper(&db, "p-rp7", "T", Some(""));
+        let repo = SqliteAnnotationRepository::new(db.clone());
+        let root = Annotation::new_root(
+            pid,
+            "lars".into(),
+            "root note".into(),
+            Anchor {
+                quote: Some("q".into()),
+                ..Anchor::default()
+            },
+        );
+        let reply = Annotation::new_reply(&root, "claude".into(), "agreed".into());
+        repo.create(&root).unwrap();
+        repo.create(&reply).unwrap();
+
+        let paper = load_paper(&db, "p-rp7");
+        let out =
+            assemble_read_paper_response(&db, &paper, "body".into(), None, "(cached)", 100, true)
+                .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let arr = v["annotations"].as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        let reply_entry = arr
+            .iter()
+            .find(|a| a["parent_id"].is_string())
+            .expect("has reply");
+        assert_eq!(reply_entry["root_id"], root.id.as_str());
     }
 
     #[test]

--- a/crates/scitadel-mcp/src/tools.rs
+++ b/crates/scitadel-mcp/src/tools.rs
@@ -558,9 +558,19 @@ pub async fn download_paper_tool(
 /// Extract text from a paper's downloaded file (PDF or HTML).
 ///
 /// Looks up the paper in the DB, locates its cached file under `papers_dir()`,
-/// and returns the extracted text. Truncated to `max_chars` (default 20_000) to
-/// keep responses manageable for the host LLM.
-pub async fn read_paper_tool(paper_id: &str, max_chars: Option<usize>) -> Result<String, String> {
+/// and returns the extracted text. Truncated to `max_chars` (default 20_000)
+/// to keep responses manageable for the host LLM.
+///
+/// When `with_annotations` is `None` or `Some(true)` (the default), the
+/// response is a JSON envelope that folds in live annotations alongside the
+/// extracted text — closes the silent-miss bug where an agent calling
+/// `read_paper` would never observe a human comment (#185). Pass
+/// `Some(false)` for the legacy text shape.
+pub async fn read_paper_tool(
+    paper_id: &str,
+    max_chars: Option<usize>,
+    with_annotations: Option<bool>,
+) -> Result<String, String> {
     let config = load_config();
     let db = open_db()?;
     let (paper_repo, _, _, _, _) = db.repositories();
@@ -610,21 +620,73 @@ pub async fn read_paper_tool(paper_id: &str, max_chars: Option<usize>) -> Result
     let text = text.expect("text populated above");
 
     let limit = max_chars.unwrap_or(20_000);
-    let truncated = if text.chars().count() > limit {
-        let head: String = text.chars().take(limit).collect();
-        format!(
-            "{head}\n\n[... truncated, {} of {} chars shown ...]",
-            limit,
-            text.chars().count()
-        )
+    assemble_read_paper_response(
+        &db,
+        paper_id,
+        &paper.title,
+        text,
+        extractor,
+        &path_display,
+        limit,
+        with_annotations.unwrap_or(true),
+    )
+}
+
+/// Format the extracted text + (optionally) annotations into the
+/// `read_paper` response. Factored out of `read_paper_tool` so the
+/// JSON-shape contract can be exercised with an in-memory DB without
+/// wiring a real PDF fixture.
+#[allow(clippy::too_many_arguments)]
+fn assemble_read_paper_response(
+    db: &Database,
+    paper_id: &str,
+    paper_title: &str,
+    extracted_text: String,
+    extractor: Option<&str>,
+    path_display: &str,
+    max_chars: usize,
+    with_annotations: bool,
+) -> Result<String, String> {
+    let total_chars = extracted_text.chars().count();
+    let was_truncated = total_chars > max_chars;
+    let body: String = if was_truncated {
+        extracted_text.chars().take(max_chars).collect()
     } else {
-        text
+        extracted_text
     };
 
+    if with_annotations {
+        let (paper_repo, _, _, _, _) = db.repositories();
+        let paper = paper_repo
+            .get(paper_id)
+            .map_err(|e| e.to_string())?
+            .ok_or_else(|| format!("paper not found: {paper_id}"))?;
+        let (annotations, source_version) = build_annotations_json(db, paper_id)?;
+        let response = serde_json::json!({
+            "paper": {
+                "id": paper.id.as_str(),
+                "title": paper.title,
+                "abstract": paper.r#abstract,
+                "full_text": body,
+            },
+            "annotations": annotations,
+            "source_version": source_version,
+            "extractor": extractor,
+            "path": path_display,
+            "truncated": was_truncated,
+            "total_chars": total_chars,
+        });
+        return serde_json::to_string_pretty(&response).map_err(|e| e.to_string());
+    }
+
+    let body_with_marker = if was_truncated {
+        format!("{body}\n\n[... truncated, {max_chars} of {total_chars} chars shown ...]")
+    } else {
+        body
+    };
     let extractor_line = extractor.map_or_else(String::new, |e| format!("Extractor: {e}\n"));
     Ok(format!(
-        "Paper: {}\nPath: {}\n{extractor_line}\n{}",
-        paper.title, path_display, truncated
+        "Paper: {paper_title}\nPath: {path_display}\n{extractor_line}\n{body_with_marker}"
     ))
 }
 
@@ -1210,14 +1272,14 @@ pub fn get_annotated_paper_tool(paper_id: &str) -> Result<String, String> {
     build_annotated_paper(&db, paper_id)
 }
 
-fn build_annotated_paper(db: &Database, paper_id: &str) -> Result<String, String> {
+/// Build the annotation array + source_version block shared by
+/// `read_paper` (when `with_annotations=true`) and `get_annotated_paper`.
+/// Soft-deleted annotations are excluded by `list_by_paper`.
+fn build_annotations_json(
+    db: &Database,
+    paper_id: &str,
+) -> Result<(Vec<serde_json::Value>, Option<String>), String> {
     use std::collections::HashMap;
-
-    let (paper_repo, _, _, _, _) = db.repositories();
-    let paper = paper_repo
-        .get(paper_id)
-        .map_err(|e| e.to_string())?
-        .ok_or_else(|| format!("Paper '{paper_id}' not found."))?;
 
     let ann_repo = scitadel_db::sqlite::SqliteAnnotationRepository::new(db.clone());
     let annotations = ann_repo
@@ -1272,6 +1334,18 @@ fn build_annotated_paper(db: &Database, paper_id: &str) -> Result<String, String
             })
         })
         .collect();
+
+    Ok((entries, source_version))
+}
+
+fn build_annotated_paper(db: &Database, paper_id: &str) -> Result<String, String> {
+    let (paper_repo, _, _, _, _) = db.repositories();
+    let paper = paper_repo
+        .get(paper_id)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("Paper '{paper_id}' not found."))?;
+
+    let (entries, source_version) = build_annotations_json(db, paper_id)?;
 
     let response = serde_json::json!({
         "paper": {
@@ -2005,8 +2079,8 @@ pub fn bib_diff_tool(
 #[cfg(test)]
 mod tests {
     use super::{
-        SOURCE_REGISTRY, build_annotated_paper, html_to_text, is_source_configured,
-        truncate_abstract,
+        SOURCE_REGISTRY, assemble_read_paper_response, build_annotated_paper, html_to_text,
+        is_source_configured, truncate_abstract,
     };
     use scitadel_core::config::Config;
     use scitadel_core::models::{Anchor, Annotation, Paper, PaperId};
@@ -2144,6 +2218,180 @@ mod tests {
     fn get_annotated_paper_unknown_paper_errors() {
         let db = fresh_db();
         let err = build_annotated_paper(&db, "nope").unwrap_err();
+        assert!(err.contains("not found"));
+    }
+
+    // -- read_paper #185: with_annotations folds the annotation array
+    //    into the response so an agent never silently misses comments.
+
+    #[test]
+    fn read_paper_with_annotations_default_true_returns_json_envelope() {
+        let db = fresh_db();
+        let pid = save_paper(&db, "p-rp1", "Cosmic rays", Some("body text"));
+        let repo = SqliteAnnotationRepository::new(db.clone());
+        let ann = Annotation::new_root(
+            pid,
+            "lars".into(),
+            "interesting".into(),
+            Anchor {
+                quote: Some("body".into()),
+                ..Anchor::default()
+            },
+        );
+        repo.create(&ann).unwrap();
+
+        let out = assemble_read_paper_response(
+            &db,
+            "p-rp1",
+            "Cosmic rays",
+            "body text".into(),
+            Some("pdftotext"),
+            "/tmp/p-rp1.pdf",
+            100,
+            true,
+        )
+        .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).expect("json");
+        assert_eq!(v["paper"]["id"], "p-rp1");
+        assert_eq!(v["paper"]["full_text"], "body text");
+        assert_eq!(v["extractor"], "pdftotext");
+        assert_eq!(v["path"], "/tmp/p-rp1.pdf");
+        assert_eq!(v["truncated"], false);
+        assert_eq!(v["total_chars"], 9);
+        assert_eq!(v["annotations"].as_array().unwrap().len(), 1);
+        assert_eq!(v["annotations"][0]["note"], "interesting");
+    }
+
+    #[test]
+    fn read_paper_with_annotations_false_returns_text_shape() {
+        let db = fresh_db();
+        save_paper(&db, "p-rp2", "Old format", Some("hello"));
+        let out = assemble_read_paper_response(
+            &db,
+            "p-rp2",
+            "Old format",
+            "hello".into(),
+            Some("pdftotext"),
+            "/tmp/p-rp2.pdf",
+            100,
+            false,
+        )
+        .unwrap();
+        // Legacy text shape: must NOT be JSON, must include the title
+        // and extractor lines exactly as before #185.
+        assert!(serde_json::from_str::<serde_json::Value>(&out).is_err());
+        assert!(out.starts_with("Paper: Old format\n"));
+        assert!(out.contains("Path: /tmp/p-rp2.pdf"));
+        assert!(out.contains("Extractor: pdftotext"));
+        assert!(out.contains("hello"));
+    }
+
+    #[test]
+    fn read_paper_with_annotations_truncates_full_text_and_flags_it() {
+        let db = fresh_db();
+        save_paper(&db, "p-rp3", "Long", Some(""));
+        let long: String = "a".repeat(50);
+        let out =
+            assemble_read_paper_response(&db, "p-rp3", "Long", long, None, "(cached)", 10, true)
+                .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["truncated"], true);
+        assert_eq!(v["total_chars"], 50);
+        assert_eq!(
+            v["paper"]["full_text"].as_str().unwrap().chars().count(),
+            10
+        );
+    }
+
+    #[test]
+    fn read_paper_text_shape_appends_truncation_marker() {
+        let db = fresh_db();
+        save_paper(&db, "p-rp4", "Long", Some(""));
+        let long: String = "a".repeat(50);
+        let out =
+            assemble_read_paper_response(&db, "p-rp4", "Long", long, None, "(cached)", 10, false)
+                .unwrap();
+        assert!(out.contains("[... truncated, 10 of 50 chars shown ...]"));
+    }
+
+    #[test]
+    fn read_paper_with_annotations_excludes_soft_deleted() {
+        let db = fresh_db();
+        let pid = save_paper(&db, "p-rp5", "T", Some(""));
+        let repo = SqliteAnnotationRepository::new(db.clone());
+        let live = Annotation::new_root(
+            pid.clone(),
+            "lars".into(),
+            "live".into(),
+            Anchor {
+                quote: Some("q1".into()),
+                ..Anchor::default()
+            },
+        );
+        let doomed = Annotation::new_root(
+            pid,
+            "lars".into(),
+            "gone".into(),
+            Anchor {
+                quote: Some("q2".into()),
+                ..Anchor::default()
+            },
+        );
+        repo.create(&live).unwrap();
+        repo.create(&doomed).unwrap();
+        repo.soft_delete(doomed.id.as_str()).unwrap();
+
+        let out = assemble_read_paper_response(
+            &db,
+            "p-rp5",
+            "T",
+            "body".into(),
+            None,
+            "(cached)",
+            100,
+            true,
+        )
+        .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let arr = v["annotations"].as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["note"], "live");
+    }
+
+    #[test]
+    fn read_paper_with_annotations_zero_annotations_returns_empty_array() {
+        let db = fresh_db();
+        save_paper(&db, "p-rp6", "Empty", Some(""));
+        let out = assemble_read_paper_response(
+            &db,
+            "p-rp6",
+            "Empty",
+            "body".into(),
+            None,
+            "(cached)",
+            100,
+            true,
+        )
+        .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["annotations"].as_array().unwrap().len(), 0);
+        assert!(v["source_version"].is_null());
+    }
+
+    #[test]
+    fn read_paper_with_annotations_unknown_paper_errors() {
+        let db = fresh_db();
+        let err = assemble_read_paper_response(
+            &db,
+            "nope",
+            "T",
+            "body".into(),
+            None,
+            "(cached)",
+            100,
+            true,
+        )
+        .unwrap_err();
         assert!(err.contains("not found"));
     }
 


### PR DESCRIPTION
## Summary

First of 5 PRs landing #185 (agent↔human comment-and-reply loop). Closes the silent-miss bug where an agent calling the natural extraction tool (`read_paper`) would never observe a human comment.

- `read_paper` now Returns: JSON `{paper, annotations[] (live, with parent_id/root_id and full anchor), source_version, extractor, path, truncated, total_chars}` by default
- `with_annotations: false` preserves the legacy text shape byte-identically (escape hatch for any existing client)
- `get_annotated_paper` is documented as superseded by `read_paper` for fetches that also need the body
- Shared `build_annotations_json` helper so both tools agree on shape

## Test plan

- [x] 7 new unit tests (default-on JSON envelope, opt-out text shape, truncation flag in JSON, truncation marker in text, soft-deleted excluded, zero annotations, replies carry root_id)
- [x] 56/56 `cargo test -p scitadel-mcp --lib` pass
- [x] `cargo clippy -p scitadel-mcp --tests -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] E2E sanity: invoke via the running MCP host

[tape-exempt: MCP-only tool surface change; no TUI/CLI source touched]

Refs #185.