### PR TITLE
feat: create_paper_note — quote-less paper-level commentary (#185 PR4/5)

### DIFF
--- a/.github/workflows/vhs.yml
+++ b/.github/workflows/vhs.yml
@@ -40,7 +40,7 @@ jobs:
           - name: tui-papers
             tapes: "papers-download-state.tape queue-tab.tape reading-queue-star.tape question-dashboard.tape tui-inbox.tape"
           - name: tui-reader
-            tapes: "tui-annotation-write.tape tui-annotations-reader.tape annotations-in-detail.tape tui-export-keybind.tape"
+            tapes: "tui-annotation-write.tape tui-annotations-reader.tape annotations-in-detail.tape tui-export-keybind.tape tui-paper-note.tape"
           - name: theme
             tapes: "theme-dark.tape theme-light.tape theme-toggle.tape"
           - name: connectivity
@@ -193,7 +193,7 @@ jobs:
           cli-bib-import.tape cli-bib-rekey.tape cli-question-workflow.tape cli-search.tape
           tui-launch.tape init-wizard.tape
           papers-download-state.tape queue-tab.tape reading-queue-star.tape question-dashboard.tape tui-inbox.tape
-          tui-annotation-write.tape tui-annotations-reader.tape annotations-in-detail.tape tui-export-keybind.tape
+          tui-annotation-write.tape tui-annotations-reader.tape annotations-in-detail.tape tui-export-keybind.tape tui-paper-note.tape
           theme-dark.tape theme-light.tape theme-toggle.tape
           offline-indicator.tape open-externally.tape
           EOF

--- a/.github/workflows/vhs.yml
+++ b/.github/workflows/vhs.yml
@@ -20,15 +20,17 @@ jobs:
   tapes:
     name: Run tapes (${{ matrix.shard.name }})
     runs-on: ubuntu-latest
-    # Per-shard budget — uniform 10m. Empirically the cargo build +
-    # ttyd/ffmpeg install eats ~3m of fixed overhead before a single
-    # tape renders, and TUI tapes can take 60-90s each. With 4 tapes
-    # in the largest shards, 6m was too tight even on the happy path
-    # (tui-papers blew it on the first sharded run); 10m gives every
-    # shard headroom to absorb the build cost plus the per-tape retry
-    # logic in the distinctness assertion. Total wall-clock stays
-    # <10m because shards run in parallel.
-    timeout-minutes: 10
+    # Per-shard budget — per-shard timeout via matrix entry. The
+    # cargo build + ttyd/ffmpeg install eats ~3m of fixed overhead
+    # before a single tape renders, and TUI tapes can take 60-90s
+    # each. tui-reader carries the historically flaky
+    # `tui-export-keybind.tape` which fires the distinctness retry
+    # loop on roughly half of CI runs (3 extra renders × 60-90s
+    # each), so it needs 14m to absorb that on top of 5 tapes; the
+    # rest stay at 10m where they have ~3m of headroom over their
+    # observed wall-clock. Total wall-clock stays under 14m because
+    # shards run in parallel.
+    timeout-minutes: ${{ matrix.shard.timeout-minutes || 10 }}
     strategy:
       fail-fast: false
       matrix:
@@ -41,6 +43,7 @@ jobs:
             tapes: "papers-download-state.tape queue-tab.tape reading-queue-star.tape question-dashboard.tape tui-inbox.tape"
           - name: tui-reader
             tapes: "tui-annotation-write.tape tui-annotations-reader.tape annotations-in-detail.tape tui-export-keybind.tape tui-paper-note.tape"
+            timeout-minutes: 14
           - name: theme
             tapes: "theme-dark.tape theme-light.tape theme-toggle.tape"
           - name: connectivity

--- a/crates/scitadel-core/src/models/annotation.rs
+++ b/crates/scitadel-core/src/models/annotation.rs
@@ -128,6 +128,22 @@ pub fn paper_note_sentence_id(paper_id: &str) -> String {
     format!("{PAPER_NOTE_SENTENCE_ID_PREFIX}{paper_id}")
 }
 
+/// Build the synthetic `Anchor` that flags an annotation as a
+/// paper-level note. No quote, no char_range — only the
+/// `paper-note:<paper_id>` sentinel sentence_id and `AnchorStatus::Ok`
+/// so the resolver short-circuits without trying to match anything in
+/// the body text. Shared by every paper-note write path (MCP tool +
+/// TUI DataStore wrapper) so the two surfaces produce byte-identical
+/// anchors. (#185)
+#[must_use]
+pub fn paper_note_anchor(paper_id: &str) -> Anchor {
+    Anchor {
+        sentence_id: Some(paper_note_sentence_id(paper_id)),
+        status: AnchorStatus::Ok,
+        ..Anchor::default()
+    }
+}
+
 /// Build a synthetic `sentence_id` for an unanchored imported
 /// `note=`. Combines the source citekey with the SHA1 of the
 /// normalized note content so the same `(citekey, note)` pair
@@ -352,6 +368,23 @@ mod tests {
         assert!(pn.starts_with(PAPER_NOTE_SENTENCE_ID_PREFIX));
         assert!(!imp.starts_with(PAPER_NOTE_SENTENCE_ID_PREFIX));
         assert!(!pn.starts_with(IMPORTED_SENTENCE_ID_PREFIX));
+    }
+
+    #[test]
+    fn paper_note_anchor_is_recognised_by_predicate() {
+        // The shared helper must produce an anchor that
+        // `is_paper_note()` accepts; otherwise the two write paths
+        // (MCP tool + DataStore) drift from the resolver and the TUI
+        // rendering filter, and the round-trip silently breaks.
+        let a = paper_note_anchor("p-attn");
+        assert!(a.is_paper_note());
+        assert_eq!(a.status, AnchorStatus::Ok);
+        assert!(a.quote.is_none());
+        assert!(a.char_range.is_none());
+        assert_eq!(
+            a.sentence_id.as_deref(),
+            Some(&*paper_note_sentence_id("p-attn"))
+        );
     }
 
     #[test]

--- a/crates/scitadel-core/src/models/annotation.rs
+++ b/crates/scitadel-core/src/models/annotation.rs
@@ -86,6 +86,23 @@ impl Anchor {
                 .as_deref()
                 .is_some_and(|s| s.starts_with(IMPORTED_SENTENCE_ID_PREFIX))
     }
+
+    /// True when this anchor represents a paper-level note: a
+    /// commentary on the publication as a whole rather than a
+    /// passage in it. Built by `paper_note_sentence_id(paper_id)`
+    /// and recognised by the resolver as `AnchorStatus::Ok` without
+    /// needing a quote / char_range / fuzzy match. The TUI renders
+    /// these in a separate "paper-level notes" section above the
+    /// thread list. (#185)
+    #[must_use]
+    pub fn is_paper_note(&self) -> bool {
+        self.char_range.is_none()
+            && self.quote.is_none()
+            && self
+                .sentence_id
+                .as_deref()
+                .is_some_and(|s| s.starts_with(PAPER_NOTE_SENTENCE_ID_PREFIX))
+    }
 }
 
 /// Marker prefix on a synthetic `sentence_id` produced by the
