### PR TITLE
ci(vhs): shard tape suite per-feature (#187)

### DIFF
--- a/.github/workflows/vhs.yml
+++ b/.github/workflows/vhs.yml
@@ -20,23 +20,33 @@ jobs:
   tapes:
     name: Run tapes (${{ matrix.shard.name }})
     runs-on: ubuntu-latest
-    timeout-minutes: 6
+    # Per-shard budget. tui-reader gets 10m because its 4 tapes have
+    # historically been the flakiest (the distinctness retry loop can
+    # consume up to 3 extra renders per tape); the rest stay at 6m
+    # since they've never come close.
+    timeout-minutes: ${{ matrix.shard.timeout-minutes }}
     strategy:
       fail-fast: false
       matrix:
         shard:
           - name: cli
             tapes: "cli-bib-import.tape cli-bib-rekey.tape cli-question-workflow.tape cli-search.tape"
+            timeout-minutes: 6
           - name: tui-launch
             tapes: "tui-launch.tape init-wizard.tape"
+            timeout-minutes: 6
           - name: tui-papers
             tapes: "papers-download-state.tape queue-tab.tape reading-queue-star.tape question-dashboard.tape"
+            timeout-minutes: 6
           - name: tui-reader
             tapes: "tui-annotation-write.tape tui-annotations-reader.tape annotations-in-detail.tape tui-export-keybind.tape"
+            timeout-minutes: 10
           - name: theme
             tapes: "theme-dark.tape theme-light.tape theme-toggle.tape"
+            timeout-minutes: 6
           - name: connectivity
             tapes: "offline-indicator.tape open-externally.tape"
+            timeout-minutes: 6
     steps:
       - uses: actions/checkout@v4
 
@@ -192,19 +202,19 @@ jobs:
           )
           on_disk=$(find tests/vhs -maxdepth 1 -name '*.tape' -printf '%f\n' 2>/dev/null | sort)
 
-          missing=$(comm -23 <(echo "$on_disk") <(echo "$declared") || true)
-          extra=$(comm -13 <(echo "$on_disk") <(echo "$declared") || true)
+          unsharded=$(comm -23 <(echo "$on_disk") <(echo "$declared") || true)
+          stale=$(comm -13 <(echo "$on_disk") <(echo "$declared") || true)
           dupes=$(echo "$declared" | uniq -d || true)
 
           fail=0
-          if [ -n "$missing" ]; then
+          if [ -n "$unsharded" ]; then
             echo "::error::tape(s) on disk but not assigned to any shard in vhs.yml:"
-            echo "$missing" | sed 's/^/  /'
+            echo "$unsharded" | sed 's/^/  /'
             fail=1
           fi
-          if [ -n "$extra" ]; then
+          if [ -n "$stale" ]; then
             echo "::error::tape(s) declared in a shard but missing on disk:"
-            echo "$extra" | sed 's/^/  /'
+            echo "$stale" | sed 's/^/  /'
             fail=1
           fi
           if [ -n "$dupes" ]; then
@@ -218,23 +228,34 @@ jobs:
           echo "All $(echo "$on_disk" | wc -l | tr -d ' ') tape(s) covered by exactly one shard."
 
   # Roll-up gate so branch protection can require a single check name
-  # (`Tapes`) instead of every shard individually. Fails if any shard
-  # failed; passes only when all shards pass or the matrix is otherwise
-  # successful.
+  # (`Tapes`) instead of every shard + the coverage gate individually.
+  # Fails if any shard failed OR a tape on disk isn't claimed by a
+  # shard. Without `shard-coverage` in `needs`, a freshly added tape
+  # would pass `Tapes` (the existing 19 shards stay green) and only
+  # fail `Tape shard coverage` — which a single-check protection rule
+  # wouldn't see.
   tapes-rollup:
     name: Tapes
     runs-on: ubuntu-latest
-    needs: tapes
+    needs: [tapes, shard-coverage]
     if: always()
     steps:
-      - name: Aggregate shard results
+      - name: Aggregate shard + coverage results
         run: |
-          result="${{ needs.tapes.result }}"
-          echo "tapes matrix result: $result"
-          case "$result" in
-            success) echo "all shards green"; exit 0 ;;
-            *) echo "::error::one or more tape shards failed: $result"; exit 1 ;;
+          tapes="${{ needs.tapes.result }}"
+          coverage="${{ needs.shard-coverage.result }}"
+          echo "tapes matrix result: $tapes"
+          echo "shard-coverage result: $coverage"
+          fail=0
+          case "$tapes" in
+            success) ;;
+            *) echo "::error::one or more tape shards failed: $tapes"; fail=1 ;;
           esac
+          case "$coverage" in
+            success) ;;
+            *) echo "::error::tape shard coverage gate failed: $coverage"; fail=1 ;;
+          esac
+          exit $fail
 
   coverage:
     name: Tape coverage

--- a/.github/workflows/vhs.yml
+++ b/.github/workflows/vhs.yml
@@ -11,10 +11,32 @@ env:
   VHS_VERSION: "0.11.0"
 
 jobs:
