### PR TITLE
feat(tui): consume unread state — badge, glyph, inbox, focus-leave (#185 PR2/5)

### DIFF
--- a/.github/workflows/vhs.yml
+++ b/.github/workflows/vhs.yml
@@ -38,7 +38,7 @@ jobs:
           - name: tui-launch
             tapes: "tui-launch.tape init-wizard.tape"
           - name: tui-papers
-            tapes: "papers-download-state.tape queue-tab.tape reading-queue-star.tape question-dashboard.tape"
+            tapes: "papers-download-state.tape queue-tab.tape reading-queue-star.tape question-dashboard.tape tui-inbox.tape"
           - name: tui-reader
             tapes: "tui-annotation-write.tape tui-annotations-reader.tape annotations-in-detail.tape tui-export-keybind.tape"
           - name: theme
@@ -192,7 +192,7 @@ jobs:
           declared=$(cat <<'EOF' | tr ' ' '\n' | sed '/^$/d' | sort
           cli-bib-import.tape cli-bib-rekey.tape cli-question-workflow.tape cli-search.tape
           tui-launch.tape init-wizard.tape
-          papers-download-state.tape queue-tab.tape reading-queue-star.tape question-dashboard.tape
+          papers-download-state.tape queue-tab.tape reading-queue-star.tape question-dashboard.tape tui-inbox.tape
           tui-annotation-write.tape tui-annotations-reader.tape annotations-in-detail.tape tui-export-keybind.tape
           theme-dark.tape theme-light.tape theme-toggle.tape
           offline-indicator.tape open-externally.tape

--- a/crates/scitadel-db/src/sqlite/annotations.rs
+++ b/crates/scitadel-db/src/sqlite/annotations.rs
@@ -246,6 +246,27 @@ impl SqliteAnnotationRepository {
         Ok(rows)
     }
 
+    /// Set of paper IDs that have at least one annotation `reader`
+    /// hasn't acknowledged. Drives the per-row `●` glyph on the
+    /// Papers list — one indexed query per draw tick. (#185)
+    pub fn papers_with_unread(
+        &self,
+        reader: &str,
+    ) -> Result<std::collections::HashSet<String>, DbError> {
+        let conn = self.db.conn()?;
+        let mut stmt = conn.prepare(
+            "SELECT DISTINCT a.paper_id FROM annotations a
+             LEFT JOIN annotation_reads r
+               ON r.annotation_id = a.id AND r.reader = ?1
+             WHERE a.deleted_at IS NULL
+               AND (r.seen_at IS NULL OR r.seen_at < a.updated_at)",
+        )?;
+        let rows = stmt
+            .query_map(params![reader], |row| row.get::<_, String>(0))?
+            .filter_map(Result::ok);
+        Ok(rows.collect())
+    }
+
     /// Same predicate as `list_unread` but returns just the count.
     /// Called on every TUI draw tick (~10 Hz) to drive the status-bar
     /// `[N new]` badge — `COUNT(*)` keeps the per-tick cost in
@@ -839,6 +860,41 @@ mod tests {
         repo.mark_thread_seen(root.id.as_str(), "lars").unwrap();
         let unread = repo.list_unread("lars", Some("p1")).unwrap();
         assert!(unread.is_empty());
+    }
+
+    #[test]
+    fn papers_with_unread_returns_distinct_paper_ids() {
+        let db = fresh_db_with_paper();
+        // Add a second paper.
+        db.conn()
+            .unwrap()
+            .execute(
+                "INSERT INTO papers (id, title, authors, abstract, created_at, updated_at)
+                 VALUES ('p2', 'Other', '[]', '', '2026-04-28T00:00:00Z', '2026-04-28T00:00:00Z')",
+                [],
+            )
+            .unwrap();
+        let repo = SqliteAnnotationRepository::new(db);
+        let on_p1 = sample_root();
+        let on_p2 = Annotation::new_root(
+            scitadel_core::models::PaperId::from("p2"),
+            "claude".into(),
+            "n".into(),
+            Anchor::default(),
+        );
+        repo.create(&on_p1).unwrap();
+        let p1_b = Annotation::new_reply(&on_p1, "claude".into(), "follow".into());
+        repo.create(&p1_b).unwrap();
+        repo.create(&on_p2).unwrap();
+
+        let set = repo.papers_with_unread("lars").unwrap();
+        assert_eq!(set.len(), 2, "two distinct paper_ids despite three rows");
+        assert!(set.contains("p1"));
+        assert!(set.contains("p2"));
+
+        repo.mark_thread_seen(on_p1.id.as_str(), "lars").unwrap();
+        let set = repo.papers_with_unread("lars").unwrap();
+        assert_eq!(set, std::iter::once("p2".to_string()).collect());
     }
 
     #[test]

--- a/crates/scitadel-db/src/sqlite/annotations.rs
+++ b/crates/scitadel-db/src/sqlite/annotations.rs
@@ -245,6 +245,37 @@ impl SqliteAnnotationRepository {
         let _ = sql; // kept for potential future logging
         Ok(rows)
     }
+
+    /// Same predicate as `list_unread` but returns just the count.
+    /// Called on every TUI draw tick (~10 Hz) to drive the status-bar
+    /// `[N new]` badge — `COUNT(*)` keeps the per-tick cost in
+    /// microseconds even when there are many annotations. (#185)
+    pub fn count_unread(&self, reader: &str, paper_id: Option<&str>) -> Result<i64, DbError> {
+        let conn = self.db.conn()?;
+        let n: i64 = if let Some(pid) = paper_id {
+            conn.query_row(
+                "SELECT COUNT(*) FROM annotations a
+                 LEFT JOIN annotation_reads r
+                   ON r.annotation_id = a.id AND r.reader = ?1
+                 WHERE a.paper_id = ?2
+                   AND a.deleted_at IS NULL
+                   AND (r.seen_at IS NULL OR r.seen_at < a.updated_at)",
+                params![reader, pid],
+                |row| row.get(0),
+            )?
+        } else {
+            conn.query_row(
+                "SELECT COUNT(*) FROM annotations a
+                 LEFT JOIN annotation_reads r
+                   ON r.annotation_id = a.id AND r.reader = ?1
+                 WHERE a.deleted_at IS NULL
+                   AND (r.seen_at IS NULL OR r.seen_at < a.updated_at)",
+                params![reader],
+                |row| row.get(0),
+            )?
+        };
+        Ok(n)
+    }
 }
 
 fn row_to_annotation(row: &rusqlite::Row) -> rusqlite::Result<Annotation> {
@@ -808,6 +839,35 @@ mod tests {
         repo.mark_thread_seen(root.id.as_str(), "lars").unwrap();
         let unread = repo.list_unread("lars", Some("p1")).unwrap();
         assert!(unread.is_empty());
+    }
+
+    #[test]
+    fn count_unread_matches_list_unread_length() {
+        let db = fresh_db_with_paper();
+        let repo = SqliteAnnotationRepository::new(db);
+        let root = sample_root();
+        repo.create(&root).unwrap();
+        let reply = Annotation::new_reply(&root, "claude".into(), "follow-up".into());
+        repo.create(&reply).unwrap();
+
+        // Both unread for lars.
+        assert_eq!(repo.count_unread("lars", None).unwrap(), 2);
+        assert_eq!(repo.count_unread("lars", Some("p1")).unwrap(), 2);
+
+        repo.mark_thread_seen(root.id.as_str(), "lars").unwrap();
+        assert_eq!(repo.count_unread("lars", None).unwrap(), 0);
+        assert_eq!(repo.count_unread("lars", Some("p1")).unwrap(), 0);
+
+        // Soft-delete must not be counted.
+        let solo = Annotation::new_root(
+            scitadel_core::models::PaperId::from("p1"),
+            "lars".into(),
+            "doomed".into(),
+            Anchor::default(),
+        );
+        repo.create(&solo).unwrap();
+        repo.soft_delete(solo.id.as_str()).unwrap();
+        assert_eq!(repo.count_unread("lars", None).unwrap(), 0);
     }
 
     #[test]

--- a/crates/scitadel-tui/src/app.rs
+++ b/crates/scitadel-tui/src/app.rs
@@ -104,6 +104,14 @@ pub enum Overlay {
         selected: usize,
         export_prompt: Option<BibExportPrompt>,
     },
+    /// Unread-annotations inbox (#185 P0). `items` is the rendered
+    /// flat list (mixed headers + rows); `selected` points at the
+    /// currently-highlighted row. Built once on overlay open and
+    /// rebuilt on every render so MCP-side writes show up live.
+    Inbox {
+        items: Vec<crate::views::inbox::InboxItem>,
+        selected: usize,
+    },
 }
 
 /// Main application state.
@@ -435,7 +443,9 @@ impl App {
                 (Some(paper_id.clone()), None, ann_id)
             }
             Some(Overlay::SearchPapers { search_id, .. }) => (None, Some(search_id.clone()), None),
-            Some(Overlay::QuestionDashboard { .. }) | None => (None, None, None),
+            Some(Overlay::QuestionDashboard { .. } | Overlay::Inbox { .. }) | None => {
+                (None, None, None)
+            }
         };
         // Question id: from the overlay (dashboard open) or the
         // Questions-tab cursor. Dashboard wins since it's more specific.
@@ -613,6 +623,17 @@ impl App {
             return;
         }
 