@@ -93,6 +110,23 @@ impl Anchor {
 /// Picked to be unambiguous: SHA1 hex (the real `sentence_id`
 /// output) cannot start with `bibtex-import:`.
 pub const IMPORTED_SENTENCE_ID_PREFIX: &str = "bibtex-import:";
+
+/// Marker prefix on a synthetic `sentence_id` for paper-level
+/// commentary (no quote, no anchor — the user is commenting on the
+/// publication as a whole). Lives in a different namespace from
+/// [`IMPORTED_SENTENCE_ID_PREFIX`] so a single resolver pass can
+/// route each kind to its own short-circuit path. SHA1 hex output
+/// cannot start with `paper-note:`, and `bibtex-import:` /
+/// `paper-note:` are disjoint by construction. (#185)
+pub const PAPER_NOTE_SENTENCE_ID_PREFIX: &str = "paper-note:";
+
+/// Build the synthetic `sentence_id` that identifies a paper-level
+/// note. Stable per `paper_id` so future calls (e.g. for de-dup)
+/// can re-derive the same handle. (#185)
+#[must_use]
+pub fn paper_note_sentence_id(paper_id: &str) -> String {
+    format!("{PAPER_NOTE_SENTENCE_ID_PREFIX}{paper_id}")
+}
 
 /// Build a synthetic `sentence_id` for an unanchored imported
 /// `note=`. Combines the source citekey with the SHA1 of the
@@ -303,6 +337,59 @@ mod tests {
             ..Anchor::default()
         };
         assert!(!a.is_imported_synthetic());
+    }
+
+    #[test]
+    fn paper_note_sentinel_is_disjoint_from_imported() {
+        // The two sentinel namespaces must not collide — a single
+        // resolver pass needs to route each kind to its own
+        // short-circuit. Pin the disjointness here so a future
+        // rename can't quietly break it. (#185)
+        assert_ne!(IMPORTED_SENTENCE_ID_PREFIX, PAPER_NOTE_SENTENCE_ID_PREFIX);
+        let imp = imported_sentence_id("k", "n");
+        let pn = paper_note_sentence_id("p-attn");
+        assert!(imp.starts_with(IMPORTED_SENTENCE_ID_PREFIX));
+        assert!(pn.starts_with(PAPER_NOTE_SENTENCE_ID_PREFIX));
+        assert!(!imp.starts_with(PAPER_NOTE_SENTENCE_ID_PREFIX));
+        assert!(!pn.starts_with(IMPORTED_SENTENCE_ID_PREFIX));
+    }
+
+    #[test]
+    fn paper_note_id_is_stable_per_paper() {
+        // Same paper_id ⇒ same id; different paper_id ⇒ different id.
+        // Used by future de-dup logic if "comment on the paper as a
+        // whole" ever needs uniqueness per paper+author.
+        assert_eq!(paper_note_sentence_id("p-1"), paper_note_sentence_id("p-1"));
+        assert_ne!(paper_note_sentence_id("p-1"), paper_note_sentence_id("p-2"));
+    }
+
+    #[test]
+    fn is_paper_note_recognises_marker_anchor() {
+        let a = Anchor {
+            sentence_id: Some(paper_note_sentence_id("p-1")),
+            ..Anchor::default()
+        };
+        assert!(a.is_paper_note());
+        // …and is_imported_synthetic must NOT also be true; the two
+        // predicates are mutually exclusive on a well-formed anchor.
+        assert!(!a.is_imported_synthetic());
+    }
+
+    #[test]
+    fn is_paper_note_rejects_quote_or_range() {
+        let with_quote = Anchor {
+            sentence_id: Some(paper_note_sentence_id("p-1")),
+            quote: Some("hi".into()),
+            ..Anchor::default()
+        };
+        assert!(!with_quote.is_paper_note());
+
+        let with_range = Anchor {
+            sentence_id: Some(paper_note_sentence_id("p-1")),
+            char_range: Some((0, 2)),
+            ..Anchor::default()
+        };
+        assert!(!with_range.is_paper_note());
     }
 
     #[test]

--- a/crates/scitadel-core/src/models/mod.rs
+++ b/crates/scitadel-core/src/models/mod.rs
@@ -8,7 +8,8 @@ mod search;
 
 pub use annotation::{
     Anchor, AnchorStatus, Annotation, AnnotationRead, IMPORTED_SENTENCE_ID_PREFIX,
-    imported_sentence_id, normalize_sentence, sentence_id,
+    PAPER_NOTE_SENTENCE_ID_PREFIX, imported_sentence_id, normalize_sentence,
+    paper_note_sentence_id, sentence_id,
 };
 pub use assessment::Assessment;
 pub use citation::{Citation, CitationDirection, SnowballRun};

--- a/crates/scitadel-core/src/models/mod.rs
+++ b/crates/scitadel-core/src/models/mod.rs
@@ -8,7 +8,7 @@ mod search;
 
 pub use annotation::{
     Anchor, AnchorStatus, Annotation, AnnotationRead, IMPORTED_SENTENCE_ID_PREFIX,
-    PAPER_NOTE_SENTENCE_ID_PREFIX, imported_sentence_id, normalize_sentence,
+    PAPER_NOTE_SENTENCE_ID_PREFIX, imported_sentence_id, normalize_sentence, paper_note_anchor,
     paper_note_sentence_id, sentence_id,
 };
 pub use assessment::Assessment;

--- a/crates/scitadel-db/src/sqlite/annotations.rs
+++ b/crates/scitadel-db/src/sqlite/annotations.rs
@@ -394,6 +394,17 @@ pub fn resolve_anchor_with_threshold(
         return AnchorStatus::Ok;
     }
 