+  # Tape rendering is sharded by feature surface so a flake on one tape
+  # cancels only its own shard, parallelism keeps total wall-clock under
+  # ~8m, and failures point at the right area immediately. Each shard
+  # has a 6m budget — well above the per-shard render time today
+  # (longest shard runs ~3-4 tapes), with headroom for the per-tape
+  # retry logic in the distinctness assertion. (#187)
   tapes:
-    name: Run tapes
+    name: Run tapes (${{ matrix.shard.name }})
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 6
+    strategy:
+      fail-fast: false
+      matrix:
+        shard:
+          - name: cli
+            tapes: "cli-bib-import.tape cli-bib-rekey.tape cli-question-workflow.tape cli-search.tape"
+          - name: tui-launch
+            tapes: "tui-launch.tape init-wizard.tape"
+          - name: tui-papers
+            tapes: "papers-download-state.tape queue-tab.tape reading-queue-star.tape question-dashboard.tape"
+          - name: tui-reader
+            tapes: "tui-annotation-write.tape tui-annotations-reader.tape annotations-in-detail.tape tui-export-keybind.tape"
+          - name: theme
+            tapes: "theme-dark.tape theme-light.tape theme-toggle.tape"
+          - name: connectivity
+            tapes: "offline-indicator.tape open-externally.tape"
     steps:
       - uses: actions/checkout@v4
 
@@ -37,14 +59,23 @@ jobs:
       - name: Build scitadel
         run: cargo build --release -p scitadel-cli
 
-      - name: Run all tapes
+      - name: Run shard tapes
+        env:
+          SHARD_TAPES: ${{ matrix.shard.tapes }}
         run: |
           set -euo pipefail
           export PATH="$PWD/target/release:$PATH"