+        // `U` toggles the unread inbox overlay (#185 P0). Same gating
+        // as `T`: skip when a text input is open. Pressing `U` again
+        // (or `Esc`/`q` inside the overlay) closes it. The toggle has
+        // to run BEFORE the generic overlay dispatch so it can close
+        // the inbox from on-top-of-itself; otherwise pressing `U`
+        // inside the inbox would just dispatch into the inbox view.
+        if code == KeyCode::Char('U') && !self.in_text_input_context() {
+            self.toggle_inbox();
+            return;
+        }
+
         if self.overlay.is_some() {
             self.handle_overlay_key(code);
             return;
@@ -626,6 +647,56 @@ impl App {
             KeyCode::Char('c') => self.clear_completed_tasks(),
             _ => self.handle_tab_key(code),
         }
+    }
+
+    /// Open the inbox overlay if no overlay is active, or close it if
+    /// the inbox is the current overlay. Cursor lands on the first
+    /// selectable row. (#185)
+    fn toggle_inbox(&mut self) {
+        if matches!(self.overlay, Some(Overlay::Inbox { .. })) {
+            self.overlay = None;
+            return;
+        }
+        let items = crate::views::inbox::load(&self.data, &self.reader);
+        // Cursor on first selectable row (skip the leading header).
+        let selected = items.iter().position(|i| i.is_selectable()).unwrap_or(0);
+        self.overlay = Some(Overlay::Inbox { items, selected });
+    }
+
+    /// Replace the overlay with a PaperDetail in two-pane reader mode
+    /// focused on the given thread. Caller has already resolved the
+    /// inbox cursor to `(paper_id, root_id)` so this method takes
+    /// concrete arguments rather than peeking at `self.overlay` —
+    /// keeps the borrow story straightforward in the inbox key
+    /// handler. (#185)
+    fn jump_to_thread(&mut self, paper_id: &str, root_id: &str) {
+        // Find the highlight_focus index of the target root over the
+        // paper's roots so reader mode opens with the cursor on it.
+        let highlight_focus = self
+            .data
+            .load_annotations_for_paper(paper_id)
+            .ok()
+            .and_then(|anns| {
+                anns.into_iter()
+                    .filter(|a| !a.is_reply())
+                    .position(|a| a.id.as_str() == root_id)
+            });
+        self.overlay = Some(Overlay::PaperDetail {
+            paper_id: paper_id.to_string(),
+            scroll: 0,
+            annotation_focus: None,
+            prompt: None,
+            reader: true,
+            highlight_focus,
+        });
+        // Track the focused root so leave-events mark it seen.
+        focus_thread_by_root_idx(
+            &self.data,
+            &self.reader,
+            &mut self.last_focused_root_id,
+            paper_id,
+            highlight_focus,
+        );
     }
 
     fn handle_overlay_key(&mut self, code: KeyCode) {
@@ -669,7 +740,46 @@ impl App {
             Some(Overlay::QuestionDashboard { .. }) => {
                 self.handle_question_dashboard_key(code);
             }
+            Some(Overlay::Inbox { .. }) => self.handle_inbox_key(code),
             None => {}
+        }
+    }
+
+    /// Routes a key inside the Inbox overlay. Esc/q close, j/k step
+    /// over selectable rows (skipping headers), Enter jumps to the
+    /// paper reader focused on the selected thread. (#185)
+    fn handle_inbox_key(&mut self, code: KeyCode) {
+        // Compute the action under the overlay borrow, then apply it
+        // after the borrow drops so the Enter path can call
+        // `&mut self` helpers without fighting the borrow checker.
+        enum InboxAction {
+            Close,
+            Jump(String, String),
+            None,
+        }
+        let action = {
+            let Some(Overlay::Inbox { items, selected }) = self.overlay.as_mut() else {
+                return;
+            };
+            match code {
+                KeyCode::Esc | KeyCode::Char('q') => InboxAction::Close,
+                KeyCode::Char('j') | KeyCode::Down => {
+                    *selected = crate::views::inbox::step_selection(items, *selected, 1);
+                    InboxAction::None
+                }
+                KeyCode::Char('k') | KeyCode::Up => {
+                    *selected = crate::views::inbox::step_selection(items, *selected, -1);
+                    InboxAction::None
+                }
+                KeyCode::Enter => crate::views::inbox::jump_target(items, *selected)
+                    .map_or(InboxAction::None, |(p, r)| InboxAction::Jump(p, r)),
+                _ => InboxAction::None,
+            }
+        };
+        match action {
+            InboxAction::Close => self.overlay = None,
+            InboxAction::Jump(paper_id, root_id) => self.jump_to_thread(&paper_id, &root_id),
+            InboxAction::None => {}
         }
     }
 
@@ -1370,6 +1480,19 @@ fn draw(frame: &mut ratatui::Frame, app: &mut App) {
     // show up in the status bar + per-row glyphs within ~100ms (the
     // event-poll cadence). (#185)
     app.refresh_unread();
+    // If the inbox overlay is open, rebuild its items each tick so a
+    // newly-arrived annotation shows up live without the user having
+    // to close + reopen. The cursor index is preserved (clamped to
+    // the new length).
+    if let Some(Overlay::Inbox { items, selected }) = app.overlay.as_mut() {
+        let fresh = crate::views::inbox::load(&app.data, &app.reader);
+        let max = fresh.len().saturating_sub(1);
+        *selected = (*selected).min(max);
+        // If the cursor lands on a header after the rebuild, snap it
+        // forward to the next selectable row.
+        *selected = crate::views::inbox::step_selection(&fresh, *selected, 0);
+        *items = fresh;
+    }
     let task_panel_height = tasks_view::panel_height(&app.tasks);
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -1469,6 +1592,9 @@ fn draw(frame: &mut ratatui::Frame, app: &mut App) {
                 bib_export_prompt::draw_overlay(frame, chunks[1], prompt);
             }
         }
+        Some(Overlay::Inbox { items, selected }) => {
+            crate::views::inbox::draw(frame, chunks[1], items, *selected);
+        }
         None => match app.tab {
             Tab::Searches => searches::draw(frame, chunks[1], &app.data, app.search_selected),
             Tab::Papers => papers::draw(
@@ -1541,11 +1667,14 @@ fn draw(frame: &mut ratatui::Frame, app: &mut App) {
         (Some(Overlay::QuestionDashboard { .. }), _) => {
             "Esc/q: back | j/k: navigate | Enter: open paper | c: toggle shortlist | E: export bib"
         }
+        (Some(Overlay::Inbox { .. }), _) => {
+            "Esc/q/U: close inbox | j/k: navigate | Enter: jump to thread"
+        }
         (None, Tab::Papers | Tab::Queue) => {
-            "Tab: switch tabs | j/k: navigate | Enter: open | s: (un)star | c: clear tasks | T: theme | q: quit"
+            "Tab: switch tabs | j/k: navigate | Enter: open | s: (un)star | c: clear tasks | T: theme | U: inbox | q: quit"
         }
         (None, _) => {
-            "Tab/Shift-Tab: switch tabs | j/k: navigate | Enter: select | c: clear tasks | T: theme | q: quit"
+            "Tab/Shift-Tab: switch tabs | j/k: navigate | Enter: select | c: clear tasks | T: theme | U: inbox | q: quit"
         }
     };
     // Startup toast (#137) hijacks the status bar for its lifetime so
@@ -2020,6 +2149,59 @@ mod tests {
             None,
         );
         assert_eq!(app.data.load_unread_count("lars").unwrap(), 0);
+    }
+
+    /// `U` opens the inbox overlay; pressing `U` again closes it.
+    /// Cursor lands on the first selectable row when there are unread
+    /// items.
+    #[tokio::test(flavor = "current_thread")]
+    async fn u_toggles_inbox_overlay() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (mut app, _, _) = fixture(&tmp);
+        let _ = seed_thread(&tmp.path().join("scitadel.db"));
+
+        // Open.
+        app.handle_key(KeyCode::Char('U'), KeyModifiers::NONE);
+        match &app.overlay {
+            Some(Overlay::Inbox { items, selected }) => {
+                assert!(items.iter().any(|i| i.is_selectable()));
+                assert!(items.get(*selected).is_some_and(|i| i.is_selectable()));
+            }
+            other => panic!("expected Inbox overlay, got {other:?}"),
+        }
+        // Close via U again.
+        app.handle_key(KeyCode::Char('U'), KeyModifiers::NONE);
+        assert!(app.overlay.is_none(), "U should toggle the inbox closed");
+    }
+
+    /// Enter on a selectable inbox row replaces the overlay with a
+    /// PaperDetail in two-pane reader mode focused on the chosen
+    /// thread.
+    #[tokio::test(flavor = "current_thread")]
+    async fn inbox_enter_jumps_to_paper_reader_focused_on_thread() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (mut app, _, _) = fixture(&tmp);
+        let (root_id, _) = seed_thread(&tmp.path().join("scitadel.db"));
+
+        app.handle_key(KeyCode::Char('U'), KeyModifiers::NONE);
+        app.handle_key(KeyCode::Enter, KeyModifiers::NONE);
+
+        match &app.overlay {
+            Some(Overlay::PaperDetail {
+                paper_id,
+                reader,
+                highlight_focus,
+                ..
+            }) => {
+                assert_eq!(paper_id, "p-attn");
+                assert!(*reader, "reader mode should be on after inbox jump");
+                assert_eq!(*highlight_focus, Some(0));
+            }
+            other => panic!("expected PaperDetail reader after Enter, got {other:?}"),
+        }
+        // The focus tracker should be set to the chosen root, so a
+        // subsequent leave-event will mark it seen.
+        assert_eq!(app.last_focused_root_id, Some(root_id));
     }
 
     /// Closing the PaperDetail overlay marks the focused thread seen,

--- a/crates/scitadel-tui/src/app.rs
+++ b/crates/scitadel-tui/src/app.rs
@@ -155,6 +155,11 @@ pub struct App {
     /// the widget so a future event-driven refresh path can update the
     /// same field. (#185)
     pub unread_count: i64,
+    /// Cached set of paper IDs that have at least one unread
+    /// annotation for `reader`. Drives the per-row `●` glyph in the
+    /// Papers list. Refreshed on every draw alongside `unread_count`.
+    /// (#185)
+    pub papers_with_unread: std::collections::HashSet<String>,
 
     task_tx: mpsc::UnboundedSender<TaskUpdate>,
     task_rx: mpsc::UnboundedReceiver<TaskUpdate>,
@@ -223,18 +228,23 @@ impl App {
             startup_toast_frames: 0,
             status_toast: None,
             unread_count: 0,
+            papers_with_unread: std::collections::HashSet::new(),
             task_tx,
             task_rx,
             offline_rx,
         }
     }
 