+    // Short-circuit: paper-level notes — commentary on the
+    // publication as a whole — carry a synthetic `paper-note:<id>`
+    // sentence_id with no quote / range. They have nothing to
+    // re-anchor against in the body text by design, so the only
+    // sensible status is Ok. The TUI renders them in a separate
+    // section above the thread list. (#185)
+    if anchor.is_paper_note() {
+        anchor.status = AnchorStatus::Ok;
+        return AnchorStatus::Ok;
+    }
+
     // Step 1: position selector — bounds-checked.
     if let (Some((start, end)), Some(quote)) = (anchor.char_range, anchor.quote.as_ref())
         && let Some(slice) = char_slice(text, start, end)
@@ -791,6 +802,22 @@ mod tests {
         // Paper text deliberately contains nothing matching the
         // synthetic id — the short-circuit must fire regardless.
         let status = resolve_anchor(&mut a, "the body of the paper says many things.");
+        assert_eq!(status, AnchorStatus::Ok);
+        assert_eq!(a.status, AnchorStatus::Ok);
+        assert!(!a.is_orphan());
+    }
+
+    /// #185: paper-level notes carry a `paper-note:<paper_id>`
+    /// sentence_id with no quote / range. Same short-circuit story
+    /// as the import case but in its own namespace so the two
+    /// kinds can render distinctly in the TUI.
+    #[test]
+    fn resolver_short_circuits_paper_note_anchor_to_ok() {
+        let mut a = Anchor {
+            sentence_id: Some(scitadel_core::models::paper_note_sentence_id("p-attn")),
+            ..Anchor::default()
+        };
+        let status = resolve_anchor(&mut a, "irrelevant body text.");
         assert_eq!(status, AnchorStatus::Ok);
         assert_eq!(a.status, AnchorStatus::Ok);
         assert!(!a.is_orphan());

--- a/crates/scitadel-mcp/src/server.rs
+++ b/crates/scitadel-mcp/src/server.rs
@@ -139,6 +139,16 @@ pub struct ReplyAnnotationRequest {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+pub struct CreatePaperNoteRequest {
+    /// Paper ID this note comments on. Must already exist.
+    pub paper_id: String,
+    /// Note body — markdown allowed.
+    pub note: String,
+    /// Author identity (e.g. agent slug, user name).
+    pub author: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct DeleteAnnotationRequest {
     /// Annotation ID
     pub id: String,
@@ -574,6 +584,26 @@ impl ScitadelServer {
                 },
             );
         }
+        Ok(id)
+    }
+
+    #[tool(
+        description = "Comment on a paper as a whole — quote-less, anchor-less commentary. Use this when the observation isn't tied to a specific passage (overall reaction, methodology critique, taxonomy tag). The TUI renders these in a dedicated 'paper-level notes' section above the threaded annotations. NOTE: author identity is trust-on-first-use (see create_annotation); writes are tracing-logged. Emits an MCP-spec `notifications/resources/updated` to active `subscribe_annotations` clients (#185). Returns: text (the new annotation ID)."
+    )]
+    fn create_paper_note(
+        &self,
+        Parameters(req): Parameters<CreatePaperNoteRequest>,
+    ) -> Result<String, String> {
+        let id = tools::create_paper_note_tool(&req.paper_id, &req.note, &req.author)?;
+        crate::events::emit(
+            &self.event_tx,
+            AnnotationEvent {
+                paper_id: req.paper_id.clone(),
+                annotation_id: id.clone(),
+                kind: AnnotationEventKind::Created,
+                reader: None,
+            },
+        );
         Ok(id)
     }
 
@@ -1145,6 +1175,14 @@ mod tests {
         assert_eq!(super::subscription_uri(Some("")), "scitadel://annotations/");
     }
 
+    /// All env-var-mutating tests in this module share a single
+    /// mutex so SCITADEL_DB doesn't get clobbered by parallel runs.
+    /// The lock is held for the duration of each test; the Database
+    /// is opened from the env var inside the same lock, so the
+    /// effective DB path is stable per test even though
+    /// `cargo test` launches them concurrently.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     /// End-to-end: a real `create_annotation` call goes through the
     /// tool surface and emits a `Created` event on the broadcast
     /// channel. Insurance against a future refactor that re-routes a
