### PR TITLE
fix(ci): release-please single-tag config

### DIFF
--- a/crates/scitadel-adapters/Cargo.toml
+++ b/crates/scitadel-adapters/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scitadel-adapters"
-version = "0.6.0"
+version = "0.6.0" # x-release-please-version
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -16,7 +16,7 @@ default = []
 contract-tests = []
 
 [dependencies]
-scitadel-core = { path = "../scitadel-core", version = "0.6.0" }
+scitadel-core = { path = "../scitadel-core", version = "0.6.0" } # x-release-please-version
 reqwest = { workspace = true }
 quick-xml = { workspace = true }
 serde = { workspace = true }

--- a/crates/scitadel-cli/Cargo.toml
+++ b/crates/scitadel-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scitadel-cli"
-version = "0.6.0"
+version = "0.6.0" # x-release-please-version
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -16,13 +16,13 @@ name = "scitadel"
 path = "src/main.rs"
 
 [dependencies]
-scitadel-core = { path = "../scitadel-core", version = "0.6.0" }
-scitadel-db = { path = "../scitadel-db", version = "0.6.0" }
-scitadel-adapters = { path = "../scitadel-adapters", version = "0.6.0" }
-scitadel-scoring = { path = "../scitadel-scoring", version = "0.6.0" }
-scitadel-export = { path = "../scitadel-export", version = "0.6.0" }
-scitadel-mcp = { path = "../scitadel-mcp", version = "0.6.0" }
-scitadel-tui = { path = "../scitadel-tui", version = "0.6.0" }
+scitadel-core = { path = "../scitadel-core", version = "0.6.0" } # x-release-please-version
+scitadel-db = { path = "../scitadel-db", version = "0.6.0" } # x-release-please-version
+scitadel-adapters = { path = "../scitadel-adapters", version = "0.6.0" } # x-release-please-version
+scitadel-scoring = { path = "../scitadel-scoring", version = "0.6.0" } # x-release-please-version
+scitadel-export = { path = "../scitadel-export", version = "0.6.0" } # x-release-please-version
+scitadel-mcp = { path = "../scitadel-mcp", version = "0.6.0" } # x-release-please-version
+scitadel-tui = { path = "../scitadel-tui", version = "0.6.0" } # x-release-please-version
 rmcp = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }

--- a/crates/scitadel-core/Cargo.toml
+++ b/crates/scitadel-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scitadel-core"
-version = "0.6.0"
+version = "0.6.0" # x-release-please-version
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/scitadel-db/Cargo.toml
+++ b/crates/scitadel-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scitadel-db"
-version = "0.6.0"
+version = "0.6.0" # x-release-please-version
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -12,7 +12,7 @@ description = "SQLite-backed repositories and migrations for scitadel."
 readme = "../../README.md"
 
 [dependencies]
-scitadel-core = { path = "../scitadel-core", version = "0.6.0" }
+scitadel-core = { path = "../scitadel-core", version = "0.6.0" } # x-release-please-version
 rusqlite = { workspace = true }
 r2d2 = { workspace = true }
 r2d2_sqlite = { workspace = true }

--- a/crates/scitadel-export/Cargo.toml
+++ b/crates/scitadel-export/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scitadel-export"
-version = "0.6.0"
+version = "0.6.0" # x-release-please-version
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -12,7 +12,7 @@ description = "BibTeX, JSON, and CSV exporters for scitadel search results."
 readme = "../../README.md"
 
 [dependencies]
-scitadel-core = { path = "../scitadel-core", version = "0.6.0" }
+scitadel-core = { path = "../scitadel-core", version = "0.6.0" } # x-release-please-version
 serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }

--- a/crates/scitadel-mcp/Cargo.toml
+++ b/crates/scitadel-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scitadel-mcp"
-version = "0.6.0"
+version = "0.6.0" # x-release-please-version
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -12,11 +12,11 @@ description = "MCP server exposing scitadel tools to host LLMs."
 readme = "../../README.md"
 
 [dependencies]