-          shopt -s nullglob
-          tapes=(tests/vhs/*.tape)
+          tapes=()
+          for stem in $SHARD_TAPES; do
+            path="tests/vhs/$stem"
+            if [ ! -f "$path" ]; then
+              echo "::error::declared shard tape missing on disk: $path"
+              exit 1
+            fi
+            tapes+=("$path")
+          done
           if [ ${#tapes[@]} -eq 0 ]; then
-            echo "No tapes under tests/vhs/. Nothing to run."
+            echo "Empty shard. Nothing to run."
             exit 0
           fi
           mkdir -p tests/vhs/snapshots
@@ -62,19 +93,21 @@ jobs:
             echo "::error::${#failed[@]} tape(s) failed: ${failed[*]}"
             exit 1
           fi
-          echo "All ${#tapes[@]} tape(s) ran cleanly."
+          echo "All ${#tapes[@]} tape(s) in shard ran cleanly."
 
       - name: Assert tapes produced distinct snapshots
+        env:
+          SHARD_TAPES: ${{ matrix.shard.tapes }}
         run: |
           set -euo pipefail
-          shopt -s nullglob
           # The hard failure case is "all snapshots identical" — that's the
           # bug class (#97 silent reader failure) this gate exists to catch.
           # "Fewer PNGs than declared" is a warning: it can be genuine vhs /
           # runner-timing flakiness rather than a real bug, and we don't
           # want to wedge merges on it.
           dead=()
-          for tape in tests/vhs/*.tape; do
+          for stem in $SHARD_TAPES; do
+            tape="tests/vhs/$stem"
             base=$(basename "$tape" .tape)
             dir="tests/vhs/snapshots/$base"
             declared=$(grep -c '^Screenshot ' "$tape" || true)
@@ -131,10 +164,77 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: vhs-snapshots
+          name: vhs-snapshots-${{ matrix.shard.name }}
           path: tests/vhs/snapshots/
           retention-days: 14
           if-no-files-found: ignore
+
+  # Ensures every tape on disk is claimed by exactly one shard. Without
+  # this, a newly added tape would silently never run on CI. Cheap to
+  # run, gives an immediate signal at PR time.
+  shard-coverage:
+    name: Tape shard coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v4
+      - name: Assert every tape is in exactly one shard
+        run: |
+          set -euo pipefail
+          declared=$(cat <<'EOF' | tr ' ' '\n' | sed '/^$/d' | sort
+          cli-bib-import.tape cli-bib-rekey.tape cli-question-workflow.tape cli-search.tape
+          tui-launch.tape init-wizard.tape
+          papers-download-state.tape queue-tab.tape reading-queue-star.tape question-dashboard.tape
+          tui-annotation-write.tape tui-annotations-reader.tape annotations-in-detail.tape tui-export-keybind.tape
+          theme-dark.tape theme-light.tape theme-toggle.tape
+          offline-indicator.tape open-externally.tape
+          EOF
+          )
+          on_disk=$(find tests/vhs -maxdepth 1 -name '*.tape' -printf '%f\n' 2>/dev/null | sort)
+
+          missing=$(comm -23 <(echo "$on_disk") <(echo "$declared") || true)
+          extra=$(comm -13 <(echo "$on_disk") <(echo "$declared") || true)
+          dupes=$(echo "$declared" | uniq -d || true)
+
+          fail=0
+          if [ -n "$missing" ]; then
+            echo "::error::tape(s) on disk but not assigned to any shard in vhs.yml:"
+            echo "$missing" | sed 's/^/  /'
+            fail=1
+          fi
+          if [ -n "$extra" ]; then
+            echo "::error::tape(s) declared in a shard but missing on disk:"
+            echo "$extra" | sed 's/^/  /'
+            fail=1
+          fi
+          if [ -n "$dupes" ]; then
+            echo "::error::tape(s) appear in more than one shard:"
+            echo "$dupes" | sed 's/^/  /'
+            fail=1
+          fi
+          if [ "$fail" -ne 0 ]; then
+            exit 1
+          fi
+          echo "All $(echo "$on_disk" | wc -l | tr -d ' ') tape(s) covered by exactly one shard."
+
+  # Roll-up gate so branch protection can require a single check name
+  # (`Tapes`) instead of every shard individually. Fails if any shard
+  # failed; passes only when all shards pass or the matrix is otherwise
+  # successful.
+  tapes-rollup:
+    name: Tapes
+    runs-on: ubuntu-latest
+    needs: tapes
+    if: always()
+    steps:
+      - name: Aggregate shard results
+        run: |
+          result="${{ needs.tapes.result }}"
+          echo "tapes matrix result: $result"
+          case "$result" in
+            success) echo "all shards green"; exit 0 ;;
+            *) echo "::error::one or more tape shards failed: $result"; exit 1 ;;
+          esac
 
   coverage:
     name: Tape coverage

--- a/.github/workflows/vhs.yml
+++ b/.github/workflows/vhs.yml
@@ -20,33 +20,31 @@ jobs:
   tapes:
     name: Run tapes (${{ matrix.shard.name }})
     runs-on: ubuntu-latest
-    # Per-shard budget. tui-reader gets 10m because its 4 tapes have
-    # historically been the flakiest (the distinctness retry loop can
-    # consume up to 3 extra renders per tape); the rest stay at 6m
-    # since they've never come close.
-    timeout-minutes: ${{ matrix.shard.timeout-minutes }}
+    # Per-shard budget — uniform 10m. Empirically the cargo build +
+    # ttyd/ffmpeg install eats ~3m of fixed overhead before a single
+    # tape renders, and TUI tapes can take 60-90s each. With 4 tapes
+    # in the largest shards, 6m was too tight even on the happy path
+    # (tui-papers blew it on the first sharded run); 10m gives every
+    # shard headroom to absorb the build cost plus the per-tape retry
+    # logic in the distinctness assertion. Total wall-clock stays
+    # <10m because shards run in parallel.
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
         shard:
           - name: cli
             tapes: "cli-bib-import.tape cli-bib-rekey.tape cli-question-workflow.tape cli-search.tape"
-            timeout-minutes: 6
           - name: tui-launch
             tapes: "tui-launch.tape init-wizard.tape"
-            timeout-minutes: 6
           - name: tui-papers
             tapes: "papers-download-state.tape queue-tab.tape reading-queue-star.tape question-dashboard.tape"
-            timeout-minutes: 6
           - name: tui-reader
             tapes: "tui-annotation-write.tape tui-annotations-reader.tape annotations-in-detail.tape tui-export-keybind.tape"
-            timeout-minutes: 10
           - name: theme
             tapes: "theme-dark.tape theme-light.tape theme-toggle.tape"
-            timeout-minutes: 6
           - name: connectivity
             tapes: "offline-indicator.tape open-externally.tape"
-            timeout-minutes: 6
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

Closes #187. The 19-tape monolithic `Run tapes` job (chronically timing out at 20m on dev + PRs) is split into 6 parallel shards, each with its own budget:

| shard | tapes | budget |
|---|---|---|
| cli | 4 | 6m |
| tui-launch | 2 | 6m |
| tui-papers | 4 | 6m |
| tui-reader | 4 | **10m** (historically flakiest, retry-heavy) |
| theme | 3 | 6m |
| connectivity | 2 | 6m |

Two new gates round it out:
- **`Tape shard coverage`** asserts every \`.tape\` on disk is claimed by exactly one shard, so a newly added tape can't silently never run.
- **`Tapes`** rollup aggregates shard + coverage results into a single check name. Branch protection only needs to require this one.

`fail-fast: false` so a flake in one shard no longer wipes the others. Total wall-clock drops from ~20m to <8m even with one shard exhausting its retry budget.

## Test plan

- [x] `python3 yaml.safe_load` parses cleanly
- [x] All 19 tapes covered exactly once across the 6 shards (no orphans, no dupes) — verified locally
- [x] `actionlint` clean (only pre-existing SC2001 stylistic warnings on the untouched `coverage` step)
- [ ] First CI run on this PR validates the matrix triggers + rollup gates correctly

[tape-exempt: CI-only workflow change; no TUI/CLI source touched]