@@ -1155,49 +1193,153 @@ mod tests {
     /// (#185 PR3 review)
     #[tokio::test]
     async fn create_annotation_through_server_emits_created_event() {
-        // Each test gets its own SCITADEL_DB path. No other lib test
-        // in this crate touches SCITADEL_DB (the rest go through
-        // `Database::open_in_memory()` directly in their test
-        // helpers), so the env var isn't a parallel-test hazard
-        // here.
-        let tmp = tempfile::tempdir().unwrap();
-        let db_path = tmp.path().join("test.db");
-        // Safety: we own the env var for the lifetime of this test
-        // and no parallel test in this crate reads SCITADEL_DB.
-        unsafe {
-            std::env::set_var("SCITADEL_DB", &db_path);
-        }
+        // Hold the env-var lock for the sync setup (env-var write +
+        // db open + repo save + server.create_*). All those calls
+        // are sync; we drop the guard *before* the only .await so
+        // the lock isn't held across an await point. Each test
+        // releases the lock as soon as the broadcast Sender has
+        // already been populated for *this* server instance, so a
+        // parallel test taking the lock next can't disturb us.
+        let (id, mut rx) = {
+            let _lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+            let tmp = tempfile::tempdir().unwrap();
+            let db_path = tmp.path().join("test.db");
+            unsafe {
+                std::env::set_var("SCITADEL_DB", &db_path);
+            }
 
-        // Seed one paper so the annotation has somewhere to anchor.
-        let db = scitadel_db::sqlite::Database::open(&db_path).unwrap();
-        db.migrate().unwrap();
-        let mut p = scitadel_core::models::Paper::new("e2e");
-        p.id = scitadel_core::models::PaperId::from("p-e2e");
-        let (paper_repo, _, _, _, _) = db.repositories();
-        scitadel_core::ports::PaperRepository::save(&paper_repo, &p).unwrap();
+            let db = scitadel_db::sqlite::Database::open(&db_path).unwrap();
+            db.migrate().unwrap();
+            let mut p = scitadel_core::models::Paper::new("e2e");
+            p.id = scitadel_core::models::PaperId::from("p-e2e");
+            let (paper_repo, _, _, _, _) = db.repositories();
+            scitadel_core::ports::PaperRepository::save(&paper_repo, &p).unwrap();
 
-        let server = super::ScitadelServer::new();
-        let mut rx = server.subscribe_events();
-        let req = super::CreateAnnotationRequest {
-            paper_id: "p-e2e".into(),
-            quote: "Q".into(),
-            note: "N".into(),
-            author: "claude".into(),
-            prefix: None,
-            suffix: None,
-            question_id: None,
-            color: None,
-            tags: None,
+            let server = super::ScitadelServer::new();
+            let rx = server.subscribe_events();
+            let req = super::CreateAnnotationRequest {
+                paper_id: "p-e2e".into(),
+                quote: "Q".into(),
+                note: "N".into(),
+                author: "claude".into(),
+                prefix: None,
+                suffix: None,
+                question_id: None,
+                color: None,
+                tags: None,
+            };
+            let id = server
+                .create_annotation(rmcp::handler::server::wrapper::Parameters(req))
+                .expect("create_annotation succeeds");
+            (id, rx)
         };
-        let id = server
-            .create_annotation(rmcp::handler::server::wrapper::Parameters(req))
-            .expect("create_annotation succeeds");
-
+        // Lock dropped — safe to await on a broadcast channel that's
+        // already populated for *our* `rx`.
         let event = rx.recv().await.expect("event arrives");
         assert_eq!(event.paper_id, "p-e2e");
         assert_eq!(event.kind, super::AnnotationEventKind::Created);
         assert_eq!(event.annotation_id, id);
         assert!(event.reader.is_none(), "create events have no reader");
+    }
+
+    /// End-to-end paper-note write: the new MCP tool persists with
+    /// the `paper-note:<paper_id>` sentinel and emits a `Created`
+    /// event on the broadcast channel. (#185 PR4)
+    #[tokio::test]
+    async fn create_paper_note_through_server_persists_and_emits() {
+        // Same lock-then-drop-before-await pattern as the
+        // create_annotation e2e test above — sync setup + write
+        // happen under the lock, the .await is on an already-
+        // populated broadcast channel.
+        let (id, mut rx, db) = {
+            let _lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+            let tmp = tempfile::tempdir().unwrap();
+            let db_path = tmp.path().join("test.db");
+            unsafe {
+                std::env::set_var("SCITADEL_DB", &db_path);
+            }
+            let db = scitadel_db::sqlite::Database::open(&db_path).unwrap();
+            db.migrate().unwrap();
+            let mut p = scitadel_core::models::Paper::new("paper-note-target");
+            p.id = scitadel_core::models::PaperId::from("p-pn");
+            let (paper_repo, _, _, _, _) = db.repositories();
+            scitadel_core::ports::PaperRepository::save(&paper_repo, &p).unwrap();
+
+            let server = super::ScitadelServer::new();
+            let rx = server.subscribe_events();
+            let req = super::CreatePaperNoteRequest {
+                paper_id: "p-pn".into(),
+                note: "overall: methodology weak".into(),
+                author: "claude".into(),
+            };
+            let id = server
+                .create_paper_note(rmcp::handler::server::wrapper::Parameters(req))
+                .expect("create_paper_note succeeds");
+            (id, rx, db)
+        };
+
+        let event = rx.recv().await.expect("event arrives");
+        assert_eq!(event.paper_id, "p-pn");
+        assert_eq!(event.annotation_id, id);
+        assert_eq!(event.kind, super::AnnotationEventKind::Created);
+
+        let repo = scitadel_db::sqlite::SqliteAnnotationRepository::new(db);
+        let stored = repo.get(&id).unwrap().expect("annotation persisted");
+        assert!(stored.anchor.is_paper_note());
+        assert!(stored.anchor.quote.is_none());
+    }
+
+    /// `create_paper_note` rejects an empty note and a missing paper
+    /// at the boundary so a typo doesn't create a dangling note with
+    /// no UI surface to find it again.
+    #[tokio::test]
+    async fn create_paper_note_rejects_empty_note_and_missing_paper() {
+        // The std::sync::Mutex guard would normally need to drop
+        // before .await, but the env-var protection here only needs
+        // to hold for the duration of THIS test's setup +
+        // server.create_*() call (which is sync). The single .await
+        // afterwards (rx.recv) waits on a broadcast already populated
+        // synchronously, so holding the guard is benign in practice.
+        #[allow(clippy::await_holding_lock)]
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let db_path = tmp.path().join("test.db");
+        unsafe {
+            std::env::set_var("SCITADEL_DB", &db_path);
+        }
+        let db = scitadel_db::sqlite::Database::open(&db_path).unwrap();
+        db.migrate().unwrap();
+
+        let server = super::ScitadelServer::new();
+
+        let err = server
+            .create_paper_note(rmcp::handler::server::wrapper::Parameters(
+                super::CreatePaperNoteRequest {
+                    paper_id: "p-missing".into(),
+                    note: "any".into(),
+                    author: "claude".into(),
+                },
+            ))
+            .expect_err("missing paper should reject");
+        assert!(err.contains("not found"));
+
+        // Seed a paper so the second case (empty note) is the only
+        // failure mode under test.
+        let mut p = scitadel_core::models::Paper::new("p");
+        p.id = scitadel_core::models::PaperId::from("p-pn-empty");
+        let (paper_repo, _, _, _, _) = db.repositories();
+        scitadel_core::ports::PaperRepository::save(&paper_repo, &p).unwrap();
+
+        let err = server
+            .create_paper_note(rmcp::handler::server::wrapper::Parameters(
+                super::CreatePaperNoteRequest {
+                    paper_id: "p-pn-empty".into(),
+                    note: "   ".into(),
+                    author: "claude".into(),
+                },
+            ))
+            .expect_err("whitespace-only note should reject");
+        assert!(err.contains("note"));
     }
 
     /// `subscribe_events` must hand out a receiver that observes

--- a/crates/scitadel-mcp/src/tools.rs
+++ b/crates/scitadel-mcp/src/tools.rs
@@ -1166,6 +1166,54 @@ pub fn reply_annotation_tool(parent_id: &str, note: &str, author: &str) -> Resul
     Ok(reply.id.as_str().to_string())
 }
 
+/// Create a paper-level note: commentary on the publication as a
+/// whole, with no quote / char_range / fuzzy match. The anchor
+/// carries only a synthetic `paper-note:<paper_id>` sentence_id and
+/// the resolver short-circuits it to Ok. (#185)
+pub fn create_paper_note_tool(paper_id: &str, note: &str, author: &str) -> Result<String, String> {
+    if author.trim().is_empty() {
+        return Err("author is required (pass an identity string)".into());
+    }
+    if note.trim().is_empty() {
+        return Err("note is required".into());
+    }
+    let db = open_db()?;
+    // Verify the paper exists. Without this, a typo in `paper_id`
+    // would create a dangling note with no UI surface to find it
+    // again — a bigger footfun than a clean error here.
+    {
+        let (paper_repo, _, _, _, _) = db.repositories();
+        if scitadel_core::ports::PaperRepository::get(&paper_repo, paper_id)
+            .map_err(|e| e.to_string())?
+            .is_none()
+        {
+            return Err(format!("Paper '{paper_id}' not found."));
+        }
+    }
+    let repo = scitadel_db::sqlite::SqliteAnnotationRepository::new(db);
+
+    let anchor = scitadel_core::models::Anchor {
+        sentence_id: Some(scitadel_core::models::paper_note_sentence_id(paper_id)),
+        status: scitadel_core::models::AnchorStatus::Ok,
+        ..Default::default()
+    };
+    let ann = scitadel_core::models::Annotation::new_root(
+        scitadel_core::models::PaperId::from(paper_id),
+        author.to_string(),
+        note.to_string(),
+        anchor,
+    );
+    repo.create(&ann).map_err(|e| e.to_string())?;
+    tracing::info!(
+        op = "create_paper_note",
+        annotation_id = ann.id.as_str(),
+        paper_id = paper_id,
+        author = author,
+        "annotation write (trust-on-first-use)"
+    );
+    Ok(ann.id.as_str().to_string())
+}
+
 /// Update mutable fields on an existing annotation.
 pub fn update_annotation_tool(
     id: &str,

--- a/crates/scitadel-mcp/src/tools.rs
+++ b/crates/scitadel-mcp/src/tools.rs
@@ -1192,16 +1192,11 @@ pub fn create_paper_note_tool(paper_id: &str, note: &str, author: &str) -> Resul
     }
     let repo = scitadel_db::sqlite::SqliteAnnotationRepository::new(db);
 
-    let anchor = scitadel_core::models::Anchor {
-        sentence_id: Some(scitadel_core::models::paper_note_sentence_id(paper_id)),
-        status: scitadel_core::models::AnchorStatus::Ok,
-        ..Default::default()
-    };
     let ann = scitadel_core::models::Annotation::new_root(
         scitadel_core::models::PaperId::from(paper_id),
         author.to_string(),
         note.to_string(),
-        anchor,
+        scitadel_core::models::paper_note_anchor(paper_id),
     );
     repo.create(&ann).map_err(|e| e.to_string())?;
     tracing::info!(

--- a/crates/scitadel-tui/src/app.rs
+++ b/crates/scitadel-tui/src/app.rs
@@ -1149,6 +1149,13 @@ impl App {
             KeyCode::Char('n') => {
                 *prompt = Some(AnnotationPrompt::create());
             }
+            KeyCode::Char('P') => {
+                // Paper-level note (#185): quote-less commentary on
+                // the publication as a whole. Capital `P` so the
+                // namespace stays parallel to `D` (download), `O`
+                // (open externally), `R` (reader), `E` (export).
+                *prompt = Some(AnnotationPrompt::paper_note());
+            }
             KeyCode::Char('J') => {
                 // Enter annotation focus mode if the paper has any.
                 let pid = paper_id.clone();
@@ -1275,6 +1282,9 @@ impl App {
                         *focus = new_count - 1;
                     }
                 }
+            }
+            PromptSubmission::PaperNote { note } => {
+                let _ = self.data.create_paper_note(&pid, &note, &reader);
             }
         }
     }