-scitadel-core = { path = "../scitadel-core", version = "0.6.0" }
-scitadel-db = { path = "../scitadel-db", version = "0.6.0" }
-scitadel-adapters = { path = "../scitadel-adapters", version = "0.6.0" }
-scitadel-scoring = { path = "../scitadel-scoring", version = "0.6.0" }
-scitadel-export = { path = "../scitadel-export", version = "0.6.0" }
+scitadel-core = { path = "../scitadel-core", version = "0.6.0" } # x-release-please-version
+scitadel-db = { path = "../scitadel-db", version = "0.6.0" } # x-release-please-version
+scitadel-adapters = { path = "../scitadel-adapters", version = "0.6.0" } # x-release-please-version
+scitadel-scoring = { path = "../scitadel-scoring", version = "0.6.0" } # x-release-please-version
+scitadel-export = { path = "../scitadel-export", version = "0.6.0" } # x-release-please-version
 rmcp = { workspace = true }
 schemars = { workspace = true }
 tokio = { workspace = true }

--- a/crates/scitadel-scoring/Cargo.toml
+++ b/crates/scitadel-scoring/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scitadel-scoring"
-version = "0.6.0"
+version = "0.6.0" # x-release-please-version
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -16,7 +16,7 @@ default = ["scoring"]
 scoring = []
 
 [dependencies]
-scitadel-core = { path = "../scitadel-core", version = "0.6.0" }
+scitadel-core = { path = "../scitadel-core", version = "0.6.0" } # x-release-please-version
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/scitadel-tui/Cargo.toml
+++ b/crates/scitadel-tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scitadel-tui"
-version = "0.6.0"
+version = "0.6.0" # x-release-please-version
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -12,10 +12,10 @@ description = "Interactive TUI for browsing scitadel searches, papers, and asses
 readme = "../../README.md"
 
 [dependencies]
-scitadel-core = { path = "../scitadel-core", version = "0.6.0" }
-scitadel-db = { path = "../scitadel-db", version = "0.6.0" }
-scitadel-adapters = { path = "../scitadel-adapters", version = "0.6.0" }
-scitadel-export = { path = "../scitadel-export", version = "0.6.0" }
+scitadel-core = { path = "../scitadel-core", version = "0.6.0" } # x-release-please-version
+scitadel-db = { path = "../scitadel-db", version = "0.6.0" } # x-release-please-version
+scitadel-adapters = { path = "../scitadel-adapters", version = "0.6.0" } # x-release-please-version
+scitadel-export = { path = "../scitadel-export", version = "0.6.0" } # x-release-please-version
 ratatui = { workspace = true }
 crossterm = { workspace = true }
 anyhow = { workspace = true }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,14 +1,21 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "release-type": "rust",
+  "release-type": "simple",
   "include-v-in-tag": false,
   "include-component-in-tag": false,
   "packages": {
     ".": {
-      "component": "scitadel"
+      "component": "scitadel",
+      "extra-files": [
+        { "type": "generic", "path": "crates/scitadel-core/Cargo.toml" },
+        { "type": "generic", "path": "crates/scitadel-db/Cargo.toml" },
+        { "type": "generic", "path": "crates/scitadel-adapters/Cargo.toml" },
+        { "type": "generic", "path": "crates/scitadel-scoring/Cargo.toml" },
+        { "type": "generic", "path": "crates/scitadel-export/Cargo.toml" },
+        { "type": "generic", "path": "crates/scitadel-mcp/Cargo.toml" },
+        { "type": "generic", "path": "crates/scitadel-tui/Cargo.toml" },
+        { "type": "generic", "path": "crates/scitadel-cli/Cargo.toml" }
+      ]
     }
-  },
-  "plugins": [
-    "cargo-workspace"
-  ]
+  }
 }


### PR DESCRIPTION
release-please failed on main: the cargo-workspace plugin can't handle the virtual root package, and multi-package forms emit per-component tags that don't match the bare X.Y.Z triggers in publish-crates.yml/binaries.yml.

Switches to a single `.` package (release-type simple) that cuts one unprefixed tag + CHANGELOG + GitHub release, with `generic` extra-files bumping the 8 crate versions + their internal dep refs via `x-release-please-version` markers. cargo publish (no --locked) regenerates the lock at publish time.

After merge, release-please re-runs and should open the 0.7.0 release PR.