-    /// Refresh `unread_count` from the DB. Cheap (`COUNT(*)` over the
-    /// annotations LEFT JOIN annotation_reads predicate), called on
-    /// every render tick. Failures are silently swallowed — a stale
-    /// badge is acceptable; an error toast every 100 ms is not. (#185)
-    fn refresh_unread_count(&mut self) {
+    /// Refresh `unread_count` and `papers_with_unread` from the DB.
+    /// Two cheap indexed queries per render tick; failures are silently
+    /// swallowed (a stale badge is acceptable, an error toast every
+    /// 100 ms is not). (#185)
+    fn refresh_unread(&mut self) {
         self.unread_count = self.data.load_unread_count(&self.reader).unwrap_or(0);
+        self.papers_with_unread = self
+            .data
+            .load_papers_with_unread(&self.reader)
+            .unwrap_or_default();
     }
 
     /// Advance the startup-toast lifetime by one draw (#137). Call once
@@ -1213,10 +1223,10 @@ fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &mut App
 }
 
 fn draw(frame: &mut ratatui::Frame, app: &mut App) {
-    // Refresh the unread badge each tick so MCP-side annotation
-    // writes show up in the status bar within ~100ms (the event-poll
-    // cadence). (#185)
-    app.refresh_unread_count();
+    // Refresh unread state each tick so MCP-side annotation writes
+    // show up in the status bar + per-row glyphs within ~100ms (the
+    // event-poll cadence). (#185)
+    app.refresh_unread();
     let task_panel_height = tasks_view::panel_height(&app.tasks);
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -1262,7 +1272,14 @@ fn draw(frame: &mut ratatui::Frame, app: &mut App) {
             highlight_focus,
         }) => {
             if *reader {
-                crate::views::reader::draw(frame, chunks[1], &app.data, paper_id, *highlight_focus);
+                crate::views::reader::draw(
+                    frame,
+                    chunks[1],
+                    &app.data,
+                    paper_id,
+                    *highlight_focus,
+                    &app.reader,
+                );
             } else {
                 detail::draw(
                     frame,
@@ -1289,6 +1306,7 @@ fn draw(frame: &mut ratatui::Frame, app: &mut App) {
                 *selected,
                 &app.starred,
                 &app.downloading_paper_ids(),
+                &app.papers_with_unread,
             );
         }
         Some(Overlay::QuestionDashboard {
@@ -1317,6 +1335,7 @@ fn draw(frame: &mut ratatui::Frame, app: &mut App) {
                 app.paper_selected,
                 &app.starred,
                 &app.downloading_paper_ids(),
+                &app.papers_with_unread,
             ),
             Tab::Questions => {
                 questions::draw(frame, chunks[1], &app.data, app.question_selected);

--- a/crates/scitadel-tui/src/app.rs
+++ b/crates/scitadel-tui/src/app.rs
@@ -148,6 +148,13 @@ pub struct App {
     /// rendering branch — both feed the same status-bar slot. Lifetime
     /// is per-toast so a long error can linger longer than a quick OK.
     status_toast: Option<StatusToast>,
+    /// Cached count of annotations the current `reader` hasn't
+    /// acknowledged. Refreshed on every draw via `data.load_unread_count`
+    /// so the `[N new]` status-bar badge reflects MCP-side writes within
+    /// one tick (~100 ms). Kept on `App` rather than recomputing inside
+    /// the widget so a future event-driven refresh path can update the
+    /// same field. (#185)
+    pub unread_count: i64,
 
     task_tx: mpsc::UnboundedSender<TaskUpdate>,
     task_rx: mpsc::UnboundedReceiver<TaskUpdate>,
@@ -215,10 +222,19 @@ impl App {
             startup_toast: None,
             startup_toast_frames: 0,
             status_toast: None,
+            unread_count: 0,
             task_tx,
             task_rx,
             offline_rx,
         }
+    }
+
+    /// Refresh `unread_count` from the DB. Cheap (`COUNT(*)` over the
+    /// annotations LEFT JOIN annotation_reads predicate), called on
+    /// every render tick. Failures are silently swallowed — a stale
+    /// badge is acceptable; an error toast every 100 ms is not. (#185)
+    fn refresh_unread_count(&mut self) {
+        self.unread_count = self.data.load_unread_count(&self.reader).unwrap_or(0);
     }
 
     /// Advance the startup-toast lifetime by one draw (#137). Call once
@@ -1197,6 +1213,10 @@ fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &mut App
 }
 
 fn draw(frame: &mut ratatui::Frame, app: &mut App) {
+    // Refresh the unread badge each tick so MCP-side annotation
+    // writes show up in the status bar within ~100ms (the event-poll
+    // cadence). (#185)
+    app.refresh_unread_count();
     let task_panel_height = tasks_view::panel_height(&app.tasks);
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -1383,7 +1403,7 @@ fn draw(frame: &mut ratatui::Frame, app: &mut App) {
     } else {
         help_text
     };
-    status_bar::draw(frame, chunks[3], bar_text, app.offline);
+    status_bar::draw(frame, chunks[3], bar_text, app.offline, app.unread_count);
     app.tick_startup_toast();
     app.tick_status_toast();
 }

--- a/crates/scitadel-tui/src/app.rs
+++ b/crates/scitadel-tui/src/app.rs
@@ -160,10 +160,83 @@ pub struct App {
     /// Papers list. Refreshed on every draw alongside `unread_count`.
     /// (#185)
     pub papers_with_unread: std::collections::HashSet<String>,
+    /// The thread root ID the user most recently had in focus. Set
+    /// when annotation-focus / reader-highlight cursor moves onto a
+    /// thread; the *previous* value gets passed to `mark_thread_seen`
+    /// when focus moves to another thread (or away entirely). This is
+    /// the "focus-leave" semantics #185 calls for — a glance doesn't
+    /// mark seen, but moving past a thread does. (#185)
+    last_focused_root_id: Option<String>,
 
     task_tx: mpsc::UnboundedSender<TaskUpdate>,
     task_rx: mpsc::UnboundedReceiver<TaskUpdate>,
     offline_rx: mpsc::UnboundedReceiver<bool>,
+}
+
+/// Update the focus tracker and mark the *previous* thread seen if
+/// focus transitioned to a different thread (or to nothing). Free
+/// function rather than `&mut self` method so it can be called with
+/// disjoint borrows on `App` while `self.overlay.as_mut()` holds a
+/// mutable reference to the overlay slot. Failure of `mark_thread_seen`
+/// is silently swallowed — a stale badge is acceptable, an error
+/// toast every keystroke is not. (#185)
+fn set_focused_thread(
+    data: &DataStore,
+    reader: &str,
+    last_focused_root_id: &mut Option<String>,
+    new_root_id: Option<String>,
+) {
+    if *last_focused_root_id == new_root_id {
+        return;
+    }
+    if let Some(prev) = last_focused_root_id.take() {
+        let _ = data.mark_thread_seen(reader, &prev);
+    }
+    *last_focused_root_id = new_root_id;
+}
+
+/// Resolve the root at `root_idx` over the paper's live roots
+/// (oldest-first) and update the focus tracker. None clears focus
+/// without a DB hit. Used by reader-mode highlight navigation. (#185)
+fn focus_thread_by_root_idx(
+    data: &DataStore,
+    reader: &str,
+    last_focused_root_id: &mut Option<String>,
+    paper_id: &str,
+    root_idx: Option<usize>,
+) {
+    let new_root_id = root_idx.and_then(|idx| {
+        data.load_annotations_for_paper(paper_id)
+            .ok()?
+            .into_iter()
+            .filter(|a| !a.is_reply())
+            .nth(idx)
+            .map(|a| a.id.as_str().to_string())
+    });
+    set_focused_thread(data, reader, last_focused_root_id, new_root_id);
+}
+
+/// Resolve the thread root for the annotation at `annotation_idx`
+/// (mixed roots and replies, oldest-first) and update the focus
+/// tracker. Walks `parent_id` to the root so replies still mark their
+/// thread as the unit of "seen-ness". Used by annotation-focus
+/// navigation. (#185)
+fn focus_thread_by_annotation_idx(
+    data: &DataStore,
+    reader: &str,
+    last_focused_root_id: &mut Option<String>,
+    paper_id: &str,
+    annotation_idx: Option<usize>,
+) {
+    let new_root_id = annotation_idx.and_then(|idx| {
+        let annotations = data.load_annotations_for_paper(paper_id).ok()?;
+        let target = annotations.get(idx)?;
+        Some(target.parent_id.as_ref().map_or_else(
+            || target.id.as_str().to_string(),
+            |p| p.as_str().to_string(),
+        ))
+    });
+    set_focused_thread(data, reader, last_focused_root_id, new_root_id);
 }
 
 /// How many draws the startup toast lingers for (#137). At the
@@ -229,6 +302,7 @@ impl App {
             status_toast: None,
             unread_count: 0,
             papers_with_unread: std::collections::HashSet::new(),
+            last_focused_root_id: None,
             task_tx,
             task_rx,
             offline_rx,
@@ -821,12 +895,37 @@ impl App {
                 KeyCode::Esc | KeyCode::Char('q' | 'R') => {
                     *reader = false;
                     *highlight_focus = None;
+                    // Focus left the reader entirely — mark whatever
+                    // thread was focused as seen. (#185)
+                    focus_thread_by_root_idx(
+                        &self.data,
+                        &self.reader,
+                        &mut self.last_focused_root_id,
+                        paper_id,
+                        None,
+                    );
                 }
                 KeyCode::Char('J') | KeyCode::Down if count > 0 => {
-                    *highlight_focus = Some(highlight_focus.map_or(0, |f| (f + 1).min(count - 1)));
+                    let next = Some(highlight_focus.map_or(0, |f| (f + 1).min(count - 1)));
+                    *highlight_focus = next;
+                    focus_thread_by_root_idx(
+                        &self.data,
+                        &self.reader,
+                        &mut self.last_focused_root_id,
+                        paper_id,
+                        next,
+                    );
                 }
                 KeyCode::Char('K') | KeyCode::Up if count > 0 => {
-                    *highlight_focus = Some(highlight_focus.map_or(0, |f| f.saturating_sub(1)));
+                    let next = Some(highlight_focus.map_or(0, |f| f.saturating_sub(1)));
+                    *highlight_focus = next;
+                    focus_thread_by_root_idx(
+                        &self.data,
+                        &self.reader,
+                        &mut self.last_focused_root_id,
+                        paper_id,
+                        next,
+                    );
                 }
                 KeyCode::Char('D') => {
                     let pid = paper_id.clone();
@@ -855,15 +954,28 @@ impl App {
                 .unwrap_or_default();
             if annotations.is_empty() {
                 *annotation_focus = None;
+                focus_thread_by_annotation_idx(
+                    &self.data,
+                    &self.reader,
+                    &mut self.last_focused_root_id,
+                    &pid,
+                    None,
+                );
             } else {
                 let count = annotations.len();
+                let mut new_focus_idx: Option<usize> = Some(*focus);
                 match code {
-                    KeyCode::Esc => *annotation_focus = None,
+                    KeyCode::Esc => {
+                        *annotation_focus = None;
+                        new_focus_idx = None;
+                    }
                     KeyCode::Char('j') | KeyCode::Down => {
                         *focus = (*focus + 1).min(count - 1);
+                        new_focus_idx = Some(*focus);
                     }
                     KeyCode::Char('k') | KeyCode::Up => {
                         *focus = focus.saturating_sub(1);
+                        new_focus_idx = Some(*focus);
                     }
                     KeyCode::Char('e') => {
                         let target = &annotations[*focus];
@@ -892,13 +1004,30 @@ impl App {
                     }
                     _ => {}
                 }
+                focus_thread_by_annotation_idx(
+                    &self.data,
+                    &self.reader,
+                    &mut self.last_focused_root_id,
+                    &pid,
+                    new_focus_idx,
+                );
                 return;
             }
         }
 
         // Layer 3: scroll mode.
         match code {
-            KeyCode::Esc | KeyCode::Char('q') => self.overlay = None,
+            KeyCode::Esc | KeyCode::Char('q') => {
+                // Closing the PaperDetail overlay leaves whatever
+                // thread was last focused — mark it seen. (#185)
+                set_focused_thread(
+                    &self.data,
+                    &self.reader,
+                    &mut self.last_focused_root_id,
+                    None,
+                );
+                self.overlay = None;
+            }
             KeyCode::Char('j') | KeyCode::Down => *scroll = scroll.saturating_add(1),
             KeyCode::Char('k') | KeyCode::Up => *scroll = scroll.saturating_sub(1),
             KeyCode::Char('d') => *scroll = scroll.saturating_add(10),
@@ -919,6 +1048,13 @@ impl App {
                     .map_or(0, |a| a.len());
                 if count > 0 {
                     *annotation_focus = Some(0);
+                    focus_thread_by_annotation_idx(
+                        &self.data,
+                        &self.reader,
+                        &mut self.last_focused_root_id,
+                        &pid,
+                        Some(0),
+                    );
                 }
             }
             KeyCode::Char('R') => {
@@ -928,6 +1064,13 @@ impl App {
                 let count = crate::views::reader::highlight_count(&self.data, &pid);
                 *reader = true;
                 *highlight_focus = if count > 0 { Some(0) } else { None };
+                focus_thread_by_root_idx(
+                    &self.data,
+                    &self.reader,
+                    &mut self.last_focused_root_id,
+                    &pid,
+                    *highlight_focus,
+                );
             }
             KeyCode::Char('O') => {
                 // #144: open the locally downloaded file in the OS
@@ -1749,5 +1892,166 @@ mod tests {
             other => panic!("expected dashboard with prompt cleared, got {other:?}"),
         }
         assert!(app.status_toast.is_none(), "no toast on cancel");
+    }
+
+    // ---- #185 focus-leave plumbing ----
+
+    /// Seed an annotation thread (root + reply) on `p-attn` so the
+    /// focus-leave tests can assert mark_thread_seen actually clears
+    /// unread state.
+    fn seed_thread(db_path: &std::path::Path) -> (String, String) {
+        use scitadel_core::models::{Anchor, Annotation};
+        let db = scitadel_db::sqlite::Database::open(db_path).unwrap();
+        let repo = scitadel_db::sqlite::SqliteAnnotationRepository::new(db);
+        let root = Annotation::new_root(
+            PaperId::from("p-attn"),
+            "claude".into(),
+            "claim".into(),
+            Anchor {
+                quote: Some("Attention".into()),
+                ..Anchor::default()
+            },
+        );
+        repo.create(&root).unwrap();
+        let reply = Annotation::new_reply(&root, "claude".into(), "follow-up".into());
+        repo.create(&reply).unwrap();
+        (root.id.as_str().to_string(), reply.id.as_str().to_string())
+    }
+
+    /// First focus arrives: nothing was previously focused, so no
+    /// mark_seen happens. The new root is just remembered.
+    #[tokio::test(flavor = "current_thread")]
+    async fn focus_arrive_does_not_mark_seen_when_none_was_focused() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (mut app, _, _) = fixture(&tmp);
+        let (root_id, _) = seed_thread(&tmp.path().join("scitadel.db"));
+        // Pre: 2 unread for lars.
+        assert_eq!(app.data.load_unread_count("lars").unwrap(), 2);
+
+        set_focused_thread(
+            &app.data,
+            &app.reader,
+            &mut app.last_focused_root_id,
+            Some(root_id.clone()),
+        );
+        // Tracker advanced...
+        assert_eq!(app.last_focused_root_id, Some(root_id));
+        // ...but nothing got marked seen yet (focus-leave semantics:
+        // mark only when leaving the previous thread, and there was
+        // no previous).
+        assert_eq!(app.data.load_unread_count("lars").unwrap(), 2);
+    }
+
+    /// Focus-leave path: A → None marks A's thread seen.
+    #[tokio::test(flavor = "current_thread")]
+    async fn focus_leave_to_none_marks_previous_thread_seen() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (mut app, _, _) = fixture(&tmp);
+        let (root_id, _) = seed_thread(&tmp.path().join("scitadel.db"));
+
+        set_focused_thread(
+            &app.data,
+            &app.reader,
+            &mut app.last_focused_root_id,
+            Some(root_id),
+        );
+        assert_eq!(app.data.load_unread_count("lars").unwrap(), 2);
+
+        set_focused_thread(&app.data, &app.reader, &mut app.last_focused_root_id, None);
+        assert_eq!(
+            app.data.load_unread_count("lars").unwrap(),
+            0,
+            "focus-leave to None must mark the previous thread (root + replies) seen"
+        );
+        assert_eq!(app.last_focused_root_id, None);
+    }
+
+    /// Re-focusing the same thread is a no-op — no double-write, no
+    /// toggle, no spurious mark_seen of an unrelated thread.
+    #[tokio::test(flavor = "current_thread")]
+    async fn focus_same_root_is_idempotent_noop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (mut app, _, _) = fixture(&tmp);
+        let (root_id, _) = seed_thread(&tmp.path().join("scitadel.db"));
+
+        set_focused_thread(
+            &app.data,
+            &app.reader,
+            &mut app.last_focused_root_id,
+            Some(root_id.clone()),
+        );
+        // Calling again with the same root must NOT mark the focused
+        // thread seen on every call (would defeat focus-leave
+        // semantics) — it's a no-op.
+        set_focused_thread(
+            &app.data,
+            &app.reader,
+            &mut app.last_focused_root_id,
+            Some(root_id.clone()),
+        );
+        assert_eq!(app.data.load_unread_count("lars").unwrap(), 2);
+        assert_eq!(app.last_focused_root_id, Some(root_id));
+    }
+
+    /// Annotation-focus by reply index resolves to the reply's root,
+    /// so leaving the focus marks the whole thread seen.
+    #[tokio::test(flavor = "current_thread")]
+    async fn annotation_focus_on_reply_marks_root_thread_on_leave() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (mut app, _, _) = fixture(&tmp);
+        let (root_id, _reply_id) = seed_thread(&tmp.path().join("scitadel.db"));
+        // Annotations are ordered by created_at ASC: [root, reply].
+        // Index 1 is the reply; its parent_id points at root.
+        focus_thread_by_annotation_idx(
+            &app.data,
+            &app.reader,
+            &mut app.last_focused_root_id,
+            "p-attn",
+            Some(1),
+        );
+        assert_eq!(app.last_focused_root_id, Some(root_id.clone()));
+
+        // Now leave focus. Both root and reply should clear.
+        focus_thread_by_annotation_idx(
+            &app.data,
+            &app.reader,
+            &mut app.last_focused_root_id,
+            "p-attn",
+            None,
+        );
+        assert_eq!(app.data.load_unread_count("lars").unwrap(), 0);
+    }
+
+    /// Closing the PaperDetail overlay marks the focused thread seen,
+    /// driven through the real `handle_key` dispatch.
+    #[tokio::test(flavor = "current_thread")]
+    async fn closing_paper_detail_overlay_marks_focused_thread_seen() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (mut app, _, _) = fixture(&tmp);
+        let (_root_id, _) = seed_thread(&tmp.path().join("scitadel.db"));
+
+        // Open the PaperDetail overlay scrolled, then enter
+        // annotation-focus mode (`J`) to land focus on the root.
+        app.overlay = Some(Overlay::PaperDetail {
+            paper_id: "p-attn".into(),
+            scroll: 0,
+            annotation_focus: None,
+            prompt: None,
+            reader: false,
+            highlight_focus: None,
+        });
+        app.handle_key(KeyCode::Char('J'), KeyModifiers::NONE);
+        assert!(app.last_focused_root_id.is_some(), "J should focus root");
+
+        // Close the overlay. Esc out of annotation-focus first, then
+        // Esc closes the overlay.
+        app.handle_key(KeyCode::Esc, KeyModifiers::NONE);
+        app.handle_key(KeyCode::Esc, KeyModifiers::NONE);
+        assert!(app.overlay.is_none());
+        assert_eq!(
+            app.data.load_unread_count("lars").unwrap(),
+            0,
+            "overlay close must mark whatever thread was last focused as seen",
+        );
     }
 }

--- a/crates/scitadel-tui/src/data.rs
+++ b/crates/scitadel-tui/src/data.rs
@@ -126,6 +126,14 @@ impl DataStore {
         Ok(SqliteAnnotationRepository::new(self.db.clone()).papers_with_unread(reader)?)
     }
 
+    /// Every unread annotation across all papers for `reader`,
+    /// oldest-first per the underlying `list_unread` query. Used by
+    /// the inbox overlay (#185 P0) which then groups by paper for
+    /// display.
+    pub fn load_all_unread(&self, reader: &str) -> Result<Vec<Annotation>> {
+        Ok(SqliteAnnotationRepository::new(self.db.clone()).list_unread(reader, None)?)
+    }
+
     /// Mark a thread (root + replies) as seen by `reader`. Called from
     /// the TUI on focus-leave / overlay-close so the badge and
     /// `[unread]` markers clear without a manual action. (#185)

--- a/crates/scitadel-tui/src/data.rs
+++ b/crates/scitadel-tui/src/data.rs
@@ -105,6 +105,29 @@ impl DataStore {
         Ok(SqliteAnnotationRepository::new(self.db.clone()).list_by_paper(paper_id)?)
     }
 
+    /// Total annotations `reader` hasn't acknowledged across all papers.
+    /// Drives the status-bar `[N new]` badge — called every TUI draw,
+    /// so it goes through the SQL `COUNT(*)` rather than materialising
+    /// the rows. (#185)
+    pub fn load_unread_count(&self, reader: &str) -> Result<i64> {
+        Ok(SqliteAnnotationRepository::new(self.db.clone()).count_unread(reader, None)?)
+    }
+
+    /// Annotations `reader` hasn't acknowledged on a specific paper.
+    /// Used by the per-row `●` glyph in the Papers list and the
+    /// `[unread]` markers in the reader-view thread pane. (#185)
+    pub fn load_unread_for_paper(&self, reader: &str, paper_id: &str) -> Result<Vec<Annotation>> {
+        Ok(SqliteAnnotationRepository::new(self.db.clone()).list_unread(reader, Some(paper_id))?)
+    }
+
+    /// Mark a thread (root + replies) as seen by `reader`. Called from
+    /// the TUI on focus-leave / overlay-close so the badge and
+    /// `[unread]` markers clear without a manual action. (#185)
+    pub fn mark_thread_seen(&self, reader: &str, root_id: &str) -> Result<()> {
+        SqliteAnnotationRepository::new(self.db.clone()).mark_thread_seen(root_id, reader)?;
+        Ok(())
+    }
+
     /// Toggle the starred flag for a paper and return the new value.
     pub fn toggle_starred(&self, paper_id: &str, reader: &str) -> Result<bool> {
         Ok(SqlitePaperStateRepository::new(self.db.clone()).toggle_starred(paper_id, reader)?)
@@ -256,6 +279,15 @@ impl DataStore {
     /// paper IDs in DB order, the hydrated `Paper` rows, and a
     /// `paper_id → tags` map. Mirrors `load_shortlist` in `scitadel-cli`
     /// so the CLI and TUI surfaces produce byte-identical snapshots.
+    /// Test-only: construct a `DataStore` around an in-memory DB so
+    /// unread/mark-seen plumbing can be exercised without a temp dir.
+    #[cfg(test)]
+    fn for_tests() -> Self {
+        let db = Database::open_in_memory().expect("open in-memory db");
+        db.migrate().expect("migrate");
+        Self { db }
+    }
+
     pub fn load_snapshot_inputs(
         &self,
         question_id: &str,
@@ -282,5 +314,97 @@ impl DataStore {
             tags.insert(id.clone(), t);
         }
         Ok((paper_ids, papers, tags))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DataStore;
+    use scitadel_core::models::{Anchor, Paper, PaperId};
+    use scitadel_core::ports::PaperRepository;
+
+    fn save_paper(store: &DataStore, id: &str, title: &str) {
+        let (paper_repo, _, _, _, _) = store.db.repositories();
+        let mut p = Paper::new(title);
+        p.id = PaperId::from(id);
+        paper_repo.save(&p).unwrap();
+    }
+
+    #[test]
+    fn unread_count_zero_on_empty_db() {
+        let store = DataStore::for_tests();
+        assert_eq!(store.load_unread_count("lars").unwrap(), 0);
+    }
+
+    #[test]
+    fn unread_count_counts_root_and_replies_then_clears_after_mark_thread_seen() {
+        use scitadel_core::models::Annotation;
+        use scitadel_db::sqlite::SqliteAnnotationRepository;
+
+        let store = DataStore::for_tests();
+        save_paper(&store, "p-1", "T");
+        let repo = SqliteAnnotationRepository::new(store.db.clone());
+        let root = Annotation::new_root(
+            PaperId::from("p-1"),
+            "claude".into(),
+            "claim".into(),
+            Anchor {
+                quote: Some("Q".into()),
+                ..Anchor::default()
+            },
+        );
+        repo.create(&root).unwrap();
+        let reply = Annotation::new_reply(&root, "claude".into(), "follow".into());
+        repo.create(&reply).unwrap();
+
+        assert_eq!(store.load_unread_count("lars").unwrap(), 2);
+        assert_eq!(store.load_unread_for_paper("lars", "p-1").unwrap().len(), 2);
+
+        store.mark_thread_seen("lars", root.id.as_str()).unwrap();
+        assert_eq!(store.load_unread_count("lars").unwrap(), 0);
+        assert!(
+            store
+                .load_unread_for_paper("lars", "p-1")
+                .unwrap()
+                .is_empty()
+        );
+
+        // Other reader still sees them as unread.
+        assert_eq!(store.load_unread_count("alice").unwrap(), 2);
+    }
+
+    #[test]
+    fn unread_for_paper_scopes_correctly() {
+        use scitadel_core::models::Annotation;
+        use scitadel_db::sqlite::SqliteAnnotationRepository;
+
+        let store = DataStore::for_tests();
+        save_paper(&store, "p-a", "A");
+        save_paper(&store, "p-b", "B");
+        let repo = SqliteAnnotationRepository::new(store.db.clone());
+        let on_a = Annotation::new_root(
+            PaperId::from("p-a"),
+            "claude".into(),
+            "a-note".into(),
+            Anchor {
+                quote: Some("q".into()),
+                ..Anchor::default()
+            },
+        );
+        let on_b = Annotation::new_root(
+            PaperId::from("p-b"),
+            "claude".into(),
+            "b-note".into(),
+            Anchor {
+                quote: Some("q".into()),
+                ..Anchor::default()
+            },
+        );
+        repo.create(&on_a).unwrap();
+        repo.create(&on_b).unwrap();
+
+        assert_eq!(store.load_unread_for_paper("lars", "p-a").unwrap().len(), 1);
+        assert_eq!(store.load_unread_for_paper("lars", "p-b").unwrap().len(), 1);
+        assert_eq!(store.load_unread_count("lars").unwrap(), 2);
     }
 }

--- a/crates/scitadel-tui/src/data.rs
+++ b/crates/scitadel-tui/src/data.rs
@@ -288,11 +288,6 @@ impl DataStore {
         Ok(scitadel_db::sqlite::SqliteTuiStateRepository::new(self.db.clone()).set(state)?)
     }
 
-    /// Load the inputs needed by `scitadel_export::write_snapshot` for a
-    /// question + reader (#135 sub-feature B). Returns the shortlist's
-    /// paper IDs in DB order, the hydrated `Paper` rows, and a
-    /// `paper_id → tags` map. Mirrors `load_shortlist` in `scitadel-cli`
-    /// so the CLI and TUI surfaces produce byte-identical snapshots.
     /// Test-only: construct a `DataStore` around an in-memory DB so
     /// unread/mark-seen plumbing can be exercised without a temp dir.
     #[cfg(test)]
@@ -302,6 +297,11 @@ impl DataStore {
         Self { db }
     }
 
+    /// Load the inputs needed by `scitadel_export::write_snapshot` for a
+    /// question + reader (#135 sub-feature B). Returns the shortlist's
+    /// paper IDs in DB order, the hydrated `Paper` rows, and a
+    /// `paper_id → tags` map. Mirrors `load_shortlist` in `scitadel-cli`
+    /// so the CLI and TUI surfaces produce byte-identical snapshots.
     pub fn load_snapshot_inputs(
         &self,
         question_id: &str,

--- a/crates/scitadel-tui/src/data.rs
+++ b/crates/scitadel-tui/src/data.rs
@@ -129,7 +129,6 @@ impl DataStore {
     /// Mark a thread (root + replies) as seen by `reader`. Called from
     /// the TUI on focus-leave / overlay-close so the badge and
     /// `[unread]` markers clear without a manual action. (#185)
-    #[allow(dead_code)] // wired up in commit C4 of this branch
     pub fn mark_thread_seen(&self, reader: &str, root_id: &str) -> Result<()> {
         SqliteAnnotationRepository::new(self.db.clone()).mark_thread_seen(root_id, reader)?;
         Ok(())

--- a/crates/scitadel-tui/src/data.rs
+++ b/crates/scitadel-tui/src/data.rs
@@ -120,9 +120,16 @@ impl DataStore {
         Ok(SqliteAnnotationRepository::new(self.db.clone()).list_unread(reader, Some(paper_id))?)
     }
 
+    /// Set of paper IDs `reader` has at least one unread annotation
+    /// on. Drives the per-row `●` glyph in the Papers list. (#185)
+    pub fn load_papers_with_unread(&self, reader: &str) -> Result<HashSet<String>> {
+        Ok(SqliteAnnotationRepository::new(self.db.clone()).papers_with_unread(reader)?)
+    }
+
     /// Mark a thread (root + replies) as seen by `reader`. Called from
     /// the TUI on focus-leave / overlay-close so the badge and
     /// `[unread]` markers clear without a manual action. (#185)
+    #[allow(dead_code)] // wired up in commit C4 of this branch
     pub fn mark_thread_seen(&self, reader: &str, root_id: &str) -> Result<()> {
         SqliteAnnotationRepository::new(self.db.clone()).mark_thread_seen(root_id, reader)?;
         Ok(())

--- a/crates/scitadel-tui/src/views/inbox.rs
+++ b/crates/scitadel-tui/src/views/inbox.rs
@@ -1,0 +1,430 @@
+//! Inbox overlay (#185 P0): a flat list of every unread annotation
+//! grouped by paper, sorted thread-major (root first, then its
+//! replies). Drives the `[N new]` status-bar badge to a concrete
+//! action — the user presses `U`, sees what's new, presses Enter to
+//! jump to the paper reader focused on the thread.
+//!
+//! Closed via `Esc` / `q` / `U` (toggle).
+
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph};
+use std::collections::HashMap;
+
+use scitadel_core::models::{Annotation, Paper};
+
+use crate::data::DataStore;
+
+/// One row in the inbox — either a paper header or an annotation under it.
+/// Headers are non-selectable and don't carry a paper_id payload that
+/// would let the user "jump" to anything different than picking the
+/// first unread row under the header. Kept distinct so the index
+/// passed back to `app.rs` (the cursor) maps cleanly.
+#[derive(Debug, Clone)]
+pub enum InboxItem {
+    /// Paper-level header. Not selectable (selection skips it).
+    /// `paper_id` is kept on the variant so future PRs that add a
+    /// "mark all in this paper as read" action have a target without
+    /// needing to walk back through the rows beneath the header.
+    Header {
+        #[allow(dead_code)]
+        paper_id: String,
+        title: String,
+        count: usize,
+    },
+    /// Selectable row representing an unread annotation. `paper_id`
+    /// + `root_id` are the jump target.
+    Row {
+        paper_id: String,
+        root_id: String,
+        author: String,
+        note_preview: String,
+        is_reply: bool,
+    },
+}
+
+impl InboxItem {
+    pub fn is_selectable(&self) -> bool {
+        matches!(self, InboxItem::Row { .. })
+    }
+}
+
+/// Build the flat thread-major item list from every unread annotation
+/// for `reader`. Pure function over the loaded data so it's
+/// unit-testable without a Frame.
+pub fn build_items(unread: &[Annotation], papers: &HashMap<String, Paper>) -> Vec<InboxItem> {
+    use std::collections::BTreeMap;
+    // Group by paper_id, preserving insertion order (BTreeMap by
+    // paper_id keeps the output deterministic across runs even when
+    // SQLite returns equal-`created_at` rows in unspecified order).
+    let mut by_paper: BTreeMap<String, Vec<&Annotation>> = BTreeMap::new();
+    for a in unread {
+        by_paper
+            .entry(a.paper_id.as_str().to_string())
+            .or_default()
+            .push(a);
+    }
+
+    let mut items = Vec::new();
+    for (paper_id, anns) in &by_paper {
+        let title = papers
+            .get(paper_id)
+            .map_or_else(|| paper_id.clone(), |p| p.title.clone());
+        items.push(InboxItem::Header {
+            paper_id: paper_id.clone(),
+            title,
+            count: anns.len(),
+        });
+        // Thread-major: roots first, then their replies, in created_at
+        // order (which is what `list_unread` already guarantees).
+        let roots: Vec<&&Annotation> = anns.iter().filter(|a| !a.is_reply()).collect();
+        for root in roots {
+            items.push(InboxItem::Row {
+                paper_id: paper_id.clone(),
+                root_id: root.id.as_str().to_string(),
+                author: root.author.clone(),
+                note_preview: preview(&root.note, 60),
+                is_reply: false,
+            });
+            for ann in anns.iter().filter(|a| {
+                a.parent_id
+                    .as_ref()
+                    .is_some_and(|p| p.as_str() == root.id.as_str())
+            }) {
+                items.push(InboxItem::Row {
+                    paper_id: paper_id.clone(),
+                    root_id: root.id.as_str().to_string(),
+                    author: ann.author.clone(),
+                    note_preview: preview(&ann.note, 60),
+                    is_reply: true,
+                });
+            }
+        }
+        // Orphan replies: parent is not in the unread set (e.g. user
+        // already saw the root and only the reply is fresh). Surface
+        // them under their parent_id as the root.
+        let live_root_ids: std::collections::HashSet<&str> = anns
+            .iter()
+            .filter(|a| !a.is_reply())
+            .map(|a| a.id.as_str())
+            .collect();
+        for orphan in anns.iter().filter(|a| {
+            a.is_reply()
+                && a.parent_id
+                    .as_ref()
+                    .is_some_and(|p| !live_root_ids.contains(p.as_str()))
+        }) {
+            let root_id = orphan
+                .parent_id
+                .as_ref()
+                .map_or(orphan.id.as_str().to_string(), |p| p.as_str().to_string());
+            items.push(InboxItem::Row {
+                paper_id: paper_id.clone(),
+                root_id,
+                author: orphan.author.clone(),
+                note_preview: preview(&orphan.note, 60),
+                is_reply: true,
+            });
+        }
+    }
+    items
+}
+
+fn preview(note: &str, n: usize) -> String {
+    let cleaned: String = note.replace(['\n', '\r'], " ");
+    if cleaned.chars().count() <= n {
+        cleaned
+    } else {
+        let head: String = cleaned.chars().take(n.saturating_sub(1)).collect();
+        format!("{head}…")
+    }
+}
+
+/// Reload the inbox state from the DB. Returned items match what
+/// `draw` will render; the caller stores them on the overlay so the
+/// jump action can resolve `selected` → `(paper_id, root_id)`.
+pub fn load(data: &DataStore, reader: &str) -> Vec<InboxItem> {
+    let unread = data.load_all_unread(reader).unwrap_or_default();
+    // Hydrate paper titles. The distinct-paper count is bounded by
+    // the size of `unread` (typically tens, never thousands).
+    let mut papers: HashMap<String, Paper> = HashMap::new();
+    for a in &unread {
+        let pid = a.paper_id.as_str();
+        // `map_entry` doesn't apply: we want to skip the insert when
+        // load_paper returns None (paper deleted out from under us),
+        // which `or_insert_with` can't express cleanly.
+        #[allow(clippy::map_entry)]
+        if !papers.contains_key(pid)
+            && let Ok(Some(p)) = data.load_paper(pid)
+        {
+            papers.insert(pid.to_string(), p);
+        }
+    }
+    build_items(&unread, &papers)
+}
+
+/// Move the inbox cursor `delta` selectable rows from `current`. Skips
+/// over `Header` items so j/k feel natural. Returns the new index;
+/// returns `current` unchanged if no selectable rows exist or the
+/// cursor would walk off either end.
+pub fn step_selection(items: &[InboxItem], current: usize, delta: isize) -> usize {
+    if items.iter().all(|i| !i.is_selectable()) {
+        return current;
+    }
+    let mut idx = current as isize;
+    let n = items.len() as isize;
+    let dir = if delta > 0 { 1 } else { -1 };
+    let mut steps = delta.unsigned_abs();
+    while steps > 0 {
+        let next = idx + dir;
+        if next < 0 || next >= n {
+            break;
+        }
+        idx = next;
+        if items[idx as usize].is_selectable() {
+            steps -= 1;
+        }
+    }
+    // Snap to a selectable row if `current` was on a header.
+    if !items[idx as usize].is_selectable() {
+        for (i, it) in items.iter().enumerate() {
+            if it.is_selectable() {
+                idx = i as isize;
+                break;
+            }
+        }
+    }
+    idx as usize
+}
+
+/// Resolve the cursor `selected` to a jump target — the
+/// `(paper_id, root_id)` of the focused row. None if the cursor is
+/// on a header or the inbox is empty.
+pub fn jump_target(items: &[InboxItem], selected: usize) -> Option<(String, String)> {
+    match items.get(selected) {
+        Some(InboxItem::Row {
+            paper_id, root_id, ..
+        }) => Some((paper_id.clone(), root_id.clone())),
+        _ => None,
+    }
+}
+
+pub fn draw(frame: &mut Frame, area: Rect, items: &[InboxItem], selected: usize) {
+    // Clear under the overlay so the underlying view doesn't bleed
+    // through the borders.
+    frame.render_widget(Clear, area);
+
+    let block = Block::default()
+        .title(format!(" Inbox — {} unread ", count_rows(items)))
+        .borders(Borders::ALL);
+
+    if items.is_empty() {
+        let empty = Paragraph::new("Nothing unread. ✓").block(block);
+        frame.render_widget(empty, area);
+        return;
+    }
+
+    let lines: Vec<ListItem<'_>> = items
+        .iter()
+        .map(|it| match it {
+            InboxItem::Header { title, count, .. } => {
+                ListItem::new(Line::from(vec![Span::styled(
+                    format!(" {title}  [{count}]"),
+                    Style::default()
+                        .fg(crate::theme::theme().emphasis)
+                        .add_modifier(Modifier::BOLD),
+                )]))
+            }
+            InboxItem::Row {
+                author,
+                note_preview,
+                is_reply,
+                ..
+            } => {
+                let prefix = if *is_reply { "    └ " } else { "    ● " };
+                ListItem::new(Line::from(vec![
+                    Span::raw(prefix),
+                    Span::styled(
+                        format!("{author}: "),
+                        Style::default().fg(crate::theme::theme().emphasis),
+                    ),
+                    Span::raw(note_preview.clone()),
+                ]))
+            }
+        })
+        .collect();
+
+    let list = List::new(lines).block(block).highlight_style(
+        Style::default()
+            .bg(crate::theme::theme().selection_bg)
+            .add_modifier(Modifier::BOLD),
+    );
+
+    let mut state = ListState::default();
+    state.select(Some(selected));
+    frame.render_stateful_widget(list, area, &mut state);
+}
+
+fn count_rows(items: &[InboxItem]) -> usize {
+    items.iter().filter(|i| i.is_selectable()).count()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use scitadel_core::models::{Anchor, AnnotationId, PaperId};
+
+    fn root_at(paper_id: &str, id: &str, note: &str) -> Annotation {
+        let mut a = Annotation::new_root(
+            PaperId::from(paper_id),
+            "claude".into(),
+            note.into(),
+            Anchor {
+                quote: Some("Q".into()),
+                ..Anchor::default()
+            },
+        );
+        a.id = AnnotationId::from(id.to_string());
+        a
+    }
+
+    fn reply_to(parent: &Annotation, id: &str, note: &str) -> Annotation {
+        let mut a = Annotation::new_reply(parent, "claude".into(), note.into());
+        a.id = AnnotationId::from(id.to_string());
+        a
+    }
+
+    fn paper(id: &str, title: &str) -> (String, Paper) {
+        let mut p = Paper::new(title);
+        p.id = PaperId::from(id);
+        (id.to_string(), p)
+    }
+
+    #[test]
+    fn build_items_groups_by_paper_and_preserves_thread_order() {
+        let r1 = root_at("p-a", "ann-r1", "first claim");
+        let rep1 = reply_to(&r1, "ann-rep1", "follow-up");
+        let r2 = root_at("p-a", "ann-r2", "second claim");
+        let r3 = root_at("p-b", "ann-r3", "other paper claim");
+        let unread = vec![r1, rep1, r2, r3];
+        let papers = [paper("p-a", "Alpha"), paper("p-b", "Beta")]
+            .into_iter()
+            .collect();
+
+        let items = build_items(&unread, &papers);
+        // Expected: header(p-a), row(r1), row(rep1), row(r2), header(p-b), row(r3)
+        assert_eq!(items.len(), 6);
+        match &items[0] {
+            InboxItem::Header { title, count, .. } => {
+                assert_eq!(title, "Alpha");
+                assert_eq!(*count, 3);
+            }
+            InboxItem::Row { .. } => panic!("expected p-a header"),
+        }
+        match &items[1] {
+            InboxItem::Row {
+                root_id, is_reply, ..
+            } => {
+                assert_eq!(root_id, "ann-r1");
+                assert!(!is_reply);
+            }
+            InboxItem::Header { .. } => panic!("expected r1 row"),
+        }
+        match &items[2] {
+            InboxItem::Row {
+                root_id, is_reply, ..
+            } => {
+                assert_eq!(root_id, "ann-r1", "reply carries root_id");
+                assert!(is_reply);
+            }
+            InboxItem::Header { .. } => panic!("expected reply row"),
+        }
+    }
+
+    #[test]
+    fn step_selection_skips_headers() {
+        // Layout: H, R, R, H, R
+        let r1 = root_at("p-a", "ann-1", "x");
+        let r2 = root_at("p-a", "ann-2", "y");
+        let r3 = root_at("p-b", "ann-3", "z");
+        let unread = vec![r1, r2, r3];
+        let papers = [paper("p-a", "A"), paper("p-b", "B")].into_iter().collect();
+        let items = build_items(&unread, &papers);
+
+        // Start at first selectable (idx 1 — first row under p-a header).
+        // Step +1 → should land on idx 2 (second p-a row), not on the
+        // p-b header at idx 3.
+        let next = step_selection(&items, 1, 1);
+        assert_eq!(next, 2);
+        // Step +1 again from idx 2 → must skip the header at 3 and
+        // land on the row at 4.
+        let next = step_selection(&items, 2, 1);
+        assert_eq!(next, 4);
+        // Step +1 from the last row stays put (clamped).
+        let next = step_selection(&items, 4, 1);
+        assert_eq!(next, 4);
+        // Step -1 from idx 4 hops back to idx 2 (skipping header).
+        let next = step_selection(&items, 4, -1);
+        assert_eq!(next, 2);
+    }
+
+    #[test]
+    fn jump_target_returns_paper_and_root_for_row() {
+        let r = root_at("p-a", "ann-r1", "n");
+        let items = build_items(&[r], &[paper("p-a", "Alpha")].into_iter().collect());
+        // Header at idx 0, row at idx 1.
+        assert_eq!(jump_target(&items, 0), None);
+        assert_eq!(
+            jump_target(&items, 1),
+            Some(("p-a".into(), "ann-r1".into()))
+        );
+        // Out-of-range cursor.
+        assert_eq!(jump_target(&items, 99), None);
+    }
+
+    #[test]
+    fn jump_target_for_reply_resolves_to_root() {
+        let r = root_at("p-a", "ann-r1", "n");
+        let rep = reply_to(&r, "ann-rep1", "f");
+        let items = build_items(&[r, rep], &[paper("p-a", "Alpha")].into_iter().collect());
+        // Header(0), root(1), reply(2). Reply must report the root.
+        assert_eq!(
+            jump_target(&items, 2),
+            Some(("p-a".into(), "ann-r1".into()))
+        );
+    }
+
+    #[test]
+    fn build_items_orphan_reply_uses_parent_id_as_root() {
+        // The user already saw the root, so it's NOT in unread.
+        // Only the new reply remains. We still want the jump to land
+        // on the root by id.
+        let placeholder_root = root_at("p-a", "ann-orphan-root", "x");
+        let orphan_reply = reply_to(&placeholder_root, "ann-rep", "fresh reply");
+        let items = build_items(
+            &[orphan_reply],
+            &[paper("p-a", "Alpha")].into_iter().collect(),
+        );
+        // Header + reply row.
+        assert_eq!(items.len(), 2);
+        assert_eq!(
+            jump_target(&items, 1),
+            Some(("p-a".into(), "ann-orphan-root".into()))
+        );
+    }
+
+    #[test]
+    fn preview_truncates_with_ellipsis() {
+        let s: String = "a".repeat(100);
+        let p = preview(&s, 20);
+        assert_eq!(p.chars().count(), 20);
+        assert!(p.ends_with('…'));
+    }
+
+    #[test]
+    fn preview_replaces_newlines() {
+        assert_eq!(preview("line one\nline two", 100), "line one line two");
+    }
+}

--- a/crates/scitadel-tui/src/views/inbox.rs
+++ b/crates/scitadel-tui/src/views/inbox.rs
@@ -424,6 +424,40 @@ mod tests {
     }
 
     #[test]
+    fn step_selection_with_zero_delta_snaps_off_header_to_first_row() {
+        // Mirrors the per-tick-rebuild clamp path in app::draw: when an
+        // item is removed mid-tick (e.g. the row the cursor was on
+        // gets marked seen by another reader), `selected.min(max)` may
+        // land the cursor on a header. `step_selection(items, sel, 0)`
+        // is the snap that pushes it forward to the next selectable
+        // row without moving the user any further than necessary.
+        let r1 = root_at("p-a", "ann-1", "x");
+        let r2 = root_at("p-b", "ann-2", "y");
+        let unread = vec![r1, r2];
+        let papers = [paper("p-a", "A"), paper("p-b", "B")].into_iter().collect();
+        let items = build_items(&unread, &papers);
+        // Layout: H, R, H, R. Cursor on idx 0 (header) → snap to 1.
+        assert_eq!(step_selection(&items, 0, 0), 1);
+        // Cursor on idx 2 (header) → snap forward in the same direction
+        // would land on 3, but step_selection's snap goes to the FIRST
+        // selectable, which is 1. That's an acceptable behaviour: a
+        // cursor that ended up on a header gets normalised to a known
+        // good position rather than jumping unpredictably.
+        assert_eq!(step_selection(&items, 2, 0), 1);
+        // Cursor on a row (idx 1) is already selectable — no-op.
+        assert_eq!(step_selection(&items, 1, 0), 1);
+    }
+
+    #[test]
+    fn step_selection_on_empty_returns_input() {
+        let items: Vec<InboxItem> = Vec::new();
+        // Pre-rebuild cursor of 5 stays put when items is empty —
+        // nothing to clamp against. Caller is responsible for the
+        // `min(max)` clamp before calling step_selection.
+        assert_eq!(step_selection(&items, 5, 0), 5);
+    }
+
+    #[test]
     fn preview_replaces_newlines() {
         assert_eq!(preview("line one\nline two", 100), "line one line two");
     }

--- a/crates/scitadel-tui/src/views/mod.rs
+++ b/crates/scitadel-tui/src/views/mod.rs
@@ -2,6 +2,7 @@ pub mod annotation_prompt;
 pub mod bib_export_prompt;
 pub mod dashboard;
 pub mod detail;
+pub mod inbox;
 pub mod papers;
 pub mod questions;
 pub mod queue;

--- a/crates/scitadel-tui/src/views/papers.rs
+++ b/crates/scitadel-tui/src/views/papers.rs
@@ -10,6 +10,7 @@ use scitadel_core::models::{DownloadStatus, Paper};
 use crate::data::DataStore;
 use crate::views::util::truncate;
 
+#[allow(clippy::too_many_arguments)]
 pub fn draw(
     frame: &mut Frame,
     area: Rect,
@@ -17,6 +18,7 @@ pub fn draw(
     selected: usize,
     starred: &HashSet<String>,
     downloading: &HashSet<String>,
+    papers_with_unread: &HashSet<String>,
 ) {
     let papers = data.load_papers(1000, 0).unwrap_or_default();
     render_paper_table(
@@ -27,9 +29,11 @@ pub fn draw(
         " Papers ",
         starred,
         downloading,
+        papers_with_unread,
     );
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn draw_for_search(
     frame: &mut Frame,
     area: Rect,
@@ -38,13 +42,23 @@ pub fn draw_for_search(
     selected: usize,
     starred: &HashSet<String>,
     downloading: &HashSet<String>,
+    papers_with_unread: &HashSet<String>,
 ) {
     let papers = data.load_papers_for_search(search_id).unwrap_or_default();
     let title = format!(
         " Papers for search {} ",
         search_id.chars().take(8).collect::<String>()
     );
-    render_paper_table(frame, area, &papers, selected, &title, starred, downloading);
+    render_paper_table(
+        frame,
+        area,
+        &papers,
+        selected,
+        &title,
+        starred,
+        downloading,
+        papers_with_unread,
+    );
 }
 
 /// Returns (symbol, color) for the Papers-table state column.
@@ -63,6 +77,7 @@ fn download_cell(paper: &Paper, downloading: &HashSet<String>) -> (&'static str,
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn render_paper_table(
     frame: &mut Frame,
     area: Rect,
@@ -71,6 +86,7 @@ fn render_paper_table(
     title: &str,
     starred: &HashSet<String>,
     downloading: &HashSet<String>,
+    papers_with_unread: &HashSet<String>,
 ) {
     if papers.is_empty() {
         let block = Block::default()
@@ -83,6 +99,7 @@ fn render_paper_table(
 
     let header = Row::new(vec![
         Cell::from("#"),
+        Cell::from(""),
         Cell::from(""),
         Cell::from(""),
         Cell::from("Title"),
@@ -106,11 +123,17 @@ fn render_paper_table(
             } else {
                 " "
             };
+            let unread = if papers_with_unread.contains(p.id.as_str()) {
+                "●"
+            } else {
+                " "
+            };
             let (dl_symbol, dl_color) = download_cell(p, downloading);
 
             Row::new(vec![
                 Cell::from((i + 1).to_string()),
                 Cell::from(star).style(Style::default().fg(crate::theme::theme().emphasis)),
+                Cell::from(unread).style(Style::default().fg(crate::theme::theme().emphasis)),
                 Cell::from(dl_symbol).style(Style::default().fg(dl_color)),
                 Cell::from(truncate(&p.title, 60)),
                 Cell::from(truncate(&authors, 30)),
@@ -121,6 +144,7 @@ fn render_paper_table(
 
     let widths = [
         Constraint::Length(5),
+        Constraint::Length(2),
         Constraint::Length(2),
         Constraint::Length(2),
         Constraint::Min(30),

--- a/crates/scitadel-tui/src/views/reader.rs
+++ b/crates/scitadel-tui/src/views/reader.rs
@@ -26,7 +26,14 @@ use scitadel_core::models::Annotation;
 // annotation-background tints swappable alongside the rest of the UI
 // when light-mode / auto-detect ships in #137.
 
-pub fn draw(frame: &mut Frame, area: Rect, data: &DataStore, paper_id: &str, focus: Option<usize>) {
+pub fn draw(
+    frame: &mut Frame,
+    area: Rect,
+    data: &DataStore,
+    paper_id: &str,
+    focus: Option<usize>,
+    reader: &str,
+) {
     let Ok(Some(paper)) = data.load_paper(paper_id) else {
         let block = Block::default().title(" Reader ").borders(Borders::ALL);
         let msg = Paragraph::new("Paper not found.").block(block);
@@ -39,6 +46,14 @@ pub fn draw(frame: &mut Frame, area: Rect, data: &DataStore, paper_id: &str, foc
         .unwrap_or_default();
     // Roots only on the left pane — replies don't carry their own anchor.
     let roots: Vec<&Annotation> = annotations.iter().filter(|a| !a.is_reply()).collect();
+    // Set of annotation IDs `reader` hasn't acknowledged yet, used by
+    // the right-pane to render `[unread]` markers per row. (#185)
+    let unread: std::collections::HashSet<String> = data
+        .load_unread_for_paper(reader, paper_id)
+        .unwrap_or_default()
+        .into_iter()
+        .map(|a| a.id.as_str().to_string())
+        .collect();
 
     let body = paper
         .full_text
@@ -66,7 +81,7 @@ pub fn draw(frame: &mut Frame, area: Rect, data: &DataStore, paper_id: &str, foc
         .split(area);
 
     draw_text_pane(frame, chunks[0], &paper.title, body, &roots, focus);
-    draw_notes_pane(frame, chunks[1], &annotations, &roots, focus);
+    draw_notes_pane(frame, chunks[1], &annotations, &roots, focus, &unread);
 }
 
 fn draw_text_pane(
@@ -95,8 +110,17 @@ fn draw_notes_pane(
     annotations: &[Annotation],
     roots: &[&Annotation],
     focus: Option<usize>,
+    unread: &std::collections::HashSet<String>,
 ) {
     let mut lines: Vec<Line<'_>> = Vec::new();
+    let unread_span = || {
+        Span::styled(
+            "  [unread]",
+            Style::default()
+                .fg(crate::theme::theme().emphasis)
+                .add_modifier(Modifier::BOLD),
+        )
+    };
     for (idx, root) in roots.iter().enumerate() {
         let color = color_for(root.id.as_str());
         let is_focused = focus == Some(idx);
@@ -129,26 +153,34 @@ fn draw_notes_pane(
                 ),
             ]));
         }
-        lines.push(Line::from(format!(
+        let mut root_meta = vec![Span::raw(format!(
             "    {} ({}): {}",
             root.author,
             root.created_at.format("%Y-%m-%d"),
             root.note
-        )));
+        ))];
+        if unread.contains(root.id.as_str()) {
+            root_meta.push(unread_span());
+        }
+        lines.push(Line::from(root_meta));
         // Replies threaded under the root.
         for ann in annotations.iter().filter(|a| {
             a.parent_id
                 .as_ref()
                 .is_some_and(|p| p.as_str() == root.id.as_str())
         }) {
-            lines.push(Line::from(vec![
+            let mut spans = vec![
                 Span::raw("    └ "),
                 Span::styled(
                     format!("{}: ", ann.author),
                     Style::default().fg(crate::theme::theme().emphasis),
                 ),
                 Span::raw(ann.note.clone()),
-            ]));
+            ];
+            if unread.contains(ann.id.as_str()) {
+                spans.push(unread_span());
+            }
+            lines.push(Line::from(spans));
         }
         lines.push(Line::from(""));
     }

--- a/crates/scitadel-tui/src/widgets/status_bar.rs
+++ b/crates/scitadel-tui/src/widgets/status_bar.rs
@@ -4,11 +4,27 @@ use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 
-pub fn draw(frame: &mut Frame, area: Rect, help_text: &str, offline: bool) {
-    let mut spans = Vec::with_capacity(3);
+pub fn draw(frame: &mut Frame, area: Rect, help_text: &str, offline: bool, unread_count: i64) {
+    let bar = Paragraph::new(Line::from(build_spans(help_text, offline, unread_count)));
+    frame.render_widget(bar, area);
+}
+
+/// Build the status-bar spans without rendering. Factored out so the
+/// composition (which badges show, in which order) is unit-testable
+/// without a Frame.
+fn build_spans(help_text: &str, offline: bool, unread_count: i64) -> Vec<Span<'static>> {
+    let mut spans = Vec::with_capacity(4);
     if offline {
         spans.push(Span::styled(
             "[OFFLINE] ",
+            Style::default()
+                .fg(crate::theme::theme().emphasis)
+                .add_modifier(Modifier::BOLD),
+        ));
+    }
+    if unread_count > 0 {
+        spans.push(Span::styled(
+            format!("[{unread_count} new] "),
             Style::default()
                 .fg(crate::theme::theme().emphasis)
                 .add_modifier(Modifier::BOLD),
@@ -18,6 +34,59 @@ pub fn draw(frame: &mut Frame, area: Rect, help_text: &str, offline: bool) {
         help_text.to_string(),
         Style::default().fg(crate::theme::theme().muted),
     ));
-    let bar = Paragraph::new(Line::from(spans));
-    frame.render_widget(bar, area);
+    spans
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_spans;
+
+    fn texts(spans: &[ratatui::text::Span<'_>]) -> Vec<String> {
+        spans.iter().map(|s| s.content.to_string()).collect()
+    }
+
+    #[test]
+    fn no_badges_when_quiet() {
+        let spans = build_spans("[q] quit", false, 0);
+        assert_eq!(texts(&spans), vec!["[q] quit".to_string()]);
+    }
+
+    #[test]
+    fn offline_badge_renders_before_help() {
+        let spans = build_spans("[q] quit", true, 0);
+        assert_eq!(
+            texts(&spans),
+            vec!["[OFFLINE] ".to_string(), "[q] quit".into()]
+        );
+    }
+
+    #[test]
+    fn unread_badge_renders_when_positive() {
+        let spans = build_spans("[q] quit", false, 3);
+        assert_eq!(
+            texts(&spans),
+            vec!["[3 new] ".to_string(), "[q] quit".into()]
+        );
+    }
+
+    #[test]
+    fn offline_then_unread_then_help_in_that_order() {
+        let spans = build_spans("[q] quit", true, 7);
+        assert_eq!(
+            texts(&spans),
+            vec![
+                "[OFFLINE] ".to_string(),
+                "[7 new] ".into(),
+                "[q] quit".into(),
+            ]
+        );
+    }
+
+    #[test]
+    fn negative_or_zero_unread_is_hidden() {
+        // count_unread can't actually return a negative, but the type
+        // is i64 so be defensive — `[-1 new]` would be ugly.
+        let spans = build_spans("[q] quit", false, -5);
+        assert_eq!(texts(&spans), vec!["[q] quit".to_string()]);
+    }
 }

--- a/tests/vhs/tui-inbox.tape
+++ b/tests/vhs/tui-inbox.tape
@@ -1,0 +1,81 @@
+# VHS tape: status-bar [N new] badge, papers-list ● glyph,
+# inbox overlay (U), and Enter-to-jump (#185 P0).
+#
+# Seeds a paper + a root annotation + a reply via sqlite3 so the
+# unread state is non-zero on first launch. Exercises:
+#   1. [N new] badge in the status bar
+#   2. ● glyph on the Papers row
+#   3. U opens the inbox overlay
+#   4. Enter jumps to two-pane reader focused on the thread
+#   5. Esc out → focus-leave clears the badge
+
+Output "tests/vhs/snapshots/tui-inbox/run.gif"
+
+Set Shell "bash"
+Set FontSize 14
+Set Width 1400
+Set Height 900
+Set Padding 10
+Set TypingSpeed 40ms
+
+Hide
+Type `export PATH="$PWD/target/release:$HOME/.cargo/bin:$PATH"`
+Enter
+Type `export PS1="$ "`
+Enter
+Type `export SCITADEL_DB=$(mktemp -d)/scitadel.db`
+Enter
+Type "scitadel init --yes --email demo@example.org --sources arxiv --db $SCITADEL_DB"
+Enter
+Sleep 800ms
+
+# Seed: one paper + a root annotation with a reply, both authored by
+# `claude` so they're unread for the default reader (`lars`). The two
+# rows mean the badge reads `[2 new]` and the inbox lists one thread
+# with one reply under it.
+Type `sqlite3 $SCITADEL_DB "INSERT INTO papers (id, title, authors, year, abstract, created_at, updated_at) VALUES ('p-attn', 'Attention Is All You Need', '[\"Vaswani, A.\"]', 2017, 'The dominant sequence transduction models are based on complex recurrent or convolutional neural networks.', datetime('now'), datetime('now'));"`
+Enter
+Sleep 200ms
+Type `sqlite3 $SCITADEL_DB "INSERT INTO annotations (id, paper_id, quote, anchor_status, note, tags_json, author, created_at, updated_at) VALUES ('ann-root-1', 'p-attn', 'Attention', 'ok', 'Why is multi-head better than single?', '[\"transformer\"]', 'claude', datetime('now'), datetime('now'));"`
+Enter
+Sleep 200ms
+Type `sqlite3 $SCITADEL_DB "INSERT INTO annotations (id, parent_id, paper_id, anchor_status, note, tags_json, author, created_at, updated_at) VALUES ('ann-reply-1', 'ann-root-1', 'p-attn', 'ok', 'See section 3.2.2 — parallel subspaces.', '[]', 'claude', datetime('now', '+1 second'), datetime('now', '+1 second'));"`
+Enter
+Sleep 300ms
+Type "clear"
+Enter
+Show
+
+Type "scitadel tui"
+Enter
+Sleep 1500ms
+# Status bar should show `[2 new]`.
+Screenshot "tests/vhs/snapshots/tui-inbox/01-badge-on-launch.png"
+
+# Tab → Papers tab so the ● glyph row is visible.
+Tab
+Sleep 500ms
+Screenshot "tests/vhs/snapshots/tui-inbox/02-papers-list-with-bullet.png"
+
+# U → Inbox overlay opens with the thread + reply listed under the
+# paper title.
+Type "U"
+Sleep 800ms
+Screenshot "tests/vhs/snapshots/tui-inbox/03-inbox-open.png"
+
+# Enter → jump to two-pane reader focused on the thread.
+Enter
+Sleep 1s
+Screenshot "tests/vhs/snapshots/tui-inbox/04-reader-focused-on-thread.png"
+
+# Esc out of the reader, then Esc to close the overlay. The
+# focus-leave path marks both root + reply as seen, so the badge
+# should clear and the ● glyph on the Papers row should disappear.
+Escape
+Sleep 300ms
+Escape
+Sleep 800ms
+Screenshot "tests/vhs/snapshots/tui-inbox/05-badge-cleared.png"
+
+Type "q"
+Sleep 400ms


### PR DESCRIPTION
## Summary

Closes the "TUI consumes unread state" P0 of #185 — the big missing half. Before this PR, MCP-side annotation writes were invisible to the human until they happened to open the right paper. Now:

- Status bar shows \`[N new]\` whenever there's anything unread for the current reader
- Papers list rows get a \`●\` glyph for any paper with unread annotations
- Reader two-pane right side shows \`[unread]\` after every unread root + reply line
- \`U\` opens the inbox overlay listing every unread item grouped by paper, thread-major; Enter jumps to the paper reader focused on the chosen thread
- Focus-leave + overlay-close call \`mark_thread_seen\` so the badge/glyphs/markers clear without a manual action — the explicit "currently never called" gap from the issue

DB layer adds \`count_unread(reader, paper_id?)\` and \`papers_with_unread(reader)\` so per-tick state refresh is two indexed queries, not a row materialisation.

## Commits

1. \`f9eefd4\` DB \`count_unread\` / \`papers_with_unread\` + DataStore wrappers
2. \`e2ac5bb\` status-bar \`[N new]\` badge
3. \`357bdf9\` per-row \`●\` glyph + per-thread \`[unread]\` markers
4. \`c4af121\` \`mark_thread_seen\` on focus-leave + overlay-close
5. \`9eddd93\` \`views/inbox.rs\` + \`U\` keybind + tape
6. \`14a9c82\` review-driven test/doc fixes

## Test plan

- [x] 83/83 \`cargo test -p scitadel-tui --lib\` pass (up from 67 pre-PR)
- [x] DB-side: \`count_unread\` matches \`list_unread().len()\`, \`papers_with_unread\` distincts correctly, soft-delete excluded
- [x] DataStore: round-trip with mark_thread_seen, cross-reader independence, paper-scoped vs all
- [x] App: focus-arrive doesn't mark seen (no prev), focus-leave-to-None marks prev, idempotent same-root, reply-index resolves to root, overlay-close via \`handle_key\` clears badge
- [x] Inbox: groups by paper, thread-major order, orphan reply uses parent_id, jump_target on header → None / on reply → root, step_selection skips headers, snap on cursor-clamp
- [x] App E2E: \`U\` toggles inbox open/close, Enter jumps to PaperDetail-reader with focus on root
- [x] \`cargo clippy -p scitadel-tui --tests -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] New \`tests/vhs/tui-inbox.tape\` exercises badge → ● glyph → U → Enter → focus-leave-clears-badge; assigned to the \`tui-papers\` shard with shard-coverage gate updated
- [ ] CI validates the new tape renders distinct screenshots

## Out of scope (follow-ups in this issue)

- MCP push notifications (PR3)
- \`create_paper_note\` (PR4)
- Selection-fidelity fix in \`publish_tui_state\` reader mode (PR5)

Refs #185.