@@ -1649,7 +1659,7 @@ fn draw(frame: &mut ratatui::Frame, app: &mut App) {
                         "Esc: leave focus | j/k: navigate | n: new | e: edit | r: reply | d: delete"
                     }
                     (None, None) => {
-                        "Esc/q: back | j/k: scroll | d/u: page | D: download | O: open externally | R: reader | n: new | J: focus"
+                        "Esc/q: back | j/k: scroll | d/u: page | D: download | O: open externally | R: reader | n: new | P: paper-note | J: focus"
                     }
                 }
             }

--- a/crates/scitadel-tui/src/data.rs
+++ b/crates/scitadel-tui/src/data.rs
@@ -176,18 +176,12 @@ impl DataStore {
     /// whole, with no quote / char_range. The anchor carries only the
     /// `paper-note:<paper_id>` sentinel and the resolver short-circuits
     /// it to Ok. (#185)
-    #[allow(dead_code)] // wired up in C3 (TUI Pp keybind)
     pub fn create_paper_note(&self, paper_id: &str, note: &str, author: &str) -> Result<String> {
-        let anchor = Anchor {
-            sentence_id: Some(scitadel_core::models::paper_note_sentence_id(paper_id)),
-            status: AnchorStatus::Ok,
-            ..Anchor::default()
-        };
         let ann = Annotation::new_root(
             PaperId::from(paper_id),
             author.to_string(),
             note.to_string(),
-            anchor,
+            scitadel_core::models::paper_note_anchor(paper_id),
         );
         SqliteAnnotationRepository::new(self.db.clone()).create(&ann)?;
         Ok(ann.id.as_str().to_string())

--- a/crates/scitadel-tui/src/data.rs
+++ b/crates/scitadel-tui/src/data.rs
@@ -172,6 +172,27 @@ impl DataStore {
         Ok(ann.id.as_str().to_string())
     }
 
+    /// Create a paper-level note: commentary on the publication as a
+    /// whole, with no quote / char_range. The anchor carries only the
+    /// `paper-note:<paper_id>` sentinel and the resolver short-circuits
+    /// it to Ok. (#185)
+    #[allow(dead_code)] // wired up in C3 (TUI Pp keybind)
+    pub fn create_paper_note(&self, paper_id: &str, note: &str, author: &str) -> Result<String> {
+        let anchor = Anchor {
+            sentence_id: Some(scitadel_core::models::paper_note_sentence_id(paper_id)),
+            status: AnchorStatus::Ok,
+            ..Anchor::default()
+        };
+        let ann = Annotation::new_root(
+            PaperId::from(paper_id),
+            author.to_string(),
+            note.to_string(),
+            anchor,
+        );
+        SqliteAnnotationRepository::new(self.db.clone()).create(&ann)?;
+        Ok(ann.id.as_str().to_string())
+    }
+
     /// Reply to an existing annotation; inherits paper_id + question_id
     /// from the parent.
     pub fn reply_annotation(&self, parent_id: &str, note: &str, author: &str) -> Result<String> {
@@ -420,5 +441,63 @@ mod tests {
         assert_eq!(store.load_unread_for_paper("lars", "p-a").unwrap().len(), 1);
         assert_eq!(store.load_unread_for_paper("lars", "p-b").unwrap().len(), 1);
         assert_eq!(store.load_unread_count("lars").unwrap(), 2);
+    }
+
+    #[test]
+    fn create_paper_note_persists_with_paper_note_sentinel() {
+        let store = DataStore::for_tests();
+        save_paper(&store, "p-a", "Alpha");
+        let id = store
+            .create_paper_note("p-a", "overall: methodology weak", "lars")
+            .unwrap();
+        let anns = store.load_annotations_for_paper("p-a").unwrap();
+        assert_eq!(anns.len(), 1);
+        let ann = &anns[0];
+        assert_eq!(ann.id.as_str(), id);
+        assert_eq!(ann.note, "overall: methodology weak");
+        assert!(
+            ann.anchor.is_paper_note(),
+            "paper note should be recognised by Anchor::is_paper_note(); got anchor={:?}",
+            ann.anchor
+        );
+        assert!(ann.anchor.quote.is_none(), "no quote on paper-level note");
+        assert!(
+            ann.anchor.char_range.is_none(),
+            "no char_range on paper-level note"
+        );
+    }
+
+    #[test]
+    fn create_paper_note_appears_in_load_annotations_for_paper() {
+        // Sanity: paper-note + a regular root annotation co-exist on
+        // the same paper. The TUI later partitions them into two
+        // sections via Anchor::is_paper_note() (#185 PR4 C3).
+        use scitadel_core::models::{Anchor, Annotation};
+        use scitadel_db::sqlite::SqliteAnnotationRepository;
+
+        let store = DataStore::for_tests();
+        save_paper(&store, "p-a", "A");
+        let _ = store
+            .create_paper_note("p-a", "global thought", "lars")
+            .unwrap();
+        let repo = SqliteAnnotationRepository::new(store.db.clone());
+        let anchored = Annotation::new_root(
+            PaperId::from("p-a"),
+            "claude".into(),
+            "passage thought".into(),
+            Anchor {
+                quote: Some("specific phrase".into()),
+                ..Anchor::default()
+            },
+        );
+        repo.create(&anchored).unwrap();
+
+        let anns = store.load_annotations_for_paper("p-a").unwrap();
+        assert_eq!(anns.len(), 2);
+        let paper_notes: Vec<_> = anns.iter().filter(|a| a.anchor.is_paper_note()).collect();
+        let anchored_count = anns.iter().filter(|a| !a.anchor.is_paper_note()).count();
+        assert_eq!(paper_notes.len(), 1);
+        assert_eq!(anchored_count, 1);
+        assert_eq!(paper_notes[0].note, "global thought");
     }
 }

--- a/crates/scitadel-tui/src/views/annotation_prompt.rs
+++ b/crates/scitadel-tui/src/views/annotation_prompt.rs
@@ -40,6 +40,12 @@ pub enum AnnotationPrompt {
     DeleteConfirm {
         annotation_id: String,
     },
+    /// Quote-less paper-level note (#185). Single-buffer state — the
+    /// anchor is synthetic so there's nothing to type other than the
+    /// note body. Submitted as `PromptSubmission::PaperNote`.
+    PaperNote {
+        note_buf: String,
+    },
 }
 
 /// What happens when the user submits the prompt. The app translates
@@ -56,10 +62,26 @@ pub enum PromptCommit {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PromptSubmission {
-    Create { quote: String, note: String },
-    Edit { annotation_id: String, note: String },
-    Reply { parent_id: String, note: String },
-    Delete { annotation_id: String },
+    Create {
+        quote: String,
+        note: String,
+    },
+    Edit {
+        annotation_id: String,
+        note: String,
+    },
+    Reply {
+        parent_id: String,
+        note: String,
+    },
+    Delete {
+        annotation_id: String,
+    },
+    /// Quote-less paper-level commentary (#185). The app dispatches
+    /// to `data.create_paper_note(paper_id, note, reader)`.
+    PaperNote {
+        note: String,
+    },
 }
 
 impl AnnotationPrompt {
@@ -99,6 +121,15 @@ impl AnnotationPrompt {
         }
     }
 
+    /// Start a paper-level note prompt (#185). Single-buffer; no
+    /// quote stage.
+    #[must_use]
+    pub fn paper_note() -> Self {
+        Self::PaperNote {
+            note_buf: String::new(),
+        }
+    }
+
     /// Append a character to the active buffer (whichever the prompt
     /// is currently editing). Confirm prompts ignore character input
     /// other than y/n/Esc; the app handles those at the key layer.
@@ -109,7 +140,8 @@ impl AnnotationPrompt {
             } if *stage == CreateStage::Quote => quote_buf.push(ch),
             Self::Create { note_buf, .. }
             | Self::Edit { note_buf, .. }
-            | Self::Reply { note_buf, .. } => {
+            | Self::Reply { note_buf, .. }
+            | Self::PaperNote { note_buf } => {
                 note_buf.push(ch);
             }
             Self::DeleteConfirm { .. } => {}
@@ -126,7 +158,8 @@ impl AnnotationPrompt {
             }
             Self::Create { note_buf, .. }
             | Self::Edit { note_buf, .. }
-            | Self::Reply { note_buf, .. } => {
+            | Self::Reply { note_buf, .. }
+            | Self::PaperNote { note_buf } => {
                 note_buf.pop();
             }
             Self::DeleteConfirm { .. } => {}
@@ -173,6 +206,11 @@ impl AnnotationPrompt {
                 parent_id: parent_id.clone(),
                 note: note_buf.clone(),
             }),
+            Self::PaperNote { note_buf } if !note_buf.trim().is_empty() => {
+                PromptCommit::Submit(PromptSubmission::PaperNote {
+                    note: note_buf.clone(),
+                })
+            }
             // Empty buffer (or DeleteConfirm) — Enter is a no-op cancel.
             _ => PromptCommit::Cancel,
         }
@@ -210,6 +248,7 @@ impl AnnotationPrompt {
             Self::Edit { .. } => " Edit Annotation ",
             Self::Reply { .. } => " Reply ",
             Self::DeleteConfirm { .. } => " Delete annotation? ",
+            Self::PaperNote { .. } => " Paper-level note ",
         }
     }
 
@@ -229,7 +268,8 @@ impl AnnotationPrompt {
                 ..
             }
             | Self::Edit { note_buf, .. }
-            | Self::Reply { note_buf, .. } => note_buf,
+            | Self::Reply { note_buf, .. }
+            | Self::PaperNote { note_buf } => note_buf,
             Self::DeleteConfirm { .. } => "press y to delete, n/Esc to cancel",
         }
     }
@@ -301,6 +341,7 @@ pub fn draw_overlay(frame: &mut Frame, area: Rect, prompt: &AnnotationPrompt) {
             | AnnotationPrompt::Edit { .. } => "note body",
             AnnotationPrompt::Reply { .. } => "reply",
             AnnotationPrompt::DeleteConfirm { .. } => "",
+            AnnotationPrompt::PaperNote { .. } => "paper-level note",
         };
         lines.push(Line::from(vec![
             Span::styled(
@@ -451,5 +492,39 @@ mod tests {
         p.push_char(' ');
         p.push_char(' ');
         assert_eq!(p.submit(), PromptCommit::Cancel);
+    }
+
+    #[test]
+    fn paper_note_submits_single_buffer_no_quote() {
+        let mut p = AnnotationPrompt::paper_note();
+        for c in "overall: methodology weak".chars() {
+            p.push_char(c);
+        }
+        assert_eq!(
+            p.submit(),
+            PromptCommit::Submit(PromptSubmission::PaperNote {
+                note: "overall: methodology weak".into()
+            })
+        );
+    }
+
+    #[test]
+    fn paper_note_empty_buffer_cancels() {
+        let p = AnnotationPrompt::paper_note();
+        assert_eq!(p.submit(), PromptCommit::Cancel);
+        let mut p = AnnotationPrompt::paper_note();
+        p.push_char(' ');
+        p.push_char(' ');
+        assert_eq!(p.submit(), PromptCommit::Cancel);
+    }
+
+    #[test]
+    fn paper_note_supports_backspace() {
+        let mut p = AnnotationPrompt::paper_note();
+        for c in "abc".chars() {
+            p.push_char(c);
+        }
+        p.backspace();
+        assert_eq!(p.body(), "ab");
     }
 }

--- a/crates/scitadel-tui/src/views/reader.rs
+++ b/crates/scitadel-tui/src/views/reader.rs
@@ -44,8 +44,18 @@ pub fn draw(
     let annotations = data
         .load_annotations_for_paper(paper_id)
         .unwrap_or_default();
-    // Roots only on the left pane — replies don't carry their own anchor.
-    let roots: Vec<&Annotation> = annotations.iter().filter(|a| !a.is_reply()).collect();
+    // Roots only on the left pane — replies don't carry their own
+    // anchor. Paper-level notes (#185) are also excluded from the
+    // anchored-roots set: they have no quote / char_range and don't
+    // produce a body highlight; they render in their own section.
+    let roots: Vec<&Annotation> = annotations
+        .iter()
+        .filter(|a| !a.is_reply() && !a.anchor.is_paper_note())
+        .collect();
+    let paper_notes: Vec<&Annotation> = annotations
+        .iter()
+        .filter(|a| !a.is_reply() && a.anchor.is_paper_note())
+        .collect();
     // Set of annotation IDs `reader` hasn't acknowledged yet, used by
     // the right-pane to render `[unread]` markers per row. (#185)
     let unread: std::collections::HashSet<String> = data
@@ -81,7 +91,15 @@ pub fn draw(
         .split(area);
 
     draw_text_pane(frame, chunks[0], &paper.title, body, &roots, focus);
-    draw_notes_pane(frame, chunks[1], &annotations, &roots, focus, &unread);
+    draw_notes_pane(
+        frame,
+        chunks[1],
+        &annotations,
+        &roots,
+        &paper_notes,
+        focus,
+        &unread,
+    );
 }
 
 fn draw_text_pane(
@@ -104,11 +122,13 @@ fn draw_text_pane(
     frame.render_widget(para, area);
 }
 
+#[allow(clippy::too_many_arguments)]
 fn draw_notes_pane(
     frame: &mut Frame,
     area: Rect,
     annotations: &[Annotation],
     roots: &[&Annotation],
+    paper_notes: &[&Annotation],
     focus: Option<usize>,
     unread: &std::collections::HashSet<String>,
 ) {
@@ -121,6 +141,58 @@ fn draw_notes_pane(
                 .add_modifier(Modifier::BOLD),
         )
     };
+
+    // Paper-level notes section first — quote-less commentary on the
+    // publication as a whole. Drawn above the threaded annotations
+    // so the human sees overall reactions before passage-anchored
+    // ones. Replies to a paper-level note are still rendered as
+    // children, since the data model permits replying to anything. (#185)
+    if !paper_notes.is_empty() {
+        lines.push(Line::from(vec![Span::styled(
+            "── Paper-level notes ──",
+            Style::default()
+                .fg(crate::theme::theme().muted)
+                .add_modifier(Modifier::BOLD),
+        )]));
+        for note in paper_notes {
+            let mut head = vec![Span::raw(format!(
+                "  ¶ {} ({}): {}",
+                note.author,
+                note.created_at.format("%Y-%m-%d"),
+                note.note,
+            ))];
+            if unread.contains(note.id.as_str()) {
+                head.push(unread_span());
+            }
+            lines.push(Line::from(head));
+            for ann in annotations.iter().filter(|a| {
+                a.parent_id
+                    .as_ref()
+                    .is_some_and(|p| p.as_str() == note.id.as_str())
+            }) {
+                let mut spans = vec![
+                    Span::raw("    └ "),
+                    Span::styled(
+                        format!("{}: ", ann.author),
+                        Style::default().fg(crate::theme::theme().emphasis),
+                    ),
+                    Span::raw(ann.note.clone()),
+                ];
+                if unread.contains(ann.id.as_str()) {
+                    spans.push(unread_span());
+                }
+                lines.push(Line::from(spans));
+            }
+        }
+        lines.push(Line::from(""));
+        lines.push(Line::from(vec![Span::styled(
+            "── Threaded annotations ──",
+            Style::default()
+                .fg(crate::theme::theme().muted)
+                .add_modifier(Modifier::BOLD),
+        )]));
+    }
+
     for (idx, root) in roots.iter().enumerate() {
         let color = color_for(root.id.as_str());
         let is_focused = focus == Some(idx);

--- a/tests/vhs/tui-paper-note.tape
+++ b/tests/vhs/tui-paper-note.tape
@@ -1,0 +1,77 @@
+# VHS tape: paper-level notes section + P keybind (#185 PR4).
+#
+# Seeds a paper plus an existing paper-level note (so the section
+# renders even before the user adds anything), then drives the
+# `P` keybind to create a second one. The TUI should:
+#   1. Show a "Paper-level notes" section above the threaded
+#      annotations.
+#   2. Open the paper-note prompt on `P` and accept a note.
+#   3. Show the new note appended to the paper-level section.
+
+Output "tests/vhs/snapshots/tui-paper-note/run.gif"
+
+Set Shell "bash"
+Set FontSize 14
+Set Width 1400
+Set Height 900
+Set Padding 10
+Set TypingSpeed 40ms
+
+Hide
+Type `export PATH="$PWD/target/release:$HOME/.cargo/bin:$PATH"`
+Enter
+Type `export PS1="$ "`
+Enter
+Type `export SCITADEL_DB=$(mktemp -d)/scitadel.db`
+Enter
+Type "scitadel init --yes --email demo@example.org --sources arxiv --db $SCITADEL_DB"
+Enter
+Sleep 800ms
+
+Type `sqlite3 $SCITADEL_DB "INSERT INTO papers (id, title, authors, year, abstract, full_text, created_at, updated_at) VALUES ('p-pn', 'On Methodology', '[\"Author, A.\"]', 2024, 'A short abstract about methodology.', 'The body of the paper. Methodology is described in section three.', datetime('now'), datetime('now'));"`
+Enter
+Sleep 200ms
+# Pre-existing paper-level note from a previous agent session.
+Type `sqlite3 $SCITADEL_DB "INSERT INTO annotations (id, paper_id, sentence_id, anchor_status, note, tags_json, author, created_at, updated_at) VALUES ('ann-pn-1', 'p-pn', 'paper-note:p-pn', 'ok', 'Solid framing; concerns about sample size.', '[]', 'claude', datetime('now'), datetime('now'));"`
+Enter
+Sleep 300ms
+Type "clear"
+Enter
+Show
+
+Type "scitadel tui"
+Enter
+Sleep 1500ms
+
+# Tab → Papers, open the seeded paper, enter reader mode.
+Tab
+Sleep 400ms
+Enter
+Sleep 800ms
+Type "R"
+Sleep 1s
+Screenshot "tests/vhs/snapshots/tui-paper-note/01-existing-paper-note-section.png"
+
+# Leave reader mode (Esc), then `P` to open the paper-note prompt.
+Escape
+Sleep 300ms
+Type "P"
+Sleep 500ms
+Screenshot "tests/vhs/snapshots/tui-paper-note/02-paper-note-prompt-open.png"
+
+# Type a note body and submit.
+Type "Methodology check: rerun ablation with N>1000."
+Sleep 300ms
+Enter
+Sleep 800ms
+# Re-enter reader to see the new entry under the paper-level section.
+Type "R"
+Sleep 1s
+Screenshot "tests/vhs/snapshots/tui-paper-note/03-new-paper-note-rendered.png"
+
+Escape
+Sleep 200ms
+Type "q"
+Sleep 200ms
+Type "q"
+Sleep 400ms


### PR DESCRIPTION
## Summary

P1 of #185. Adds quote-less paper-level commentary on a publication as a whole, surfaced through both MCP and TUI:

- New `paper-note:<paper_id>` sentinel anchor + resolver short-circuit (mirrors #158's import-synthetic pattern in its own namespace, disjoint by construction).
- New MCP tool `create_paper_note(paper_id, note, author)` — verifies paper exists, rejects empty author/note. Emits `AnnotationEventKind::Created` on the broadcast channel like other writes.
- TUI reader-mode right pane partitions annotations into "── Paper-level notes ──" (with a `¶` glyph) and "── Threaded annotations ──" (existing) sections.
- New `P` keybind in the paper-detail overlay opens a single-buffer paper-note prompt.
- Shared `paper_note_anchor(paper_id)` helper in scitadel-core so the MCP tool and the TUI DataStore wrapper produce byte-identical anchors.

## Commits

1. \`6cfce99\` sentinel constant + Anchor::is_paper_note() + resolver short-circuit
2. \`a98e68b\` MCP tool + DataStore wrapper + e2e tests + ENV_LOCK serialization
3. \`94c5475\` TUI section + P keybind + AnnotationPrompt::PaperNote + tape
4. \`2528d8a\` review-driven: shared paper_note_anchor helper + drop stale dead_code

## Test plan

- [x] 88/88 \`cargo test -p scitadel-tui --lib\` pass
- [x] 67/67 \`cargo test -p scitadel-mcp --lib\` pass
- [x] core: sentinel disjointness, paper_note_anchor predicate match, stability per paper_id, predicate positives + rejections (quote / range / wrong namespace)
- [x] db: resolver short-circuits paper-note anchor to Ok under non-matching body
- [x] tools: lookup paths, anchor construction
- [x] mcp e2e: \`create_paper_note\` through the server surface persists with sentinel + emits \`Created\` event; rejects missing paper + whitespace-only note
- [x] tui DataStore: persists with sentinel; co-exists with anchored annotations on same paper
- [x] tui prompt: \`PaperNote\` variant submit / empty-cancel / backspace
- [x] \`cargo clippy --tests -- -D warnings\` clean across affected crates
- [x] \`cargo fmt --check\` clean
- [x] New \`tests/vhs/tui-paper-note.tape\` exercises the full P1 flow; assigned to \`tui-reader\` shard with shard-coverage gate updated

## Out of scope (follow-up)

- Selection fidelity in \`publish_tui_state\` reader mode (PR5)
- Visual-mode quote select
- Anchor selector convergence

Refs #185.